### PR TITLE
feat(stats+graph): Stats page, Graph page, and graph interaction polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ frontend/dist
 /data
 /.fastembed_cache
 .claude/
+.superpowers/

--- a/docs/design-options/stats-a.html
+++ b/docs/design-options/stats-a.html
@@ -1,0 +1,668 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Stats — Option A: Ledger</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+/* ── TOKENS ─────────────────────────────────────────────────── */
+:root[data-theme="light"], :root[data-theme="auto"] {
+  --bg: #f4f1e8; --paper: #faf7ed; --paper-2: #f0ece0;
+  --ink: #0c0c0a; --ink-soft: #2a2a26; --muted: #6b675c; --tertiary: #a8a399;
+  --rule: #ddd8c9; --rule-strong: #c4beab;
+  --hot: #ff4d1c; --hot-soft: #ffeae0;
+  --shadow-float: 0 14px 32px rgba(12,12,10,.18);
+}
+:root[data-theme="dark"] {
+  --bg: #0c0c0a; --paper: #141412; --paper-2: #1a1a17;
+  --ink: #ece8d8; --ink-soft: #c4c0b0; --muted: #8a8678; --tertiary: #4a4842;
+  --rule: #232320; --rule-strong: #3a3933;
+  --hot: #ff5a2b; --hot-soft: #2a1410;
+  --shadow-float: 0 14px 32px rgba(0,0,0,.6);
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    --bg: #0c0c0a; --paper: #141412; --paper-2: #1a1a17;
+    --ink: #ece8d8; --ink-soft: #c4c0b0; --muted: #8a8678; --tertiary: #4a4842;
+    --rule: #232320; --rule-strong: #3a3933;
+    --hot: #ff5a2b; --hot-soft: #2a1410;
+    --shadow-float: 0 14px 32px rgba(0,0,0,.6);
+  }
+}
+:root {
+  --font-display: "Bricolage Grotesque", system-ui, sans-serif;
+  --font-serif: "Newsreader", Georgia, serif;
+  --font-sans: "Inter Tight", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+  --dur: 180ms; --ease: cubic-bezier(.2,.8,.2,1);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { min-height: 100vh; }
+body { background: var(--bg); color: var(--ink); font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+a { color: var(--hot); text-decoration: none; }
+a:hover { color: var(--ink); }
+
+/* ── CHROME ─────────────────────────────────────────────────── */
+.hotbar { height: 3px; background: var(--hot); }
+.topbar {
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0 1.5rem; height: 52px;
+  background: var(--bg); border-bottom: 1px solid var(--rule);
+}
+.topbar-brand {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 78, "wght" 800;
+  font-size: 0.9rem; letter-spacing: 0.04em; text-transform: uppercase;
+  display: flex; align-items: center; gap: 0.5rem;
+}
+.topbar-brand .dot { width: 8px; height: 8px; background: var(--hot); display: inline-block; }
+.topbar-crumb {
+  font-family: var(--font-sans); font-size: 0.85rem; color: var(--muted);
+  display: flex; align-items: center; gap: 0.5rem;
+}
+.topbar-crumb .sep { color: var(--tertiary); }
+.topbar-crumb .here { color: var(--ink); font-weight: 500; }
+.theme-btns { margin-left: auto; display: flex; gap: 0.3rem; }
+.theme-btn {
+  font-family: var(--font-sans); font-size: 0.7rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 0.3rem 0.6rem; background: var(--bg); color: var(--muted);
+  border: 1px solid var(--rule); cursor: pointer;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.theme-btn:hover { background: var(--paper-2); color: var(--ink); }
+.theme-btn.on { background: var(--hot); color: #fff; border-color: var(--hot); }
+
+/* ── PAGE WRAPPER ───────────────────────────────────────────── */
+.page { max-width: 960px; margin: 0 auto; padding: 2.5rem 1.5rem 5rem; }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.page-header { margin-bottom: 2rem; }
+.page-eyebrow {
+  font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--hot); margin-bottom: 0.35rem;
+}
+.page-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 85, "wght" 700;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  text-transform: uppercase; letter-spacing: -0.02em; line-height: 0.96;
+}
+.page-subtitle {
+  font-family: var(--font-sans); font-size: 0.9rem; color: var(--muted);
+  margin-top: 0.5rem; line-height: 1.5;
+}
+
+/* ── METRIC STRIP ───────────────────────────────────────────── */
+.metric-strip {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  border: 1px solid var(--rule-strong);
+  margin-bottom: 2.5rem;
+}
+.metric-cell {
+  padding: 1.1rem 1.1rem 1rem;
+  border-right: 1px solid var(--rule);
+  position: relative;
+}
+.metric-cell:last-child { border-right: none; }
+.metric-cell::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  background: var(--rule);
+}
+.metric-cell:first-child::before { background: var(--hot); }
+.metric-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 80, "wght" 700;
+  font-size: 2rem; line-height: 1; letter-spacing: -0.04em;
+  color: var(--ink); margin-bottom: 0.3rem;
+}
+.metric-cell:first-child .metric-num { color: var(--hot); }
+.metric-label {
+  font-family: var(--font-mono); font-size: 0.62rem;
+  letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted);
+}
+
+/* ── SECTION GRID ───────────────────────────────────────────── */
+.sections { display: grid; gap: 2rem; }
+.two-col { grid-template-columns: 1fr 1fr; }
+.three-col { grid-template-columns: 1fr 1fr 1fr; }
+@media (max-width: 700px) {
+  .metric-strip { grid-template-columns: repeat(3, 1fr); }
+  .metric-cell:nth-child(3) { border-right: none; }
+  .two-col, .three-col { grid-template-columns: 1fr; }
+}
+
+/* ── SECTION BLOCK ──────────────────────────────────────────── */
+.section {
+  border-top: 1px solid var(--rule);
+  padding-top: 1.1rem;
+}
+.section-head {
+  display: flex; align-items: baseline; gap: 0.7rem; margin-bottom: 0.9rem;
+}
+.section-num {
+  font-family: var(--font-mono); font-size: 0.6rem;
+  color: var(--hot); letter-spacing: 0.1em;
+}
+.section-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 90, "wght" 700;
+  font-size: 0.78rem; text-transform: uppercase;
+  letter-spacing: 0.1em; color: var(--ink);
+}
+
+/* ── BAR CHART (pure CSS) ───────────────────────────────────── */
+.bar-list { display: grid; gap: 0; }
+.bar-row {
+  display: grid; grid-template-columns: 8rem 1fr 2.5rem;
+  align-items: center; gap: 0.6rem;
+  padding: 0.28rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.bar-row:last-child { border-bottom: none; }
+.bar-label {
+  font-family: var(--font-sans); font-size: 0.82rem; color: var(--ink-soft);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.bar-track {
+  height: 6px; background: var(--paper-2); position: relative;
+}
+.bar-fill {
+  position: absolute; top: 0; left: 0; height: 100%;
+  background: var(--ink); opacity: 0.18;
+  transition: width 0.6s var(--ease);
+}
+.bar-fill.hot { background: var(--hot); opacity: 1; }
+.bar-count {
+  font-family: var(--font-mono); font-size: 0.72rem;
+  color: var(--muted); text-align: right;
+}
+
+/* ── RANKED LIST ────────────────────────────────────────────── */
+.ranked-list { display: grid; gap: 0; }
+.ranked-row {
+  display: grid; grid-template-columns: 1.4rem 1fr auto;
+  align-items: center; gap: 0.5rem;
+  padding: 0.32rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.ranked-row:last-child { border-bottom: none; }
+.ranked-rank {
+  font-family: var(--font-mono); font-size: 0.66rem; color: var(--tertiary);
+  text-align: right;
+}
+.ranked-title {
+  font-family: var(--font-sans); font-size: 0.85rem; color: var(--hot);
+}
+.ranked-title:hover { color: var(--ink); }
+.ranked-meta {
+  font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted);
+  white-space: nowrap;
+}
+
+/* ── ACTIVITY CHART ─────────────────────────────────────────── */
+.activity-chart {
+  display: flex; align-items: flex-end; gap: 0.5rem; height: 80px;
+  padding-bottom: 1.4rem; position: relative;
+}
+.activity-chart::after {
+  content: ""; position: absolute; bottom: 1.2rem; left: 0; right: 0;
+  height: 1px; background: var(--rule);
+}
+.act-col { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 0.3rem; }
+.act-bar {
+  width: 100%; background: var(--ink); opacity: 0.12;
+  position: relative;
+}
+.act-bar.has-data { opacity: 1; background: var(--hot); }
+.act-month {
+  font-family: var(--font-mono); font-size: 0.58rem; color: var(--muted);
+  letter-spacing: 0.06em; white-space: nowrap;
+  position: absolute; bottom: 0; transform: translateY(1.3rem);
+}
+
+/* ── FOLDER LIST ────────────────────────────────────────────── */
+.folder-list { display: grid; gap: 0; }
+.folder-row {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: 0.6rem;
+  padding: 0.28rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.folder-row:last-child { border-bottom: none; }
+.folder-name {
+  font-family: var(--font-sans); font-size: 0.83rem; color: var(--ink-soft);
+}
+.folder-name .slash { color: var(--tertiary); }
+.folder-count {
+  font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted);
+}
+
+/* ── NOTE LIST (simple) ─────────────────────────────────────── */
+.note-list { display: grid; gap: 0; }
+.note-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  padding: 0.28rem 0; border-bottom: 1px solid var(--rule);
+}
+.note-row:last-child { border-bottom: none; }
+.note-row-title { font-family: var(--font-sans); font-size: 0.85rem; color: var(--hot); }
+.note-row-title:hover { color: var(--ink); }
+.note-row-meta { font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted); }
+
+/* ── PILL LIST (orphans / untagged) ─────────────────────────── */
+.pill-list { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.pill {
+  font-family: var(--font-sans); font-size: 0.78rem; color: var(--hot);
+  border: 1px solid var(--rule); background: var(--paper);
+  padding: 0.18rem 0.6rem;
+}
+.pill:hover { background: var(--paper-2); color: var(--ink); }
+
+/* ── TWIN COUNTER ───────────────────────────────────────────── */
+.twin-counter { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--rule); border: 1px solid var(--rule); }
+.twin-cell { background: var(--paper); padding: 0.85rem 1rem; }
+.twin-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 1.5rem; letter-spacing: -0.03em; line-height: 1;
+  margin-bottom: 0.2rem;
+}
+.twin-lbl { font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); }
+
+/* ── SINGLE STAT ────────────────────────────────────────────── */
+.single-stat { padding: 0.75rem 0; }
+.single-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 2.2rem; letter-spacing: -0.04em; line-height: 1;
+  color: var(--ink); margin-bottom: 0.2rem;
+}
+.single-lbl { font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted); }
+</style>
+</head>
+<body>
+<div class="hotbar"></div>
+
+<header class="topbar">
+  <div class="topbar-brand">
+    <span class="dot"></span>Hatchdoor
+  </div>
+  <div class="topbar-crumb">
+    <span class="sep">/</span>
+    <span class="here">Stats</span>
+  </div>
+  <div class="theme-btns">
+    <button class="theme-btn on" onclick="setTheme('auto')">Auto</button>
+    <button class="theme-btn" onclick="setTheme('light')">Light</button>
+    <button class="theme-btn" onclick="setTheme('dark')">Dark</button>
+  </div>
+</header>
+
+<main class="page">
+
+  <div class="page-header">
+    <p class="page-eyebrow">Vault · 2026-05-19</p>
+    <h1 class="page-title">Stats</h1>
+    <p class="page-subtitle">A complete overview of your vault — notes, links, tags, and writing activity.</p>
+  </div>
+
+  <!-- ── METRIC STRIP ── -->
+  <div class="metric-strip">
+    <div class="metric-cell">
+      <div class="metric-num">142</div>
+      <div class="metric-label">Notes</div>
+    </div>
+    <div class="metric-cell">
+      <div class="metric-num">84,320</div>
+      <div class="metric-label">Words</div>
+    </div>
+    <div class="metric-cell">
+      <div class="metric-num">38</div>
+      <div class="metric-label">Tags</div>
+    </div>
+    <div class="metric-cell">
+      <div class="metric-num">317</div>
+      <div class="metric-label">Links</div>
+    </div>
+    <div class="metric-cell">
+      <div class="metric-num">54</div>
+      <div class="metric-label">Images</div>
+    </div>
+  </div>
+
+  <!-- ── ROW 1: Tags + Most Linked ── -->
+  <div class="sections two-col" style="margin-bottom:2rem">
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">01</span>
+        <span class="section-title">Top Tags</span>
+      </div>
+      <div class="bar-list">
+        <div class="bar-row">
+          <span class="bar-label">programming</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:100%"></div></div>
+          <span class="bar-count">24</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">philosophy</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:75%"></div></div>
+          <span class="bar-count">18</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">writing</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:62%"></div></div>
+          <span class="bar-count">15</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">mathematics</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:50%"></div></div>
+          <span class="bar-count">12</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">history</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:46%"></div></div>
+          <span class="bar-count">11</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">reading</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:37%"></div></div>
+          <span class="bar-count">9</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">projects</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:33%"></div></div>
+          <span class="bar-count">8</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">design</span>
+          <div class="bar-track"><div class="bar-fill hot" style="width:29%"></div></div>
+          <span class="bar-count">7</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">02</span>
+        <span class="section-title">Most Linked Notes</span>
+      </div>
+      <div class="ranked-list">
+        <div class="ranked-row">
+          <span class="ranked-rank">1</span>
+          <a class="ranked-title" href="#">Index</a>
+          <span class="ranked-meta">31 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">2</span>
+          <a class="ranked-title" href="#">Reading List</a>
+          <span class="ranked-meta">22 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">3</span>
+          <a class="ranked-title" href="#">Project Ideas</a>
+          <span class="ranked-meta">17 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">4</span>
+          <a class="ranked-title" href="#">Philosophy Notes</a>
+          <span class="ranked-meta">14 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">5</span>
+          <a class="ranked-title" href="#">Daily Log</a>
+          <span class="ranked-meta">11 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">6</span>
+          <a class="ranked-title" href="#">Rust Book Notes</a>
+          <span class="ranked-meta">9 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">7</span>
+          <a class="ranked-title" href="#">Concepts Map</a>
+          <span class="ranked-meta">7 backlinks</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">8</span>
+          <a class="ranked-title" href="#">Contacts</a>
+          <span class="ranked-meta">5 backlinks</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── ROW 2: Activity ── -->
+  <div class="section" style="margin-bottom:2rem">
+    <div class="section-head">
+      <span class="section-num">03</span>
+      <span class="section-title">Writing Activity — last 6 months</span>
+    </div>
+    <div class="activity-chart" style="height:100px; padding-bottom: 1.6rem;">
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:31%"></div>
+        <span class="act-month">Dec</span>
+      </div>
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:55%"></div>
+        <span class="act-month">Jan</span>
+      </div>
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:88%"></div>
+        <span class="act-month">Feb</span>
+      </div>
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:35%"></div>
+        <span class="act-month">Mar</span>
+      </div>
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:72%"></div>
+        <span class="act-month">Apr</span>
+      </div>
+      <div class="act-col">
+        <div class="act-bar has-data" style="height:44%"></div>
+        <span class="act-month">May</span>
+      </div>
+    </div>
+    <div style="display:flex; gap:1.5rem; margin-top:0.5rem;">
+      <span style="font-family:var(--font-mono);font-size:0.68rem;color:var(--muted)">Peak: Feb · 22 notes</span>
+      <span style="font-family:var(--font-mono);font-size:0.68rem;color:var(--muted)">Avg: 13.7 / month</span>
+    </div>
+  </div>
+
+  <!-- ── ROW 3: Folders + Word lengths ── -->
+  <div class="sections two-col" style="margin-bottom:2rem">
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">04</span>
+        <span class="section-title">Notes per Folder</span>
+      </div>
+      <div class="folder-list">
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>Projects</span>
+          <span class="folder-count">42</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>Reading</span>
+          <span class="folder-count">28</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>Archive</span>
+          <span class="folder-count">21</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>Journal</span>
+          <span class="folder-count">18</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>Concepts</span>
+          <span class="folder-count">15</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">/</span>People</span>
+          <span class="folder-count">9</span>
+        </div>
+        <div class="folder-row">
+          <span class="folder-name"><span class="slash">·</span> root</span>
+          <span class="folder-count">9</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">05</span>
+        <span class="section-title">Word Count Extremes</span>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:0.5rem;">Longest</p>
+      <div class="note-list" style="margin-bottom:1rem">
+        <div class="note-row">
+          <a class="note-row-title" href="#">Phenomenology Overview</a>
+          <span class="note-row-meta">4,200 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Rust Book Notes</a>
+          <span class="note-row-meta">3,840 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Reading List</a>
+          <span class="note-row-meta">2,910 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">History of Computing</a>
+          <span class="note-row-meta">2,480 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Weekly Review Template</a>
+          <span class="note-row-meta">1,920 w</span>
+        </div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:0.5rem;">Shortest</p>
+      <div class="note-list">
+        <div class="note-row">
+          <a class="note-row-title" href="#">Stub</a>
+          <span class="note-row-meta">12 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">TODO</a>
+          <span class="note-row-meta">28 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Scratch</a>
+          <span class="note-row-meta">45 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Quick Ref</a>
+          <span class="note-row-meta">61 w</span>
+        </div>
+        <div class="note-row">
+          <a class="note-row-title" href="#">Draft Title</a>
+          <span class="note-row-meta">74 w</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── ROW 4: Summary stats ── -->
+  <div class="sections three-col" style="margin-bottom:2rem">
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">06</span>
+        <span class="section-title">Link Balance</span>
+      </div>
+      <div class="twin-counter">
+        <div class="twin-cell">
+          <div class="twin-num">317</div>
+          <div class="twin-lbl">Outgoing</div>
+        </div>
+        <div class="twin-cell">
+          <div class="twin-num">289</div>
+          <div class="twin-lbl">Backlinks</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">07</span>
+        <span class="section-title">Averages</span>
+      </div>
+      <div class="single-stat">
+        <div class="single-num">594</div>
+        <div class="single-lbl">Avg words / note</div>
+      </div>
+      <div style="margin-top:0.8rem;padding-top:0.8rem;border-top:1px solid var(--rule)">
+        <div style="font-family:var(--font-display);font-variation-settings:'wdth' 82,'wght' 700;font-size:1.3rem;letter-spacing:-0.02em;line-height:1;margin-bottom:0.2rem;">2.3 MB</div>
+        <div style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--muted)">Vault size on disk</div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">08</span>
+        <span class="section-title">Modified This Week</span>
+      </div>
+      <div style="font-family:var(--font-display);font-variation-settings:'wdth' 82,'wght' 700;font-size:2rem;letter-spacing:-0.04em;line-height:1;margin-bottom:0.3rem;">7</div>
+      <div style="font-family:var(--font-mono);font-size:0.6rem;letter-spacing:0.16em;text-transform:uppercase;color:var(--muted);margin-bottom:0.7rem;">notes</div>
+      <div class="note-list">
+        <div class="note-row"><a class="note-row-title" href="#">Rust Book Notes</a></div>
+        <div class="note-row"><a class="note-row-title" href="#">Index</a></div>
+        <div class="note-row"><a class="note-row-title" href="#">Weekly Review</a></div>
+        <div class="note-row"><a class="note-row-title" href="#">Philosophy Notes</a></div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── ROW 5: Orphans + No Tags ── -->
+  <div class="sections two-col">
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">09</span>
+        <span class="section-title">Orphan Notes</span>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.68rem;color:var(--muted);margin-bottom:0.7rem;line-height:1.5;">No incoming or outgoing links.</p>
+      <div class="pill-list">
+        <a class="pill" href="#">Draft Notes</a>
+        <a class="pill" href="#">Scratch Pad</a>
+        <a class="pill" href="#">Old Template</a>
+        <a class="pill" href="#">Untitled 3</a>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-head">
+        <span class="section-num">10</span>
+        <span class="section-title">Notes with No Tags</span>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.68rem;color:var(--muted);margin-bottom:0.7rem;line-height:1.5;">Missing all tags.</p>
+      <div class="pill-list">
+        <a class="pill" href="#">Untagged Entry</a>
+        <a class="pill" href="#">Daily Log</a>
+        <a class="pill" href="#">Meeting Notes</a>
+        <a class="pill" href="#">Quick Thoughts</a>
+        <a class="pill" href="#">Inbox</a>
+      </div>
+    </div>
+
+  </div>
+
+</main>
+
+<script>
+function setTheme(t) {
+  document.documentElement.dataset.theme = t;
+  document.querySelectorAll('.theme-btn').forEach(b => b.classList.toggle('on', b.textContent.toLowerCase() === t));
+}
+</script>
+</body>
+</html>

--- a/docs/design-options/stats-b.html
+++ b/docs/design-options/stats-b.html
@@ -1,0 +1,682 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Stats — Option B: Instrument</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+/* ── TOKENS ─────────────────────────────────────────────────── */
+:root[data-theme="light"], :root[data-theme="auto"] {
+  --bg: #f4f1e8; --paper: #faf7ed; --paper-2: #f0ece0;
+  --ink: #0c0c0a; --ink-soft: #2a2a26; --muted: #6b675c; --tertiary: #a8a399;
+  --rule: #ddd8c9; --rule-strong: #c4beab;
+  --hot: #ff4d1c; --hot-soft: #ffeae0;
+}
+:root[data-theme="dark"] {
+  --bg: #0c0c0a; --paper: #141412; --paper-2: #1a1a17;
+  --ink: #ece8d8; --ink-soft: #c4c0b0; --muted: #8a8678; --tertiary: #4a4842;
+  --rule: #232320; --rule-strong: #3a3933;
+  --hot: #ff5a2b; --hot-soft: #2a1410;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    --bg: #0c0c0a; --paper: #141412; --paper-2: #1a1a17;
+    --ink: #ece8d8; --ink-soft: #c4c0b0; --muted: #8a8678; --tertiary: #4a4842;
+    --rule: #232320; --rule-strong: #3a3933;
+    --hot: #ff5a2b; --hot-soft: #2a1410;
+  }
+}
+:root {
+  --font-display: "Bricolage Grotesque", system-ui, sans-serif;
+  --font-serif: "Newsreader", Georgia, serif;
+  --font-sans: "Inter Tight", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+  --dur: 180ms; --ease: cubic-bezier(.2,.8,.2,1);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { min-height: 100vh; }
+body { background: var(--bg); color: var(--ink); font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+a { color: var(--hot); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 2px; }
+
+/* ── CHROME ─────────────────────────────────────────────────── */
+.hotbar { height: 3px; background: var(--hot); }
+.topbar {
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0 1.5rem; height: 52px;
+  background: var(--bg); border-bottom: 1px solid var(--rule);
+}
+.topbar-brand {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 78, "wght" 800;
+  font-size: 0.9rem; letter-spacing: 0.04em; text-transform: uppercase;
+  display: flex; align-items: center; gap: 0.5rem;
+}
+.topbar-brand .dot { width: 8px; height: 8px; background: var(--hot); display: inline-block; }
+.topbar-crumb {
+  font-family: var(--font-sans); font-size: 0.85rem; color: var(--muted);
+  display: flex; align-items: center; gap: 0.5rem;
+}
+.topbar-crumb .sep { color: var(--tertiary); }
+.topbar-crumb .here { color: var(--ink); font-weight: 500; }
+.theme-btns { margin-left: auto; display: flex; gap: 0.3rem; }
+.theme-btn {
+  font-family: var(--font-sans); font-size: 0.7rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 0.3rem 0.6rem; background: var(--bg); color: var(--muted);
+  border: 1px solid var(--rule); cursor: pointer;
+}
+.theme-btn.on { background: var(--hot); color: #fff; border-color: var(--hot); }
+
+/* ── PAGE WRAPPER ───────────────────────────────────────────── */
+.page { max-width: 1040px; margin: 0 auto; padding: 2rem 1.5rem 6rem; }
+
+/* ── PAGE HEADER ────────────────────────────────────────────── */
+.page-header {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 1rem; margin-bottom: 1.8rem;
+  border-bottom: 2px solid var(--ink); padding-bottom: 1rem;
+}
+.page-header-left {}
+.page-eyebrow {
+  font-family: var(--font-mono); font-size: 0.65rem; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--hot); margin-bottom: 0.3rem;
+}
+.page-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  text-transform: uppercase; letter-spacing: -0.015em; line-height: 0.96;
+}
+.page-date {
+  font-family: var(--font-mono); font-size: 0.7rem; color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+/* ── TOP METRIC CARDS ───────────────────────────────────────── */
+.metric-cards {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.6rem;
+  margin-bottom: 1.8rem;
+}
+.metric-card {
+  background: var(--paper); border: 1px solid var(--rule);
+  padding: 1rem 1rem 0.85rem;
+  position: relative; overflow: hidden;
+  transition: border-color var(--dur) var(--ease);
+}
+.metric-card::after {
+  content: attr(data-label);
+  position: absolute; bottom: 0.55rem; right: 0.7rem;
+  font-family: var(--font-mono); font-size: 0.56rem;
+  letter-spacing: 0.2em; text-transform: uppercase; color: var(--tertiary);
+}
+.metric-card-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 80, "wght" 700;
+  font-size: 1.95rem; line-height: 1; letter-spacing: -0.04em;
+  color: var(--ink);
+}
+.metric-card.accent { border-color: var(--hot); }
+.metric-card.accent .metric-card-num { color: var(--hot); }
+.metric-card-label {
+  font-family: var(--font-mono); font-size: 0.6rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted);
+  margin-top: 0.3rem;
+}
+
+/* ── MAIN GRID ──────────────────────────────────────────────── */
+.main-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+.main-grid .span-2 { grid-column: span 2; }
+@media (max-width: 700px) {
+  .metric-cards { grid-template-columns: repeat(3, 1fr); }
+  .main-grid { grid-template-columns: 1fr; }
+  .main-grid .span-2 { grid-column: 1; }
+}
+
+/* ── PANEL ──────────────────────────────────────────────────── */
+.panel {
+  background: var(--paper); border: 1px solid var(--rule);
+  padding: 1rem 1.1rem;
+}
+.panel-head {
+  display: flex; align-items: center; gap: 0.6rem;
+  margin-bottom: 0.85rem; padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--rule);
+}
+.panel-icon {
+  font-size: 0.85rem; line-height: 1;
+  background: var(--paper-2); border: 1px solid var(--rule);
+  width: 1.7rem; height: 1.7rem; display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.panel-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 90, "wght" 700;
+  font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--ink);
+}
+.panel-count {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 0.65rem; color: var(--muted);
+}
+
+/* ── TAG BAR CHART ──────────────────────────────────────────── */
+.tag-bars { display: grid; gap: 0.3rem; }
+.tag-bar-row { display: grid; grid-template-columns: 7.5rem 1fr 2rem; align-items: center; gap: 0.55rem; }
+.tag-bar-label { font-family: var(--font-sans); font-size: 0.8rem; color: var(--ink-soft); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tag-bar-track { height: 8px; background: var(--paper-2); border: 1px solid var(--rule); position: relative; }
+.tag-bar-fill {
+  position: absolute; top: 0; left: 0; height: 100%;
+  transition: width 0.6s var(--ease);
+}
+.tag-bar-count { font-family: var(--font-mono); font-size: 0.68rem; color: var(--muted); text-align: right; }
+
+/* ── RANKED LIST ────────────────────────────────────────────── */
+.ranked { display: grid; gap: 0; }
+.ranked-row {
+  display: grid; grid-template-columns: 1.6rem 1fr auto;
+  align-items: center; gap: 0.4rem; padding: 0.3rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.ranked-row:last-child { border-bottom: none; }
+.ranked-rank {
+  font-family: var(--font-mono); font-size: 0.64rem; color: var(--tertiary);
+  border: 1px solid var(--rule); text-align: center; height: 1.3rem; line-height: 1.3rem;
+  background: var(--paper-2);
+}
+.ranked-title { font-family: var(--font-sans); font-size: 0.83rem; color: var(--hot); }
+.ranked-badge {
+  font-family: var(--font-mono); font-size: 0.64rem; color: var(--muted);
+  background: var(--paper-2); border: 1px solid var(--rule);
+  padding: 0.1rem 0.35rem; white-space: nowrap;
+}
+
+/* ── ACTIVITY CHART ─────────────────────────────────────────── */
+.activity-wrap { position: relative; padding-bottom: 1.5rem; }
+.activity-cols { display: flex; align-items: flex-end; gap: 0.5rem; height: 90px; }
+.act-col { flex: 1; display: flex; flex-direction: column; align-items: center; position: relative; }
+.act-bar-bg {
+  width: 100%; background: var(--paper-2); border: 1px solid var(--rule);
+  position: relative; overflow: hidden;
+}
+.act-bar-fill {
+  position: absolute; bottom: 0; left: 0; right: 0; background: var(--hot);
+  transition: height 0.6s var(--ease);
+}
+.act-label {
+  font-family: var(--font-mono); font-size: 0.58rem; color: var(--muted);
+  margin-top: 0.3rem; white-space: nowrap;
+}
+.act-count {
+  font-family: var(--font-mono); font-size: 0.6rem; color: var(--hot);
+  position: absolute; top: -1.1rem; left: 50%; transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+/* ── FOLDER BARS ────────────────────────────────────────────── */
+.folder-bars { display: grid; gap: 0.35rem; }
+.folder-bar-row { display: grid; grid-template-columns: 7rem 1fr 2rem; align-items: center; gap: 0.55rem; }
+.folder-bar-label { font-family: var(--font-sans); font-size: 0.8rem; color: var(--ink-soft); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.folder-bar-track { height: 6px; background: var(--paper-2); border: 1px solid var(--rule); position: relative; }
+.folder-bar-fill { position: absolute; top: 0; left: 0; height: 100%; background: var(--ink-soft); opacity: 0.35; }
+.folder-bar-count { font-family: var(--font-mono); font-size: 0.68rem; color: var(--muted); text-align: right; }
+
+/* ── SIMPLE LIST ────────────────────────────────────────────── */
+.simple-list { display: grid; gap: 0; }
+.simple-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  padding: 0.3rem 0; border-bottom: 1px solid var(--rule);
+}
+.simple-row:last-child { border-bottom: none; }
+.simple-title { font-family: var(--font-sans); font-size: 0.83rem; color: var(--hot); }
+.simple-meta { font-family: var(--font-mono); font-size: 0.68rem; color: var(--muted); white-space: nowrap; }
+
+/* ── TWIN STAT ──────────────────────────────────────────────── */
+.twin-stat { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--rule); }
+.twin-half { background: var(--paper); padding: 0.7rem 0.8rem; }
+.twin-half-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 1.4rem; letter-spacing: -0.03em; line-height: 1; margin-bottom: 0.15rem;
+}
+.twin-half-lbl { font-family: var(--font-mono); font-size: 0.58rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+
+/* ── BIG SINGLE ─────────────────────────────────────────────── */
+.big-single { padding: 0.2rem 0 0.5rem; }
+.big-single-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 80, "wght" 700;
+  font-size: 2.4rem; letter-spacing: -0.05em; line-height: 1; color: var(--ink);
+  margin-bottom: 0.25rem;
+}
+.big-single-lbl { font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted); }
+
+/* ── PILL LIST ──────────────────────────────────────────────── */
+.pill-list { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.pill {
+  font-family: var(--font-sans); font-size: 0.76rem;
+  background: var(--bg); border: 1px solid var(--rule-strong);
+  padding: 0.15rem 0.5rem; color: var(--hot);
+  transition: background var(--dur) var(--ease);
+}
+.pill:hover { background: var(--paper-2); color: var(--ink); }
+
+/* ── STAT ROW ───────────────────────────────────────────────── */
+.stat-row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 0.5rem; padding: 0.5rem 0; border-bottom: 1px solid var(--rule);
+}
+.stat-row:last-child { border-bottom: none; }
+.stat-row-label { font-family: var(--font-sans); font-size: 0.83rem; color: var(--muted); }
+.stat-row-val {
+  font-family: var(--font-mono); font-size: 0.83rem; font-weight: 500; color: var(--ink);
+}
+</style>
+</head>
+<body>
+<div class="hotbar"></div>
+
+<header class="topbar">
+  <div class="topbar-brand">
+    <span class="dot"></span>Hatchdoor
+  </div>
+  <div class="topbar-crumb">
+    <span class="sep">/</span>
+    <span class="here">Stats</span>
+  </div>
+  <div class="theme-btns">
+    <button class="theme-btn on" onclick="setTheme('auto')">Auto</button>
+    <button class="theme-btn" onclick="setTheme('light')">Light</button>
+    <button class="theme-btn" onclick="setTheme('dark')">Dark</button>
+  </div>
+</header>
+
+<main class="page">
+
+  <!-- ── HEADER ── -->
+  <div class="page-header">
+    <div class="page-header-left">
+      <p class="page-eyebrow">Vault analytics</p>
+      <h1 class="page-title">Stats</h1>
+    </div>
+    <span class="page-date">2026-05-19</span>
+  </div>
+
+  <!-- ── TOP METRIC CARDS ── -->
+  <div class="metric-cards">
+    <div class="metric-card accent" data-label="">
+      <div class="metric-card-num">142</div>
+      <div class="metric-card-label">Notes</div>
+    </div>
+    <div class="metric-card" data-label="">
+      <div class="metric-card-num">84,320</div>
+      <div class="metric-card-label">Words</div>
+    </div>
+    <div class="metric-card" data-label="">
+      <div class="metric-card-num">38</div>
+      <div class="metric-card-label">Tags</div>
+    </div>
+    <div class="metric-card" data-label="">
+      <div class="metric-card-num">317</div>
+      <div class="metric-card-label">Links</div>
+    </div>
+    <div class="metric-card" data-label="">
+      <div class="metric-card-num">54</div>
+      <div class="metric-card-label">Images</div>
+    </div>
+  </div>
+
+  <!-- ── MAIN GRID ── -->
+  <div class="main-grid">
+
+    <!-- Tags -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">⊞</div>
+        <span class="panel-title">Top Tags</span>
+        <span class="panel-count">38 total</span>
+      </div>
+      <div class="tag-bars">
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">programming</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:100%;background:hsl(14,100%,56%)"></div></div>
+          <span class="tag-bar-count">24</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">philosophy</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:75%;background:hsl(200,70%,52%)"></div></div>
+          <span class="tag-bar-count">18</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">writing</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:62%;background:hsl(150,60%,44%)"></div></div>
+          <span class="tag-bar-count">15</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">mathematics</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:50%;background:hsl(270,55%,58%)"></div></div>
+          <span class="tag-bar-count">12</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">history</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:46%;background:hsl(35,85%,52%)"></div></div>
+          <span class="tag-bar-count">11</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">reading</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:37%;background:hsl(340,60%,52%)"></div></div>
+          <span class="tag-bar-count">9</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">projects</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:33%;background:hsl(175,55%,42%)"></div></div>
+          <span class="tag-bar-count">8</span>
+        </div>
+        <div class="tag-bar-row">
+          <span class="tag-bar-label">design</span>
+          <div class="tag-bar-track"><div class="tag-bar-fill" style="width:29%;background:hsl(230,60%,58%)"></div></div>
+          <span class="tag-bar-count">7</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Most Linked -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">⇆</div>
+        <span class="panel-title">Most Linked</span>
+        <span class="panel-count">by backlinks</span>
+      </div>
+      <div class="ranked">
+        <div class="ranked-row">
+          <span class="ranked-rank">1</span>
+          <a class="ranked-title" href="#">Index</a>
+          <span class="ranked-badge">31</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">2</span>
+          <a class="ranked-title" href="#">Reading List</a>
+          <span class="ranked-badge">22</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">3</span>
+          <a class="ranked-title" href="#">Project Ideas</a>
+          <span class="ranked-badge">17</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">4</span>
+          <a class="ranked-title" href="#">Philosophy Notes</a>
+          <span class="ranked-badge">14</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">5</span>
+          <a class="ranked-title" href="#">Daily Log</a>
+          <span class="ranked-badge">11</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">6</span>
+          <a class="ranked-title" href="#">Rust Book Notes</a>
+          <span class="ranked-badge">9</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">7</span>
+          <a class="ranked-title" href="#">Concepts Map</a>
+          <span class="ranked-badge">7</span>
+        </div>
+        <div class="ranked-row">
+          <span class="ranked-rank">8</span>
+          <a class="ranked-title" href="#">Contacts</a>
+          <span class="ranked-badge">5</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Writing Activity -->
+    <div class="panel span-2">
+      <div class="panel-head">
+        <div class="panel-icon">↑</div>
+        <span class="panel-title">Writing Activity</span>
+        <span class="panel-count">last 6 months</span>
+      </div>
+      <div class="activity-wrap">
+        <div class="activity-cols">
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:36%"></div>
+            </div>
+            <span class="act-count">8</span>
+            <span class="act-label">Dec '25</span>
+          </div>
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:64%"></div>
+            </div>
+            <span class="act-count">14</span>
+            <span class="act-label">Jan '26</span>
+          </div>
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:100%"></div>
+            </div>
+            <span class="act-count">22</span>
+            <span class="act-label">Feb '26</span>
+          </div>
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:41%"></div>
+            </div>
+            <span class="act-count">9</span>
+            <span class="act-label">Mar '26</span>
+          </div>
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:82%"></div>
+            </div>
+            <span class="act-count">18</span>
+            <span class="act-label">Apr '26</span>
+          </div>
+          <div class="act-col">
+            <div class="act-bar-bg" style="height:70px; width:100%">
+              <div class="act-bar-fill" style="height:50%"></div>
+            </div>
+            <span class="act-count">11</span>
+            <span class="act-label">May '26</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Folders -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">⊙</div>
+        <span class="panel-title">Notes per Folder</span>
+      </div>
+      <div class="folder-bars">
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">Projects</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:100%"></div></div>
+          <span class="folder-bar-count">42</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">Reading</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:67%"></div></div>
+          <span class="folder-bar-count">28</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">Archive</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:50%"></div></div>
+          <span class="folder-bar-count">21</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">Journal</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:43%"></div></div>
+          <span class="folder-bar-count">18</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">Concepts</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:36%"></div></div>
+          <span class="folder-bar-count">15</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">People</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:21%"></div></div>
+          <span class="folder-bar-count">9</span>
+        </div>
+        <div class="folder-bar-row">
+          <span class="folder-bar-label">· root</span>
+          <div class="folder-bar-track"><div class="folder-bar-fill" style="width:21%"></div></div>
+          <span class="folder-bar-count">9</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Word Counts -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">≡</div>
+        <span class="panel-title">Word Counts</span>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--hot);margin-bottom:0.5rem;">Longest</p>
+      <div class="simple-list" style="margin-bottom:0.9rem">
+        <div class="simple-row">
+          <a class="simple-title" href="#">Phenomenology Overview</a>
+          <span class="simple-meta">4,200 w</span>
+        </div>
+        <div class="simple-row">
+          <a class="simple-title" href="#">Rust Book Notes</a>
+          <span class="simple-meta">3,840 w</span>
+        </div>
+        <div class="simple-row">
+          <a class="simple-title" href="#">Reading List</a>
+          <span class="simple-meta">2,910 w</span>
+        </div>
+        <div class="simple-row">
+          <a class="simple-title" href="#">History of Computing</a>
+          <span class="simple-meta">2,480 w</span>
+        </div>
+        <div class="simple-row">
+          <a class="simple-title" href="#">Weekly Review Template</a>
+          <span class="simple-meta">1,920 w</span>
+        </div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:0.5rem;">Shortest</p>
+      <div class="simple-list">
+        <div class="simple-row"><a class="simple-title" href="#">Stub</a><span class="simple-meta">12 w</span></div>
+        <div class="simple-row"><a class="simple-title" href="#">TODO</a><span class="simple-meta">28 w</span></div>
+        <div class="simple-row"><a class="simple-title" href="#">Scratch</a><span class="simple-meta">45 w</span></div>
+        <div class="simple-row"><a class="simple-title" href="#">Quick Ref</a><span class="simple-meta">61 w</span></div>
+        <div class="simple-row"><a class="simple-title" href="#">Draft Title</a><span class="simple-meta">74 w</span></div>
+      </div>
+    </div>
+
+    <!-- Aggregate Stats -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">∑</div>
+        <span class="panel-title">Aggregate</span>
+      </div>
+      <div>
+        <div class="stat-row">
+          <span class="stat-row-label">Avg words / note</span>
+          <span class="stat-row-val">594</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-row-label">Vault size on disk</span>
+          <span class="stat-row-val">2.3 MB</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-row-label">Notes modified this week</span>
+          <span class="stat-row-val">7</span>
+        </div>
+        <div class="stat-row">
+          <span class="stat-row-label">Notes modified this month</span>
+          <span class="stat-row-val">23</span>
+        </div>
+      </div>
+      <div style="margin-top:1rem">
+        <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:0.5rem">Link Balance</p>
+        <div class="twin-stat">
+          <div class="twin-half">
+            <div class="twin-half-num">317</div>
+            <div class="twin-half-lbl">Outgoing</div>
+          </div>
+          <div class="twin-half">
+            <div class="twin-half-num">289</div>
+            <div class="twin-half-lbl">Backlinks</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Recent Activity -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">◷</div>
+        <span class="panel-title">Recent Activity</span>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--hot);margin-bottom:0.5rem">Modified this week · 7</p>
+      <div class="simple-list" style="margin-bottom:1rem">
+        <div class="simple-row"><a class="simple-title" href="#">Rust Book Notes</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Index</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Weekly Review</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Philosophy Notes</a></div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:0.62rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--muted);margin-bottom:0.5rem">Modified this month · 23</p>
+      <div class="simple-list">
+        <div class="simple-row"><a class="simple-title" href="#">Rust Book Notes</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Index</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Weekly Review</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Philosophy Notes</a></div>
+        <div class="simple-row"><a class="simple-title" href="#">Concepts Map</a></div>
+      </div>
+    </div>
+
+    <!-- Orphans + No Tags -->
+    <div class="panel">
+      <div class="panel-head">
+        <div class="panel-icon">◌</div>
+        <span class="panel-title">Orphan Notes</span>
+        <span class="panel-count">4 found</span>
+      </div>
+      <p style="font-family:var(--font-sans);font-size:0.8rem;color:var(--muted);margin-bottom:0.7rem;line-height:1.5">No incoming or outgoing links.</p>
+      <div class="pill-list" style="margin-bottom:1.2rem">
+        <a class="pill" href="#">Draft Notes</a>
+        <a class="pill" href="#">Scratch Pad</a>
+        <a class="pill" href="#">Old Template</a>
+        <a class="pill" href="#">Untitled 3</a>
+      </div>
+      <div class="panel-head" style="margin-top:0.5rem">
+        <div class="panel-icon">∅</div>
+        <span class="panel-title">No Tags</span>
+        <span class="panel-count">5 found</span>
+      </div>
+      <p style="font-family:var(--font-sans);font-size:0.8rem;color:var(--muted);margin-bottom:0.7rem;line-height:1.5">Missing all tags.</p>
+      <div class="pill-list">
+        <a class="pill" href="#">Untagged Entry</a>
+        <a class="pill" href="#">Daily Log</a>
+        <a class="pill" href="#">Meeting Notes</a>
+        <a class="pill" href="#">Quick Thoughts</a>
+        <a class="pill" href="#">Inbox</a>
+      </div>
+    </div>
+
+  </div><!-- /main-grid -->
+
+</main>
+
+<script>
+function setTheme(t) {
+  document.documentElement.dataset.theme = t;
+  document.querySelectorAll('.theme-btn').forEach(b => b.classList.toggle('on', b.textContent.toLowerCase() === t));
+}
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-05-19-stats-graph-pages-design.md
+++ b/docs/superpowers/specs/2026-05-19-stats-graph-pages-design.md
@@ -1,0 +1,249 @@
+# Stats & Graph Pages — Design Spec
+
+**Date:** 2026-05-19
+**Branch:** stats-integration
+
+---
+
+## Overview
+
+Add two new pages to Hatchdoor — a Stats dashboard and an Obsidian-style Graph view — plus a minor update to the explorer sidebar to surface note count and navigation links to both pages.
+
+---
+
+## 1. Explorer Sidebar Changes
+
+### Notes section label
+The existing "Notes" list section in the explorer panel gets an inline total count:
+```
+Notes  142
+```
+The count comes from the existing tree data already loaded in `App.tsx`.
+
+### Navigation links
+Two new links appear at the top of the explorer panel, above the "Recently Viewed" section:
+
+```
+[ 📊 Stats ]  [ 🕸 Graph ]
+```
+
+Both are `<Link>` components routing to `/stats` and `/graph` respectively. They live inside `ExplorerPane.tsx`.
+
+---
+
+## 2. Stats Page (`/stats`)
+
+### Route
+New route added in `App.tsx`: `<Route path="/stats" element={<StatsPage />} />`
+
+### New component
+`frontend/src/components/StatsPage.tsx` — fetches from `/api/stats` on mount, renders all sections.
+
+### Top counters
+A row of large number cards:
+- **Notes** — total note count
+- **Words** — total word count across all notes
+- **Tags** — count of distinct tags
+- **Links** — total wikilinks in the vault
+- **Images** — count of image embeds (`![` and `![[image` patterns in content)
+
+### Sections
+
+| Section | Content |
+|---|---|
+| Top Tags | Horizontal bar chart (pure CSS), sorted by note count descending, top 20 |
+| Most Linked Notes | Ranked list with backlink count; each row is a `<Link>` to `/n/:slug` |
+| Writing Activity | Bar chart of notes modified per month, last 6 months |
+| Notes per Folder | Breakdown by top-level directory, note count per folder |
+| Longest Notes | Top 5 by word count, clickable |
+| Shortest Notes | Bottom 5 by word count (excluding empty), clickable |
+| Orphan Notes | Notes with zero incoming and zero outgoing links, clickable list |
+| Notes with No Tags | Notes missing all tags, clickable list |
+| Modified This Week | Count + list of notes modified in last 7 days |
+| Modified This Month | Count + list of notes modified in last 30 days |
+| Link Balance | Two side-by-side counters: total outgoing links vs total backlinks |
+| Average Word Count | Single number: mean words per note |
+| Vault Size | Total size of all note files on disk (formatted as KB / MB) |
+
+All charts are pure CSS — no charting library added.
+
+### New backend endpoint: `GET /api/stats`
+
+Returns a single JSON object computed from SQLite. All fields computed server-side.
+
+**Response shape:**
+```json
+{
+  "note_count": 142,
+  "word_count": 84320,
+  "tag_count": 38,
+  "link_count": 317,
+  "image_count": 54,
+  "avg_word_count": 594,
+  "vault_size_bytes": 2340000,
+  "top_tags": [
+    { "tag": "programming", "note_count": 24 }
+  ],
+  "most_linked": [
+    { "title": "Index", "slug": "index", "backlink_count": 31 }
+  ],
+  "activity_by_month": [
+    { "month": "2025-12", "modified_count": 8 }
+  ],
+  "notes_per_folder": [
+    { "folder": "Projects", "note_count": 42 }
+  ],
+  "longest_notes": [
+    { "title": "Big Note", "slug": "big-note", "word_count": 4200 }
+  ],
+  "shortest_notes": [
+    { "title": "Stub", "slug": "stub", "word_count": 12 }
+  ],
+  "orphan_notes": [
+    { "title": "Lost Note", "slug": "lost-note" }
+  ],
+  "no_tag_notes": [
+    { "title": "Untagged", "slug": "untagged" }
+  ],
+  "modified_this_week": {
+    "count": 7,
+    "notes": [{ "title": "Recent", "slug": "recent" }]
+  },
+  "modified_this_month": {
+    "count": 23,
+    "notes": [{ "title": "Recent", "slug": "recent" }]
+  },
+  "total_outgoing_links": 317,
+  "total_backlinks": 317
+}
+```
+
+**Word count:** computed by splitting note content on whitespace server-side. YAML frontmatter is excluded (strip lines between leading `---` delimiters before counting).
+**Image count:** count of `![` occurrences in note content — covers `![alt](url)` markdown images and `![[file.png]]` wikilink embeds. This is an approximation; non-image wikilink embeds using `![[` are rare and acceptable false positives.
+**Modified lists cap:** `modified_this_week.notes` and `modified_this_month.notes` are capped at 20 entries each.
+**Vault size:** sum of `size_bytes` from the `notes` table.
+
+New Rust handler in `src/handlers/api.rs`. New response type in `src/api_types.rs`. New cache method `SqliteCache::vault_stats()` in `src/cache/queries.rs`.
+
+---
+
+## 3. Graph Page (`/graph`)
+
+### Route
+New route added in `App.tsx`: `<Route path="/graph" element={<GraphPage />} />`
+
+### New component
+`frontend/src/components/GraphPage.tsx` — fetches from `/api/graph` on mount, renders D3 force simulation inside a `<canvas>` or `<svg>` element.
+
+### Library
+**D3.js** (`d3-force`, `d3-zoom`, `d3-drag`) — installed as a dependency. No full D3 import; only the sub-packages needed are imported to keep bundle size minimal.
+
+### New backend endpoint: `GET /api/graph`
+
+Returns all nodes and all edges in one response (avoids N+1 per-note link fetches).
+
+**Response shape:**
+```json
+{
+  "nodes": [
+    { "slug": "index", "title": "Index", "primary_tag": "programming", "backlink_count": 31 }
+  ],
+  "edges": [
+    { "source": "index", "target": "projects" }
+  ]
+}
+```
+
+`primary_tag` is the first tag alphabetically for the note (or `null` if untagged). Tag-to-color mapping is computed deterministically on the frontend (hash tag name → hue in HSL).
+
+New Rust handler in `src/handlers/api.rs`. New response types in `src/api_types.rs`. New cache method `SqliteCache::graph_data()` in `src/cache/queries.rs`.
+
+### Rendering
+
+- Canvas-based D3 force simulation for performance with large vaults
+- Node radius: `base_radius + log(backlink_count + 1) * scale_factor`
+- Node color: deterministic HSL from tag name hash; untagged nodes = muted grey
+- Edge color: subtle, low-opacity lines
+- Node labels: rendered on hover only (prevents clutter)
+
+### Interactions
+
+| Action | Behaviour |
+|---|---|
+| Hover node | Show note title tooltip, highlight direct edges |
+| Click once | Highlight node + all directly connected nodes; dim everything else |
+| Click again (same node) | Navigate to `/n/:slug` |
+| Click canvas background | Clear highlight selection |
+| Scroll | Zoom in/out (D3 zoom) |
+| Drag canvas | Pan |
+| Drag node | Reposition node (D3 drag), simulation re-stabilises |
+
+### Tag filter
+
+A chip list above the graph showing all tags. Selecting a chip dims nodes that do not have that tag. Multiple chips can be selected (union — show notes with any selected tag). Selecting no chips shows all nodes.
+
+---
+
+## 4. New Types in `frontend/src/types.ts`
+
+```ts
+export type TagStat = { tag: string; note_count: number };
+export type NoteRef = { title: string; slug: string };
+export type NoteWordRef = NoteRef & { word_count: number };
+export type LinkedNoteRef = NoteRef & { backlink_count: number };
+export type MonthActivity = { month: string; modified_count: number };
+export type FolderStat = { folder: string; note_count: number };
+export type NoteList = { count: number; notes: NoteRef[] };
+
+export type VaultStats = {
+  note_count: number;
+  word_count: number;
+  tag_count: number;
+  link_count: number;
+  image_count: number;
+  avg_word_count: number;
+  vault_size_bytes: number;
+  total_outgoing_links: number;
+  total_backlinks: number;
+  top_tags: TagStat[];
+  most_linked: LinkedNoteRef[];
+  activity_by_month: MonthActivity[];
+  notes_per_folder: FolderStat[];
+  longest_notes: NoteWordRef[];
+  shortest_notes: NoteWordRef[];
+  orphan_notes: NoteRef[];
+  no_tag_notes: NoteRef[];
+  modified_this_week: NoteList;
+  modified_this_month: NoteList;
+};
+
+export type GraphNode = { slug: string; title: string; primary_tag: string | null; backlink_count: number };
+export type GraphEdge = { source: string; target: string };
+export type GraphData = { nodes: GraphNode[]; edges: GraphEdge[] };
+```
+
+---
+
+## 5. File Summary
+
+| File | Change |
+|---|---|
+| `src/api_types.rs` | Add `VaultStatsResponse`, `GraphResponse`, `GraphNode`, `GraphEdge` |
+| `src/cache/queries.rs` | Add `vault_stats()` and `graph_data()` methods |
+| `src/handlers/api.rs` | Add `stats_handler` and `graph_handler` |
+| `src/main.rs` (or router) | Register `/api/stats` and `/api/graph` routes |
+| `frontend/src/types.ts` | Add `VaultStats`, `GraphNode`, `GraphEdge`, `GraphData` |
+| `frontend/src/app/ExplorerPane.tsx` | Add Stats/Graph nav links; add note count to section label |
+| `frontend/src/components/StatsPage.tsx` | New file |
+| `frontend/src/components/GraphPage.tsx` | New file |
+| `frontend/src/App.tsx` | Register `/stats` and `/graph` routes |
+| `package.json` | Add `d3-force`, `d3-zoom`, `d3-drag`, `@types/d3` |
+
+---
+
+## 6. Out of Scope
+
+- Editing notes from the graph view
+- Saving graph layout between sessions
+- Animated graph transitions beyond D3 defaults
+- Real-time graph updates on vault change (can be added later)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "2.0.0",
       "dependencies": {
+        "d3-force": "^3.0.0",
         "mermaid": "^11.12.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "d3-force": "^3.0.0",
     "mermaid": "^11.12.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -31,6 +32,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
@@ -40,7 +42,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
-    "@vitest/coverage-v8": "^4.0.18",
     "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,3 +6,4 @@
 @import "./styles/search.css";
 @import "./styles/responsive.css";
 @import "./styles/stats.css";
+@import "./styles/graph.css";

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,3 +5,4 @@
 @import "./styles/ui-common.css";
 @import "./styles/search.css";
 @import "./styles/responsive.css";
+@import "./styles/stats.css";

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import { useIsMobile } from "./app/useIsMobile";
 import { copyText } from "./clipboard";
 import { NotePage } from "./components/NotePage";
 import { SearchDialog } from "./components/SearchDialog";
+import { StatsPage } from "./components/StatsPage";
 import { StateBlock } from "./components/ui";
 import { isExplorerTreeEqual } from "./stateCompare";
 import type {
@@ -541,6 +542,7 @@ function App() {
         <main className="note-pane">
           <Routes>
             <Route path="/" element={<EmptyState />} />
+            <Route path="/stats" element={<StatsPage />} />
             <Route
               path="/n/:slug"
               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import { useIsMobile } from "./app/useIsMobile";
 import { copyText } from "./clipboard";
 import { NotePage } from "./components/NotePage";
 import { SearchDialog } from "./components/SearchDialog";
+import { GraphPage } from "./components/GraphPage";
 import { StatsPage } from "./components/StatsPage";
 import { StateBlock } from "./components/ui";
 import { isExplorerTreeEqual } from "./stateCompare";
@@ -539,10 +540,11 @@ function App() {
           />
         ) : null}
 
-        <main className="note-pane">
+        <main className={`note-pane${location.pathname === "/graph" ? " graph-host" : ""}`}>
           <Routes>
             <Route path="/" element={<EmptyState />} />
             <Route path="/stats" element={<StatsPage />} />
+            <Route path="/graph" element={<GraphPage />} />
             <Route
               path="/n/:slug"
               element={

--- a/frontend/src/app/ExplorerPane.tsx
+++ b/frontend/src/app/ExplorerPane.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import { NavLink } from "react-router-dom";
 
 import {
   FolderTree,
@@ -7,6 +8,13 @@ import {
 } from "../components/Explorer";
 import { ExplorerSkeleton, StateBlock, UiButton } from "../components/ui";
 import type { ExplorerFolder, ModifiedNote, RecentNote } from "../types";
+
+function countNotes(folder: ExplorerFolder): number {
+  return (
+    folder.notes.length +
+    folder.folders.reduce((sum, f) => sum + countNotes(f), 0)
+  );
+}
 
 type ExplorerPaneProps = {
   explorerPaneRef: RefObject<HTMLElement | null>;
@@ -57,6 +65,25 @@ export function ExplorerPane({
         </div>
       </header>
 
+      <div className="explorer-page-links">
+        <NavLink
+          className={({ isActive }) =>
+            `explorer-page-link${isActive ? " active" : ""}`
+          }
+          to="/stats"
+        >
+          Stats
+        </NavLink>
+        <NavLink
+          className={({ isActive }) =>
+            `explorer-page-link${isActive ? " active" : ""}`
+          }
+          to="/graph"
+        >
+          Graph
+        </NavLink>
+      </div>
+
       <RecentNotesList
         notes={recentNotes}
         currentPath={locationPathname}
@@ -77,6 +104,12 @@ export function ExplorerPane({
           actionLabel="Retry"
           onAction={onRefreshTree}
         />
+      ) : null}
+      {tree ? (
+        <p className="explorer-notes-label">
+          Notes{" "}
+          <span className="explorer-notes-count">{countNotes(tree)}</span>
+        </p>
       ) : null}
       {tree ? (
         <FolderTree

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -767,6 +767,8 @@ export function GraphPage() {
 
   // ── tag filter toggle ────────────────────────────────────────────────────────
 
+  const [filterOpen, setFilterOpen] = useState(false);
+
   const toggleTag = useCallback((tag: string) => {
     setActiveTags((prev) => {
       const next = new Set(prev);
@@ -782,10 +784,31 @@ export function GraphPage() {
   // effects (resize observer, event listeners) attach correctly.  Loading and
   // error states are rendered as absolutely-positioned overlays instead.
 
+  const tagChips = allTags.length > 0 && (
+    <div className="graph-tag-filter">
+      {allTags.map((tag) => {
+        const hue = tagHue(tag);
+        const active = activeTags.has(tag);
+        return (
+          <button
+            key={tag}
+            className={`graph-tag-chip${active ? " active" : ""}`}
+            style={active ? { "--chip-hue": String(hue) } as React.CSSProperties : undefined}
+            onClick={() => toggleTag(tag)}
+          >
+            {active && <span className="graph-tag-dot" style={{ background: `hsl(${hue}, 60%, 58%)` }} />}
+            {tag}
+          </button>
+        );
+      })}
+    </div>
+  );
+
   return (
     <div className="graph-page">
       <div className="graph-header">
         <p className="graph-eyebrow">Vault · Knowledge Graph</p>
+
         <div className="graph-header-row">
           <h1 className="graph-title">Graph</h1>
           <div className="graph-meta-strip">
@@ -799,31 +822,39 @@ export function GraphPage() {
               <span className="graph-meta-lbl">edges</span>
             </span>
           </div>
+
+          {allTags.length > 0 && (
+            <button
+              className={`graph-filter-toggle${activeTags.size > 0 ? " has-active" : ""}${filterOpen ? " is-open" : ""}`}
+              onClick={() => setFilterOpen((o) => !o)}
+              aria-expanded={filterOpen}
+            >
+              <span className="graph-filter-toggle-label">
+                Tags{activeTags.size > 0 && <span className="graph-filter-badge">{activeTags.size}</span>}
+              </span>
+              <span className="graph-filter-caret" aria-hidden>▾</span>
+            </button>
+          )}
         </div>
-        {allTags.length > 0 && (
-          <div className="graph-tag-filter">
-            {allTags.map((tag) => {
-              const hue = tagHue(tag);
-              const active = activeTags.has(tag);
-              return (
-                <button
-                  key={tag}
-                  className={`graph-tag-chip${active ? " active" : ""}`}
-                  style={active ? {
-                    "--chip-hue": String(hue),
-                  } as React.CSSProperties : undefined}
-                  onClick={() => toggleTag(tag)}
-                >
-                  {active && <span className="graph-tag-dot" style={{ background: `hsl(${hue}, 60%, 58%)` }} />}
-                  {tag}
-                </button>
-              );
-            })}
-          </div>
-        )}
+
+        {/* Desktop: always visible inline. Mobile: hidden, rendered as overlay below. */}
+        <div className="graph-tags-desktop">{tagChips}</div>
+
         <p className="graph-hint">
           Scroll to zoom · Drag background to pan · Click node to select · Double-click to open
         </p>
+      </div>
+
+      {/* Mobile-only filter overlay — sits on top of canvas, doesn't push it */}
+      {filterOpen && (
+        <button
+          className="graph-filter-backdrop"
+          aria-label="Close filter"
+          onClick={() => setFilterOpen(false)}
+        />
+      )}
+      <div className="graph-tags-mobile" aria-hidden={!filterOpen}>
+        {tagChips}
       </div>
 
       <div className="graph-canvas-wrap" ref={wrapRef}>

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -198,6 +198,14 @@ export function GraphPage() {
     const nodes = simNodesRef.current;
     const links = simLinksRef.current;
 
+    // diagnostic: log state once per second
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = window as any;
+    if (!win._dbgLast || Date.now() - win._dbgLast > 1000) {
+      win._dbgLast = Date.now();
+      console.log("[graph] nodes:", nodes.length, "transform:", { x, y, k }, "canvas:", canvas.width, "x", canvas.height, "first:", nodes[0] ? `(${nodes[0].x?.toFixed(1)}, ${nodes[0].y?.toFixed(1)})` : "none");
+    }
+
     // determine which nodes are "visible" based on tag filter
     const isVisible = (node: SimNode) => {
       if (activeTags.size === 0) return true;

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -153,6 +153,23 @@ export function GraphPage() {
     if (!ctx) return;
 
     const dpr = window.devicePixelRatio || 1;
+
+    // Sync physical canvas buffer to its CSS layout dimensions on every frame.
+    // This is more reliable than the ResizeObserver alone when the height
+    // chain is established after the observer's first fire.
+    const cssW = canvas.clientWidth;
+    const cssH = canvas.clientHeight;
+    if (cssW > 0 && cssH > 0) {
+      const needW = Math.round(cssW * dpr);
+      const needH = Math.round(cssH * dpr);
+      if (canvas.width !== needW || canvas.height !== needH) {
+        canvas.width = needW;
+        canvas.height = needH;
+        // Re-centre world origin whenever the canvas is resized.
+        transformRef.current = { x: cssW / 2, y: cssH / 2, k: transformRef.current.k };
+      }
+    }
+
     const W = canvas.width / dpr;
     const H = canvas.height / dpr;
     ctx.save();
@@ -198,13 +215,6 @@ export function GraphPage() {
     const nodes = simNodesRef.current;
     const links = simLinksRef.current;
 
-    // diagnostic: log state once per second
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const win = window as any;
-    if (!win._dbgLast || Date.now() - win._dbgLast > 1000) {
-      win._dbgLast = Date.now();
-      console.log("[graph] nodes:", nodes.length, "transform:", { x, y, k }, "canvas:", canvas.width, "x", canvas.height, "first:", nodes[0] ? `(${nodes[0].x?.toFixed(1)}, ${nodes[0].y?.toFixed(1)})` : "none");
-    }
 
     // determine which nodes are "visible" based on tag filter
     const isVisible = (node: SimNode) => {

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -1,0 +1,654 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  forceCollide,
+  type Simulation,
+  type SimulationNodeDatum,
+  type SimulationLinkDatum,
+} from "d3-force";
+
+import type { GraphData, GraphNode } from "../types";
+import { StateBlock } from "./ui";
+
+// ── simulation types ─────────────────────────────────────────────────────────
+
+interface SimNode extends SimulationNodeDatum {
+  slug: string;
+  title: string;
+  primary_tag: string | null;
+  backlink_count: number;
+  x: number;
+  y: number;
+}
+
+interface SimLink extends SimulationLinkDatum<SimNode> {
+  source: SimNode;
+  target: SimNode;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const BASE_RADIUS = 4;
+const SCALE_FACTOR = 2.8;
+
+function nodeRadius(backlinks: number): number {
+  return BASE_RADIUS + Math.log(backlinks + 1) * SCALE_FACTOR;
+}
+
+function tagHue(tag: string): number {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++) {
+    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash) % 360;
+}
+
+function nodeColor(tag: string | null, alpha = 1): string {
+  if (!tag) return `rgba(138, 134, 120, ${alpha})`;
+  const hue = tagHue(tag);
+  return `hsla(${hue}, 60%, 58%, ${alpha})`;
+}
+
+function cssVar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+// ── component ─────────────────────────────────────────────────────────────────
+
+export function GraphPage() {
+  const navigate = useNavigate();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [graphData, setGraphData] = useState<GraphData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [activeTags, setActiveTags] = useState<Set<string>>(new Set());
+  const [nodeCount, setNodeCount] = useState(0);
+  const [edgeCount, setEdgeCount] = useState(0);
+
+  // mutable state shared between render loop and event handlers
+  const simNodesRef = useRef<SimNode[]>([]);
+  const simLinksRef = useRef<SimLink[]>([]);
+  const transformRef = useRef({ x: 0, y: 0, k: 1 });
+  const hoveredRef = useRef<SimNode | null>(null);
+  const selectedRef = useRef<SimNode | null>(null);
+  const activeTagsRef = useRef<Set<string>>(new Set());
+  const lastClickSlugRef = useRef<string | null>(null);
+  const rafRef = useRef<number>(0);
+  const simRef = useRef<Simulation<SimNode, SimLink> | null>(null);
+  const dragRef = useRef<{ node: SimNode; startX: number; startY: number } | null>(null);
+  const panRef = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
+
+  // keep activeTagsRef in sync
+  useEffect(() => {
+    activeTagsRef.current = activeTags;
+  }, [activeTags]);
+
+  // ── data fetch ──────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/graph");
+        if (!res.ok) throw new Error(`Graph fetch failed: ${res.status}`);
+        const data = (await res.json()) as GraphData;
+        if (cancelled) return;
+
+        setGraphData(data);
+        setNodeCount(data.nodes.length);
+        setEdgeCount(data.edges.length);
+
+        const tags = Array.from(
+          new Set(
+            data.nodes
+              .map((n: GraphNode) => n.primary_tag)
+              .filter((t): t is string => t !== null),
+          ),
+        ).sort();
+        setAllTags(tags);
+      } catch (err) {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : "Failed to load graph");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // ── hit test ────────────────────────────────────────────────────────────────
+
+  const hitTest = useCallback((cx: number, cy: number): SimNode | null => {
+    const { x, y, k } = transformRef.current;
+    const wx = (cx - x) / k;
+    const wy = (cy - y) / k;
+    let best: SimNode | null = null;
+    let bestDist = Infinity;
+    for (const node of simNodesRef.current) {
+      const r = nodeRadius(node.backlink_count);
+      const d = Math.hypot(node.x - wx, node.y - wy);
+      if (d <= r + 2 && d < bestDist) {
+        best = node;
+        bestDist = d;
+      }
+    }
+    return best;
+  }, []);
+
+  // ── canvas rendering ────────────────────────────────────────────────────────
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const W = canvas.width / dpr;
+    const H = canvas.height / dpr;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+
+    const { x, y, k } = transformRef.current;
+    const activeTags = activeTagsRef.current;
+    const hovered = hoveredRef.current;
+    const selected = selectedRef.current;
+
+    // theme colors
+    const bgColor = cssVar("--bg");
+    const paperColor = cssVar("--paper");
+    const ruleColor = cssVar("--rule");
+    const inkColor = cssVar("--ink");
+    const mutedColor = cssVar("--muted");
+    const hotColor = cssVar("--hot");
+
+    // clear
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, W, H);
+
+    // subtle grid
+    ctx.save();
+    ctx.strokeStyle = ruleColor;
+    ctx.lineWidth = 0.5;
+    ctx.globalAlpha = 0.4;
+    const gridStep = 40 * k;
+    const gridOffX = ((x % gridStep) + gridStep) % gridStep;
+    const gridOffY = ((y % gridStep) + gridStep) % gridStep;
+    for (let gx = gridOffX; gx < W; gx += gridStep) {
+      ctx.beginPath(); ctx.moveTo(gx, 0); ctx.lineTo(gx, H); ctx.stroke();
+    }
+    for (let gy = gridOffY; gy < H; gy += gridStep) {
+      ctx.beginPath(); ctx.moveTo(0, gy); ctx.lineTo(W, gy); ctx.stroke();
+    }
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.scale(k, k);
+
+    const nodes = simNodesRef.current;
+    const links = simLinksRef.current;
+
+    // determine which nodes are "visible" based on tag filter
+    const isVisible = (node: SimNode) => {
+      if (activeTags.size === 0) return true;
+      return node.primary_tag !== null && activeTags.has(node.primary_tag);
+    };
+
+    // connected slugs for selection highlight
+    const connectedSlugs = new Set<string>();
+    if (selected) {
+      connectedSlugs.add(selected.slug);
+      for (const link of links) {
+        if (link.source.slug === selected.slug) connectedSlugs.add(link.target.slug);
+        if (link.target.slug === selected.slug) connectedSlugs.add(link.source.slug);
+      }
+    }
+
+    // draw edges
+    for (const link of links) {
+      const src = link.source;
+      const tgt = link.target;
+      const srcVis = isVisible(src);
+      const tgtVis = isVisible(tgt);
+
+      let alpha = 0.18;
+      let color = mutedColor;
+
+      if (selected) {
+        const srcConn = connectedSlugs.has(src.slug);
+        const tgtConn = connectedSlugs.has(tgt.slug);
+        if (srcConn && tgtConn) { alpha = 0.55; color = hotColor; }
+        else alpha = 0.04;
+      } else if (hovered) {
+        if (src.slug === hovered.slug || tgt.slug === hovered.slug) {
+          alpha = 0.6; color = hotColor;
+        } else {
+          alpha = 0.06;
+        }
+      }
+
+      if (!srcVis || !tgtVis) alpha *= 0.2;
+
+      ctx.beginPath();
+      ctx.moveTo(src.x, src.y);
+      ctx.lineTo(tgt.x, tgt.y);
+      ctx.strokeStyle = color;
+      ctx.globalAlpha = alpha;
+      ctx.lineWidth = selected && connectedSlugs.has(src.slug) && connectedSlugs.has(tgt.slug) ? 1.5 / k : 1 / k;
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // draw nodes
+    for (const node of nodes) {
+      const r = nodeRadius(node.backlink_count);
+      const vis = isVisible(node);
+      const isHovered = hovered?.slug === node.slug;
+      const isSelected = selected?.slug === node.slug;
+      const isConnected = selected ? connectedSlugs.has(node.slug) : false;
+
+      let alpha = vis ? 1 : 0.15;
+      if (selected && !isConnected) alpha = vis ? 0.2 : 0.06;
+
+      const color = node.primary_tag ? nodeColor(node.primary_tag) : mutedColor;
+
+      ctx.globalAlpha = alpha;
+
+      // glow for hovered/selected
+      if (isHovered || isSelected) {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, r + 5 / k, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.globalAlpha = alpha * 0.2;
+        ctx.fill();
+        ctx.globalAlpha = alpha;
+      }
+
+      // node fill
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+
+      // node border
+      ctx.strokeStyle = isSelected ? hotColor : isHovered ? inkColor : paperColor;
+      ctx.lineWidth = (isSelected || isHovered ? 2 : 1) / k;
+      ctx.globalAlpha = isHovered || isSelected ? 1 : alpha * 0.6;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+
+    // labels for hovered/selected node (show always at zoom >= 0.8)
+    const labelCandidates: SimNode[] = [];
+    if (hovered) labelCandidates.push(hovered);
+    if (selected && selected !== hovered) labelCandidates.push(selected);
+    if (k >= 0.8) {
+      // show labels for highly-linked nodes
+      for (const node of nodes) {
+        if (node.backlink_count >= 5 && isVisible(node)) {
+          if (!labelCandidates.find((n) => n.slug === node.slug)) {
+            labelCandidates.push(node);
+          }
+        }
+      }
+    }
+
+    for (const node of labelCandidates) {
+      const r = nodeRadius(node.backlink_count);
+      const isHov = node.slug === hovered?.slug;
+      const isSel = node.slug === selected?.slug;
+      const fontSize = Math.max(10, Math.min(14, 11 / k));
+
+      ctx.save();
+      ctx.font = `500 ${fontSize}px "Inter Tight", system-ui, sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+
+      const label = node.title.length > 28 ? node.title.slice(0, 26) + "…" : node.title;
+      const metrics = ctx.measureText(label);
+      const padX = 5 / k;
+      const padY = 3 / k;
+      const bw = metrics.width + padX * 2;
+      const bh = fontSize + padY * 2;
+      const bx = node.x - bw / 2;
+      const by = node.y + r + 4 / k;
+
+      ctx.globalAlpha = isSel ? 1 : isHov ? 0.95 : 0.75;
+      ctx.fillStyle = paperColor;
+      ctx.fillRect(bx, by, bw, bh);
+      ctx.strokeStyle = ruleColor;
+      ctx.lineWidth = 1 / k;
+      ctx.strokeRect(bx, by, bw, bh);
+      ctx.fillStyle = isSel ? hotColor : inkColor;
+      ctx.fillText(label, node.x, by + padY);
+      ctx.globalAlpha = 1;
+      ctx.restore();
+    }
+
+    ctx.restore();
+    ctx.restore();
+  }, []);
+
+  // ── animation loop ───────────────────────────────────────────────────────────
+
+  const startLoop = useCallback(() => {
+    const tick = () => {
+      render();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [render]);
+
+  // ── simulation setup ─────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!graphData) return;
+
+    // Nodes live in world space centred at (0,0). The canvas transform maps
+    // world (0,0) → canvas centre. Do NOT use canvas pixel dimensions here —
+    // using them caused a double-shift that put every node off-screen.
+    const spread = 500;
+    const nodes: SimNode[] = graphData.nodes.map((n) => ({
+      ...n,
+      x: (Math.random() - 0.5) * spread,
+      y: (Math.random() - 0.5) * spread,
+    })) as SimNode[];
+
+    const nodeBySlug = new Map<string, SimNode>(nodes.map((n) => [n.slug, n]));
+
+    const links: SimLink[] = graphData.edges
+      .map((e) => {
+        const source = nodeBySlug.get(e.source);
+        const target = nodeBySlug.get(e.target);
+        if (!source || !target) return null;
+        return { source, target } as SimLink;
+      })
+      .filter((l): l is SimLink => l !== null);
+
+    simNodesRef.current = nodes;
+    simLinksRef.current = links;
+
+    // Centre transform on the canvas. The canvas is already sized by the
+    // ResizeObserver so clientWidth/Height are reliable here.
+    const canvas = canvasRef.current;
+    const W = canvas?.clientWidth ?? 800;
+    const H = canvas?.clientHeight ?? 600;
+    transformRef.current = { x: W / 2, y: H / 2, k: 0.9 };
+
+    simRef.current?.stop();
+    const sim = forceSimulation<SimNode>(nodes)
+      .force("link", forceLink<SimNode, SimLink>(links).id((d) => d.slug).distance(60).strength(0.4))
+      .force("charge", forceManyBody<SimNode>().strength(-180).distanceMax(400))
+      .force("center", forceCenter<SimNode>(0, 0))
+      .force("collide", forceCollide<SimNode>().radius((d) => nodeRadius(d.backlink_count) + 4))
+      .alphaDecay(0.02);
+
+    simRef.current = sim;
+
+    return () => { sim.stop(); };
+  }, [graphData]);
+
+  // ── canvas resize ───────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    let centred = false;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = wrap.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+      // Re-centre the world origin on first valid size so the graph
+      // is always visible regardless of when the sim initialised.
+      if (!centred) {
+        centred = true;
+        transformRef.current = { x: rect.width / 2, y: rect.height / 2, k: 0.9 };
+      }
+    };
+
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+    return () => ro.disconnect();
+  }, []);
+
+  // ── start render loop ────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    startLoop();
+    return () => { cancelAnimationFrame(rafRef.current); };
+  }, [startLoop]);
+
+  // ── mouse/touch events ───────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const getPos = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      return { cx: e.clientX - rect.left, cy: e.clientY - rect.top };
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const { cx, cy } = getPos(e);
+
+      if (panRef.current) {
+        const dx = cx - panRef.current.startX;
+        const dy = cy - panRef.current.startY;
+        transformRef.current.x = panRef.current.ox + dx;
+        transformRef.current.y = panRef.current.oy + dy;
+        return;
+      }
+
+      if (dragRef.current) {
+        const { k, x, y } = transformRef.current;
+        const wx = (cx - x) / k;
+        const wy = (cy - y) / k;
+        dragRef.current.node.x = wx;
+        dragRef.current.node.y = wy;
+        dragRef.current.node.fx = wx;
+        dragRef.current.node.fy = wy;
+        simRef.current?.alphaTarget(0.1).restart();
+        return;
+      }
+
+      const hit = hitTest(cx, cy);
+      if (hit !== hoveredRef.current) {
+        hoveredRef.current = hit;
+        canvas.style.cursor = hit ? "pointer" : "grab";
+      }
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button !== 0) return;
+      const { cx, cy } = getPos(e);
+      const hit = hitTest(cx, cy);
+
+      if (hit) {
+        dragRef.current = { node: hit, startX: cx, startY: cy };
+        canvas.style.cursor = "grabbing";
+      } else {
+        panRef.current = {
+          startX: cx,
+          startY: cy,
+          ox: transformRef.current.x,
+          oy: transformRef.current.y,
+        };
+        canvas.style.cursor = "grabbing";
+      }
+    };
+
+    const onMouseUp = (e: MouseEvent) => {
+      const { cx, cy } = getPos(e);
+
+      if (dragRef.current) {
+        const movedX = Math.abs(cx - dragRef.current.startX);
+        const movedY = Math.abs(cy - dragRef.current.startY);
+        const moved = movedX > 4 || movedY > 4;
+
+        if (!moved) {
+          const node = dragRef.current.node;
+          if (lastClickSlugRef.current === node.slug) {
+            void navigate(`/n/${node.slug}`);
+            lastClickSlugRef.current = null;
+          } else {
+            selectedRef.current = selectedRef.current?.slug === node.slug ? null : node;
+            lastClickSlugRef.current = node.slug;
+            setTimeout(() => {
+              if (lastClickSlugRef.current === node.slug) {
+                lastClickSlugRef.current = null;
+              }
+            }, 500);
+          }
+        }
+
+        dragRef.current.node.fx = null;
+        dragRef.current.node.fy = null;
+        simRef.current?.alphaTarget(0).restart();
+        dragRef.current = null;
+      } else if (panRef.current) {
+        const movedX = Math.abs(cx - panRef.current.startX);
+        const movedY = Math.abs(cy - panRef.current.startY);
+        if (movedX < 4 && movedY < 4) {
+          selectedRef.current = null;
+          lastClickSlugRef.current = null;
+        }
+        panRef.current = null;
+      }
+
+      canvas.style.cursor = hitTest(cx, cy) ? "pointer" : "grab";
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const { cx, cy } = getPos(e);
+      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      const t = transformRef.current;
+      const newK = Math.max(0.1, Math.min(8, t.k * factor));
+      transformRef.current = {
+        k: newK,
+        x: cx - ((cx - t.x) / t.k) * newK,
+        y: cy - ((cy - t.y) / t.k) * newK,
+      };
+    };
+
+    const onMouseLeave = () => {
+      hoveredRef.current = null;
+      dragRef.current = null;
+      panRef.current = null;
+    };
+
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mouseup", onMouseUp);
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    canvas.addEventListener("mouseleave", onMouseLeave);
+
+    return () => {
+      canvas.removeEventListener("mousemove", onMouseMove);
+      canvas.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mouseup", onMouseUp);
+      canvas.removeEventListener("wheel", onWheel);
+      canvas.removeEventListener("mouseleave", onMouseLeave);
+    };
+  }, [hitTest, navigate]);
+
+  // ── tag filter toggle ────────────────────────────────────────────────────────
+
+  const toggleTag = useCallback((tag: string) => {
+    setActiveTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  }, []);
+
+  // ── render ───────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="graph-loading">
+        <div className="graph-loading-pulse" />
+        <div className="graph-loading-label">Mapping your vault…</div>
+      </div>
+    );
+  }
+
+  if (error || !graphData) {
+    return (
+      <StateBlock
+        title="Graph Unavailable"
+        description={error ?? "Could not load graph data."}
+      />
+    );
+  }
+
+  return (
+    <div className="graph-page">
+      <div className="graph-header">
+        <p className="graph-eyebrow">Vault · Knowledge Graph</p>
+        <div className="graph-header-row">
+          <h1 className="graph-title">Graph</h1>
+          <div className="graph-meta-strip">
+            <span className="graph-meta-item">
+              <span className="graph-meta-num">{nodeCount}</span>
+              <span className="graph-meta-lbl">nodes</span>
+            </span>
+            <span className="graph-meta-sep" />
+            <span className="graph-meta-item">
+              <span className="graph-meta-num">{edgeCount}</span>
+              <span className="graph-meta-lbl">edges</span>
+            </span>
+          </div>
+        </div>
+        {allTags.length > 0 && (
+          <div className="graph-tag-filter">
+            {allTags.map((tag) => {
+              const hue = tagHue(tag);
+              const active = activeTags.has(tag);
+              return (
+                <button
+                  key={tag}
+                  className={`graph-tag-chip${active ? " active" : ""}`}
+                  style={active ? {
+                    "--chip-hue": String(hue),
+                  } as React.CSSProperties : undefined}
+                  onClick={() => toggleTag(tag)}
+                >
+                  {active && <span className="graph-tag-dot" style={{ background: `hsl(${hue}, 60%, 58%)` }} />}
+                  {tag}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <p className="graph-hint">
+          Scroll to zoom · Drag background to pan · Click node to select · Double-click to open
+        </p>
+      </div>
+
+      <div className="graph-canvas-wrap" ref={wrapRef}>
+        <canvas ref={canvasRef} className="graph-canvas" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -84,6 +84,8 @@ export function GraphPage() {
   const simRef = useRef<Simulation<SimNode, SimLink> | null>(null);
   const dragRef = useRef<{ node: SimNode; startX: number; startY: number } | null>(null);
   const panRef = useRef<{ startX: number; startY: number; ox: number; oy: number } | null>(null);
+  const zoomAnimRef = useRef<{ targetK: number; cx: number; cy: number } | null>(null);
+  const pinchRef = useRef<{ dist: number; cx: number; cy: number } | null>(null);
 
   // keep activeTagsRef in sync
   useEffect(() => {
@@ -168,6 +170,23 @@ export function GraphPage() {
         // Re-centre world origin whenever the canvas is resized.
         transformRef.current = { x: cssW / 2, y: cssH / 2, k: transformRef.current.k };
       }
+    }
+
+    // Animate zoom — lerp in log-space each frame so speed is perceptually even.
+    if (zoomAnimRef.current) {
+      const anim = zoomAnimRef.current;
+      const t = transformRef.current;
+      const logCurrent = Math.log(t.k);
+      const logTarget = Math.log(anim.targetK);
+      const diff = logTarget - logCurrent;
+      const newK = Math.abs(diff) < 0.0008
+        ? (zoomAnimRef.current = null, anim.targetK)
+        : Math.exp(logCurrent + diff * 0.18);
+      transformRef.current = {
+        k: newK,
+        x: anim.cx - ((anim.cx - t.x) / t.k) * newK,
+        y: anim.cy - ((anim.cy - t.y) / t.k) * newK,
+      };
     }
 
     const W = canvas.width / dpr;
@@ -306,18 +325,22 @@ export function GraphPage() {
       ctx.globalAlpha = 1;
     }
 
-    // labels for hovered/selected node (show always at zoom >= 0.8)
+    // Show a label when the node's rendered radius (world-radius × zoom) is
+    // large enough to be worth reading, plus always for hovered/selected.
+    const LABEL_SCREEN_THRESHOLD = 8; // px on screen
+    const LABEL_SCREEN_SIZE = 12;     // px on screen — constant regardless of zoom
+
+    const seen = new Set<string>();
     const labelCandidates: SimNode[] = [];
-    if (hovered) labelCandidates.push(hovered);
-    if (selected && selected !== hovered) labelCandidates.push(selected);
-    if (k >= 0.8) {
-      // show labels for highly-linked nodes
-      for (const node of nodes) {
-        if (node.backlink_count >= 5 && isVisible(node)) {
-          if (!labelCandidates.find((n) => n.slug === node.slug)) {
-            labelCandidates.push(node);
-          }
-        }
+    const pushLabel = (n: SimNode) => {
+      if (!seen.has(n.slug)) { seen.add(n.slug); labelCandidates.push(n); }
+    };
+
+    if (hovered) pushLabel(hovered);
+    if (selected && selected !== hovered) pushLabel(selected);
+    for (const node of nodes) {
+      if (isVisible(node) && nodeRadius(node.backlink_count) * k >= LABEL_SCREEN_THRESHOLD) {
+        pushLabel(node);
       }
     }
 
@@ -325,7 +348,7 @@ export function GraphPage() {
       const r = nodeRadius(node.backlink_count);
       const isHov = node.slug === hovered?.slug;
       const isSel = node.slug === selected?.slug;
-      const fontSize = Math.max(10, Math.min(14, 11 / k));
+      const fontSize = LABEL_SCREEN_SIZE / k; // constant screen size
 
       ctx.save();
       ctx.font = `500 ${fontSize}px "Inter Tight", system-ui, sans-serif`;
@@ -465,7 +488,9 @@ export function GraphPage() {
       return { cx: e.clientX - rect.left, cy: e.clientY - rect.top };
     };
 
-    const onMouseMove = (e: MouseEvent) => {
+    // window-level move handler used during drag/pan so events keep firing
+    // even when the cursor leaves the canvas element.
+    const onWindowMouseMove = (e: MouseEvent) => {
       const { cx, cy } = getPos(e);
 
       if (panRef.current) {
@@ -487,7 +512,12 @@ export function GraphPage() {
         simRef.current?.alphaTarget(0.1).restart();
         return;
       }
+    };
 
+    const onMouseMove = (e: MouseEvent) => {
+      if (panRef.current || dragRef.current) return; // handled by window listener
+
+      const { cx, cy } = getPos(e);
       const hit = hitTest(cx, cy);
       if (hit !== hoveredRef.current) {
         hoveredRef.current = hit;
@@ -558,14 +588,12 @@ export function GraphPage() {
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       const { cx, cy } = getPos(e);
-      const factor = e.deltaY < 0 ? 1.1 : 0.9;
-      const t = transformRef.current;
-      const newK = Math.max(0.1, Math.min(8, t.k * factor));
-      transformRef.current = {
-        k: newK,
-        x: cx - ((cx - t.x) / t.k) * newK,
-        y: cy - ((cy - t.y) / t.k) * newK,
-      };
+      // Proportional factor: works naturally for both mouse wheels (~120/notch)
+      // and trackpad gestures (small continuous deltas).
+      const factor = Math.pow(0.999, e.deltaY);
+      const baseK = zoomAnimRef.current?.targetK ?? transformRef.current.k;
+      const targetK = Math.max(0.1, Math.min(8, baseK * factor));
+      zoomAnimRef.current = { targetK, cx, cy };
     };
 
     const onMouseLeave = () => {
@@ -574,18 +602,166 @@ export function GraphPage() {
       panRef.current = null;
     };
 
+    // ── touch helpers ────────────────────────────────────────────────────────
+
+    const getTouchPos = (t: Touch) => {
+      const rect = canvas.getBoundingClientRect();
+      return { cx: t.clientX - rect.left, cy: t.clientY - rect.top };
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+
+      if (e.touches.length === 2) {
+        // Begin pinch — cancel any ongoing pan/drag
+        dragRef.current = null;
+        panRef.current = null;
+        zoomAnimRef.current = null;
+        const a = getTouchPos(e.touches[0]);
+        const b = getTouchPos(e.touches[1]);
+        pinchRef.current = {
+          dist: Math.hypot(b.cx - a.cx, b.cy - a.cy),
+          cx: (a.cx + b.cx) / 2,
+          cy: (a.cy + b.cy) / 2,
+        };
+        return;
+      }
+
+      if (e.touches.length === 1) {
+        pinchRef.current = null;
+        const { cx, cy } = getTouchPos(e.touches[0]);
+        const hit = hitTest(cx, cy);
+        if (hit) {
+          dragRef.current = { node: hit, startX: cx, startY: cy };
+        } else {
+          panRef.current = {
+            startX: cx, startY: cy,
+            ox: transformRef.current.x,
+            oy: transformRef.current.y,
+          };
+        }
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+
+      if (e.touches.length === 2 && pinchRef.current) {
+        const a = getTouchPos(e.touches[0]);
+        const b = getTouchPos(e.touches[1]);
+        const newDist = Math.hypot(b.cx - a.cx, b.cy - a.cy);
+        const midCx = (a.cx + b.cx) / 2;
+        const midCy = (a.cy + b.cy) / 2;
+        const factor = newDist / pinchRef.current.dist;
+        const t = transformRef.current;
+        const newK = Math.max(0.1, Math.min(8, t.k * factor));
+        // Also pan with the midpoint so two-finger drag works simultaneously
+        const panDx = midCx - pinchRef.current.cx;
+        const panDy = midCy - pinchRef.current.cy;
+        transformRef.current = {
+          k: newK,
+          x: midCx - ((pinchRef.current.cx - t.x) / t.k) * newK + panDx,
+          y: midCy - ((pinchRef.current.cy - t.y) / t.k) * newK + panDy,
+        };
+        pinchRef.current = { dist: newDist, cx: midCx, cy: midCy };
+        return;
+      }
+
+      if (e.touches.length === 1) {
+        const { cx, cy } = getTouchPos(e.touches[0]);
+
+        if (panRef.current) {
+          transformRef.current.x = panRef.current.ox + (cx - panRef.current.startX);
+          transformRef.current.y = panRef.current.oy + (cy - panRef.current.startY);
+          return;
+        }
+
+        if (dragRef.current) {
+          const { k, x, y } = transformRef.current;
+          const wx = (cx - x) / k;
+          const wy = (cy - y) / k;
+          dragRef.current.node.x = wx;
+          dragRef.current.node.y = wy;
+          dragRef.current.node.fx = wx;
+          dragRef.current.node.fy = wy;
+          simRef.current?.alphaTarget(0.1).restart();
+        }
+      }
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      e.preventDefault();
+
+      if (e.touches.length >= 1) {
+        // One finger lifted while two were down — transition to single-finger pan
+        pinchRef.current = null;
+        const { cx, cy } = getTouchPos(e.touches[0]);
+        panRef.current = {
+          startX: cx, startY: cy,
+          ox: transformRef.current.x,
+          oy: transformRef.current.y,
+        };
+        return;
+      }
+
+      // All fingers lifted
+      pinchRef.current = null;
+      const last = e.changedTouches[0];
+      const { cx, cy } = getTouchPos(last);
+
+      if (dragRef.current) {
+        const moved = Math.abs(cx - dragRef.current.startX) > 8
+                   || Math.abs(cy - dragRef.current.startY) > 8;
+
+        if (!moved) {
+          const node = dragRef.current.node;
+          if (lastClickSlugRef.current === node.slug) {
+            void navigate(`/n/${node.slug}`);
+            lastClickSlugRef.current = null;
+          } else {
+            selectedRef.current = selectedRef.current?.slug === node.slug ? null : node;
+            lastClickSlugRef.current = node.slug;
+            setTimeout(() => {
+              if (lastClickSlugRef.current === node.slug) lastClickSlugRef.current = null;
+            }, 500);
+          }
+        }
+
+        dragRef.current.node.fx = null;
+        dragRef.current.node.fy = null;
+        simRef.current?.alphaTarget(0).restart();
+        dragRef.current = null;
+      } else if (panRef.current) {
+        const moved = Math.abs(cx - panRef.current.startX) > 8
+                   || Math.abs(cy - panRef.current.startY) > 8;
+        if (!moved) {
+          selectedRef.current = null;
+          lastClickSlugRef.current = null;
+        }
+        panRef.current = null;
+      }
+    };
+
     canvas.addEventListener("mousemove", onMouseMove);
     canvas.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mousemove", onWindowMouseMove);
     window.addEventListener("mouseup", onMouseUp);
     canvas.addEventListener("wheel", onWheel, { passive: false });
     canvas.addEventListener("mouseleave", onMouseLeave);
+    canvas.addEventListener("touchstart", onTouchStart, { passive: false });
+    canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+    canvas.addEventListener("touchend", onTouchEnd, { passive: false });
 
     return () => {
       canvas.removeEventListener("mousemove", onMouseMove);
       canvas.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mousemove", onWindowMouseMove);
       window.removeEventListener("mouseup", onMouseUp);
       canvas.removeEventListener("wheel", onWheel);
       canvas.removeEventListener("mouseleave", onMouseLeave);
+      canvas.removeEventListener("touchstart", onTouchStart);
+      canvas.removeEventListener("touchmove", onTouchMove);
+      canvas.removeEventListener("touchend", onTouchEnd);
     };
   }, [hitTest, navigate]);
 
@@ -602,23 +778,9 @@ export function GraphPage() {
 
   // ── render ───────────────────────────────────────────────────────────────────
 
-  if (loading) {
-    return (
-      <div className="graph-loading">
-        <div className="graph-loading-pulse" />
-        <div className="graph-loading-label">Mapping your vault…</div>
-      </div>
-    );
-  }
-
-  if (error || !graphData) {
-    return (
-      <StateBlock
-        title="Graph Unavailable"
-        description={error ?? "Could not load graph data."}
-      />
-    );
-  }
+  // NOTE: canvas is always in the DOM so that refs are valid on mount and
+  // effects (resize observer, event listeners) attach correctly.  Loading and
+  // error states are rendered as absolutely-positioned overlays instead.
 
   return (
     <div className="graph-page">
@@ -666,6 +828,22 @@ export function GraphPage() {
 
       <div className="graph-canvas-wrap" ref={wrapRef}>
         <canvas ref={canvasRef} className="graph-canvas" />
+
+        {loading && (
+          <div className="graph-overlay">
+            <div className="graph-loading-pulse" />
+            <div className="graph-loading-label">Mapping your vault…</div>
+          </div>
+        )}
+
+        {!loading && (error || !graphData) && (
+          <div className="graph-overlay">
+            <StateBlock
+              title="Graph Unavailable"
+              description={error ?? "Could not load graph data."}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/StatsPage.tsx
+++ b/frontend/src/components/StatsPage.tsx
@@ -90,6 +90,7 @@ function ActivityChart({ months }: { months: MonthActivity[] }) {
       <div className="stats-activity">
         {months.map((m) => (
           <div key={m.month} className="stats-act-col">
+            <span className="stats-act-count">{m.modified_count}</span>
             <div
               className="stats-act-bar"
               style={{

--- a/frontend/src/components/StatsPage.tsx
+++ b/frontend/src/components/StatsPage.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { StateBlock } from "./ui";
+import type {
+  FolderStat,
+  LinkedNoteRef,
+  MonthActivity,
+  NoteRef,
+  NoteWordRef,
+  TagStat,
+  VaultStats,
+} from "../types";
+
+function fmtNum(n: number): string {
+  return n.toLocaleString();
+}
+
+function fmtBytes(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)} MB`;
+  return `${(n / 1_000).toFixed(0)} KB`;
+}
+
+function fmtMonth(m: string): string {
+  const [year, month] = m.split("-");
+  const date = new Date(Number(year), Number(month) - 1, 1);
+  return date.toLocaleString("en", { month: "short" });
+}
+
+function maxOf(arr: number[]): number {
+  return arr.length === 0 ? 1 : Math.max(...arr);
+}
+
+function SectionHead({ num, title }: { num: string; title: string }) {
+  return (
+    <div className="stats-section-head">
+      <span className="stats-section-num">{num}</span>
+      <span className="stats-section-title">{title}</span>
+    </div>
+  );
+}
+
+function TagBars({ tags }: { tags: TagStat[] }) {
+  const top = tags.slice(0, 20);
+  const max = maxOf(top.map((t) => t.note_count));
+  return (
+    <div className="stats-bar-list">
+      {top.map((t) => (
+        <div key={t.tag} className="stats-bar-row">
+          <span className="stats-bar-label">{t.tag}</span>
+          <div className="stats-bar-track">
+            <div
+              className="stats-bar-fill"
+              style={{ width: `${(t.note_count / max) * 100}%` }}
+            />
+          </div>
+          <span className="stats-bar-count">{t.note_count}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RankedList({ notes }: { notes: LinkedNoteRef[] }) {
+  return (
+    <div className="stats-ranked-list">
+      {notes.map((n, i) => (
+        <div key={n.slug} className="stats-ranked-row">
+          <span className="stats-ranked-rank">{i + 1}</span>
+          <Link className="stats-ranked-title" to={`/n/${n.slug}`}>
+            {n.title}
+          </Link>
+          <span className="stats-ranked-meta">{n.backlink_count} backlinks</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActivityChart({ months }: { months: MonthActivity[] }) {
+  if (months.length === 0) return null;
+  const max = maxOf(months.map((m) => m.modified_count));
+  const peak = months.reduce((a, b) =>
+    a.modified_count >= b.modified_count ? a : b,
+  );
+  const avg = months.reduce((s, m) => s + m.modified_count, 0) / months.length;
+
+  return (
+    <>
+      <div className="stats-activity">
+        {months.map((m) => (
+          <div key={m.month} className="stats-act-col">
+            <div
+              className="stats-act-bar"
+              style={{
+                height: `${Math.max(2, (m.modified_count / max) * 68)}px`,
+              }}
+            />
+            <span className="stats-act-month">{fmtMonth(m.month)}</span>
+          </div>
+        ))}
+      </div>
+      <div className="stats-activity-meta">
+        <span>
+          Peak: {fmtMonth(peak.month)} · {peak.modified_count} notes
+        </span>
+        <span>Avg: {avg.toFixed(1)} / month</span>
+      </div>
+    </>
+  );
+}
+
+function FolderList({ folders }: { folders: FolderStat[] }) {
+  return (
+    <div className="stats-folder-list">
+      {folders.map((f) => (
+        <div key={f.folder} className="stats-folder-row">
+          <span className="stats-folder-name">
+            <span className="stats-folder-slash">
+              {f.folder === "(root)" ? "·" : "/"}
+            </span>{" "}
+            {f.folder === "(root)" ? "root" : f.folder}
+          </span>
+          <span className="stats-folder-count">{f.note_count}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NoteWordList({
+  notes,
+  sublabel,
+}: {
+  notes: NoteWordRef[];
+  sublabel: string;
+}) {
+  return (
+    <>
+      <p className={`stats-sublabel${sublabel === "Longest" ? " hot" : ""}`}>
+        {sublabel}
+      </p>
+      <div className="stats-note-list" style={{ marginBottom: "0.9rem" }}>
+        {notes.map((n) => (
+          <div key={n.slug} className="stats-note-row">
+            <Link className="stats-note-title" to={`/n/${n.slug}`}>
+              {n.title}
+            </Link>
+            <span className="stats-note-meta">{fmtNum(n.word_count)} w</span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function PillList({ notes }: { notes: NoteRef[] }) {
+  if (notes.length === 0) {
+    return (
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.72rem",
+          color: "var(--muted)",
+        }}
+      >
+        None found.
+      </p>
+    );
+  }
+  return (
+    <div className="stats-pill-list">
+      {notes.map((n) => (
+        <Link key={n.slug} className="stats-pill" to={`/n/${n.slug}`}>
+          {n.title}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function RecentList({ notes }: { notes: NoteRef[] }) {
+  return (
+    <div className="stats-note-list">
+      {notes.map((n) => (
+        <div key={n.slug} className="stats-note-row">
+          <Link className="stats-note-title" to={`/n/${n.slug}`}>
+            {n.title}
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function StatsPage() {
+  const [stats, setStats] = useState<VaultStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/stats");
+        if (!res.ok) throw new Error(`Stats failed: ${res.status}`);
+        const data = (await res.json()) as VaultStats;
+        if (!cancelled) setStats(data);
+      } catch (err) {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : "Failed to load stats");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="stats-loading">
+        <div className="stats-loading-strip" />
+        <div className="stats-loading-block" />
+        <div className="stats-loading-block" />
+      </div>
+    );
+  }
+
+  if (error || !stats) {
+    return (
+      <StateBlock
+        title="Stats Unavailable"
+        description={error ?? "Could not load vault stats."}
+      />
+    );
+  }
+
+  return (
+    <div className="stats-page">
+      {/* Header */}
+      <div className="stats-page-header">
+        <p className="stats-eyebrow">Vault · {new Date().toISOString().slice(0, 10)}</p>
+        <h1 className="stats-title">Stats</h1>
+        <p className="stats-subtitle">
+          A complete overview of your vault — notes, links, tags, and writing
+          activity.
+        </p>
+      </div>
+
+      {/* Metric strip */}
+      <div className="stats-metric-strip">
+        <div className="stats-metric-cell">
+          <div className="stats-metric-num">{fmtNum(stats.note_count)}</div>
+          <div className="stats-metric-label">Notes</div>
+        </div>
+        <div className="stats-metric-cell">
+          <div className="stats-metric-num">{fmtNum(stats.word_count)}</div>
+          <div className="stats-metric-label">Words</div>
+        </div>
+        <div className="stats-metric-cell">
+          <div className="stats-metric-num">{fmtNum(stats.tag_count)}</div>
+          <div className="stats-metric-label">Tags</div>
+        </div>
+        <div className="stats-metric-cell">
+          <div className="stats-metric-num">{fmtNum(stats.link_count)}</div>
+          <div className="stats-metric-label">Links</div>
+        </div>
+        <div className="stats-metric-cell">
+          <div className="stats-metric-num">{fmtNum(stats.image_count)}</div>
+          <div className="stats-metric-label">Images</div>
+        </div>
+      </div>
+
+      {/* Row 1: Tags + Most Linked */}
+      <div className="stats-two-col" style={{ marginBottom: "2rem" }}>
+        <div className="stats-section">
+          <SectionHead num="01" title="Top Tags" />
+          <TagBars tags={stats.top_tags} />
+        </div>
+        <div className="stats-section">
+          <SectionHead num="02" title="Most Linked Notes" />
+          <RankedList notes={stats.most_linked} />
+        </div>
+      </div>
+
+      {/* Row 2: Writing Activity */}
+      <div className="stats-section" style={{ marginBottom: "2rem" }}>
+        <SectionHead num="03" title="Writing Activity — last 6 months" />
+        <ActivityChart months={stats.activity_by_month} />
+      </div>
+
+      {/* Row 3: Folders + Word extremes */}
+      <div className="stats-two-col" style={{ marginBottom: "2rem" }}>
+        <div className="stats-section">
+          <SectionHead num="04" title="Notes per Folder" />
+          <FolderList folders={stats.notes_per_folder} />
+        </div>
+        <div className="stats-section">
+          <SectionHead num="05" title="Word Count Extremes" />
+          <NoteWordList notes={stats.longest_notes} sublabel="Longest" />
+          <NoteWordList notes={stats.shortest_notes} sublabel="Shortest" />
+        </div>
+      </div>
+
+      {/* Row 4: Link Balance + Averages + Modified this week */}
+      <div className="stats-three-col" style={{ marginBottom: "2rem" }}>
+        <div className="stats-section">
+          <SectionHead num="06" title="Link Balance" />
+          <div className="stats-twin">
+            <div className="stats-twin-cell">
+              <div className="stats-twin-num">
+                {fmtNum(stats.total_outgoing_links)}
+              </div>
+              <div className="stats-twin-lbl">Outgoing</div>
+            </div>
+            <div className="stats-twin-cell">
+              <div className="stats-twin-num">
+                {fmtNum(stats.total_backlinks)}
+              </div>
+              <div className="stats-twin-lbl">Backlinks</div>
+            </div>
+          </div>
+        </div>
+        <div className="stats-section">
+          <SectionHead num="07" title="Averages" />
+          <div className="stats-single">
+            <div className="stats-single-num">
+              {fmtNum(stats.avg_word_count)}
+            </div>
+            <div className="stats-single-lbl">Avg words / note</div>
+          </div>
+          <div className="stats-single">
+            <div className="stats-single-num">
+              {fmtBytes(stats.vault_size_bytes)}
+            </div>
+            <div className="stats-single-lbl">Vault size on disk</div>
+          </div>
+        </div>
+        <div className="stats-section">
+          <SectionHead num="08" title="Modified This Week" />
+          <div className="stats-big-count">
+            {stats.modified_this_week.count}
+          </div>
+          <div className="stats-big-count-lbl">notes</div>
+          <RecentList notes={stats.modified_this_week.notes.slice(0, 5)} />
+        </div>
+      </div>
+
+      {/* Row 5: Orphans + No Tags */}
+      <div className="stats-two-col">
+        <div className="stats-section">
+          <SectionHead num="09" title="Orphan Notes" />
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.66rem",
+              color: "var(--muted)",
+              marginBottom: "0.65rem",
+              lineHeight: "1.5",
+            }}
+          >
+            No incoming or outgoing links.
+          </p>
+          <PillList notes={stats.orphan_notes} />
+        </div>
+        <div className="stats-section">
+          <SectionHead num="10" title="Notes with No Tags" />
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.66rem",
+              color: "var(--muted)",
+              marginBottom: "0.65rem",
+              lineHeight: "1.5",
+            }}
+          >
+            Missing all tags.
+          </p>
+          <PillList notes={stats.no_tag_notes} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/graph.css
+++ b/frontend/src/styles/graph.css
@@ -11,6 +11,7 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
 }
 
 /* ── HEADER ─────────────────────────────────────────────────── */
@@ -204,13 +205,176 @@
   color: var(--muted);
 }
 
+/* ── FILTER TOGGLE (hidden on desktop) ───────────────────────── */
+.graph-filter-toggle {
+  display: none;
+}
+
+/* ── MOBILE TAG OVERLAY (hidden on desktop) ──────────────────── */
+.graph-tags-mobile {
+  display: none;
+}
+
+.graph-filter-backdrop {
+  display: none;
+}
+
 /* ── RESPONSIVE ──────────────────────────────────────────────── */
 @media (max-width: 700px) {
+  /* Slim single-row HUD bar */
   .graph-header {
-    padding: 1rem 1rem 0.65rem;
+    padding: 0 0.75rem;
+    height: 44px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .graph-eyebrow {
+    display: none;
+  }
+
+  .graph-header-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 0;
+  }
+
+  .graph-title {
+    font-size: 1.15rem;
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
+  }
+
+  .graph-meta-strip {
+    flex: 1;
+    gap: 0.4rem;
+  }
+
+  .graph-meta-num {
+    font-size: 0.88rem;
+  }
+
+  .graph-meta-lbl {
+    font-size: 0.52rem;
   }
 
   .graph-hint {
     display: none;
+  }
+
+  /* Hide inline desktop tag block */
+  .graph-tags-desktop {
+    display: none;
+  }
+
+  /* Filter toggle button */
+  .graph-filter-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.55rem;
+    border: 1px solid var(--rule);
+    background: var(--bg);
+    color: var(--muted);
+    cursor: pointer;
+    transition:
+      border-color 120ms ease,
+      color 120ms ease,
+      background 120ms ease;
+  }
+
+  .graph-filter-toggle.has-active {
+    border-color: var(--hot);
+    color: var(--hot);
+  }
+
+  .graph-filter-toggle.is-open {
+    background: var(--paper-2);
+    color: var(--ink);
+    border-color: var(--rule-strong);
+  }
+
+  .graph-filter-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1em;
+    height: 1.1em;
+    background: var(--hot);
+    color: var(--bg);
+    border-radius: 2px;
+    font-size: 0.7em;
+    font-weight: 700;
+    padding: 0 0.2em;
+    margin-left: 0.25em;
+    vertical-align: middle;
+  }
+
+  .graph-filter-caret {
+    font-size: 0.75rem;
+    transition: transform 180ms ease;
+    line-height: 1;
+  }
+
+  .graph-filter-toggle.is-open .graph-filter-caret {
+    transform: rotate(180deg);
+  }
+
+  /* Backdrop — tapping outside closes the panel */
+  .graph-filter-backdrop {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 9;
+    background: transparent;
+    border: none;
+    cursor: default;
+  }
+
+  /* Mobile tag overlay — slides down over canvas, never pushes it */
+  .graph-tags-mobile {
+    display: block;
+    position: absolute;
+    top: 44px; /* header height */
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background: var(--paper);
+    border-bottom: 1px solid var(--rule);
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 220ms cubic-bezier(0.4, 0, 0.2, 1);
+    /* suppress inner filter which is always "open" inside the mobile container */
+  }
+
+  /* When the backdrop is present (filterOpen=true), expand the panel */
+  .graph-tags-mobile:has(~ .graph-canvas-wrap) {
+    /* fallback — open state driven by aria-hidden=false */
+  }
+
+  .graph-tags-mobile[aria-hidden="false"] {
+    max-height: 45vh;
+    overflow-y: auto;
+  }
+
+  /* Force inner tag-filter always visible inside the mobile overlay */
+  .graph-tags-mobile .graph-tag-filter {
+    display: flex !important;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    padding: 0.7rem 0.75rem;
+    margin-bottom: 0;
+  }
+
+  .graph-tag-chip {
+    font-size: 0.7rem;
+    padding: 0.18rem 0.55rem;
   }
 }

--- a/frontend/src/styles/graph.css
+++ b/frontend/src/styles/graph.css
@@ -1,0 +1,201 @@
+/* ── GRAPH PAGE ──────────────────────────────────────────────── */
+
+/* Strip note-pane padding so the graph fills the full content area */
+.note-pane.graph-host {
+  padding: 0;
+  overflow: hidden;
+}
+
+.graph-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── HEADER ─────────────────────────────────────────────────── */
+.graph-header {
+  flex-shrink: 0;
+  padding: 1.4rem 1.6rem 0.85rem;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+}
+
+.graph-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--hot);
+  margin: 0 0 0.3rem;
+}
+
+.graph-header-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1.4rem;
+  margin-bottom: 0.7rem;
+}
+
+.graph-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 85, "wght" 700;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 0.96;
+  margin: 0;
+}
+
+/* ── META STRIP ─────────────────────────────────────────────── */
+.graph-meta-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.graph-meta-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.graph-meta-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 80, "wght" 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+}
+
+.graph-meta-lbl {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.graph-meta-sep {
+  width: 1px;
+  height: 0.9rem;
+  background: var(--rule-strong);
+  flex-shrink: 0;
+}
+
+/* ── TAG FILTER ─────────────────────────────────────────────── */
+.graph-tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.65rem;
+}
+
+.graph-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition:
+    background var(--dur) var(--ease),
+    color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+  white-space: nowrap;
+}
+
+.graph-tag-chip:hover {
+  background: var(--paper-2);
+  color: var(--ink);
+  border-color: var(--rule-strong);
+}
+
+.graph-tag-chip.active {
+  background: hsl(calc(var(--chip-hue, 0) * 1deg), 60%, 58%, 0.12);
+  border-color: hsl(calc(var(--chip-hue, 0) * 1deg), 60%, 58%, 0.5);
+  color: var(--ink);
+}
+
+.graph-tag-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── HINT ────────────────────────────────────────────────────── */
+.graph-hint {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--tertiary);
+  margin: 0;
+}
+
+/* ── CANVAS WRAP ─────────────────────────────────────────────── */
+.graph-canvas-wrap {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.graph-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.graph-canvas:active {
+  cursor: grabbing;
+}
+
+/* ── LOADING ─────────────────────────────────────────────────── */
+.graph-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 1.2rem;
+  padding: 3rem;
+}
+
+.graph-loading-pulse {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--hot);
+  opacity: 0.2;
+  animation: graph-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes graph-pulse {
+  0%, 100% { transform: scale(0.6); opacity: 0.15; }
+  50% { transform: scale(1.2); opacity: 0.35; }
+}
+
+.graph-loading-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ── RESPONSIVE ──────────────────────────────────────────────── */
+@media (max-width: 700px) {
+  .graph-header {
+    padding: 1rem 1rem 0.65rem;
+  }
+
+  .graph-hint {
+    display: none;
+  }
+}

--- a/frontend/src/styles/graph.css
+++ b/frontend/src/styles/graph.css
@@ -156,6 +156,21 @@
   cursor: grabbing;
 }
 
+/* ── OVERLAY (loading / error shown on top of canvas) ────────── */
+.graph-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 3rem;
+  background: var(--bg);
+  pointer-events: none;
+  z-index: 2;
+}
+
 /* ── LOADING ─────────────────────────────────────────────────── */
 .graph-loading {
   display: flex;

--- a/frontend/src/styles/layout-explorer.css
+++ b/frontend/src/styles/layout-explorer.css
@@ -2,8 +2,9 @@
   --sidebar-width: 280px;
   display: grid;
   grid-template-columns: var(--sidebar-width) 8px minmax(0, 1fr);
-  min-height: calc(100dvh - 3px - 52px - env(safe-area-inset-top));
+  height: calc(100dvh - 3px - 52px - env(safe-area-inset-top));
   min-width: 0;
+  overflow: hidden;
 }
 
 /* Sidebar / Explorer pane */

--- a/frontend/src/styles/note-content.css
+++ b/frontend/src/styles/note-content.css
@@ -191,7 +191,7 @@
   margin-bottom: 0.18rem;
 }
 
-.note-body ul li::before {
+.note-body ul > li::before {
   content: "";
   position: absolute;
   left: 0;
@@ -201,12 +201,12 @@
   background: var(--hot);
 }
 
-.note-body ul ul li::before {
+.note-body ul ul > li::before {
   width: 0.42rem;
   background: var(--muted);
 }
 
-.note-body ul ul ul li::before {
+.note-body ul ul ul > li::before {
   width: 4px;
   height: 4px;
   border-radius: 50%;
@@ -215,16 +215,16 @@
 }
 
 /* Task list items — suppress dash bullet, show checkbox instead */
-.note-body ul li.task-list-item {
+.note-body ul > li.task-list-item {
   padding-left: 0;
   list-style: none;
 }
 
-.note-body ul li.task-list-item::before {
+.note-body ul > li.task-list-item::before {
   display: none;
 }
 
-.note-body ul li.task-list-item input[type="checkbox"] {
+.note-body ul > li.task-list-item input[type="checkbox"] {
   margin-right: 0.45rem;
   accent-color: var(--hot);
   width: 0.9em;
@@ -238,11 +238,13 @@
   counter-reset: olc;
 }
 
-.note-body ol li {
+/* Use > so only direct ol children get the counter — prevents ul sub-items
+   inside an ol from being counted and styled as ordered list items. */
+.note-body ol > li {
   counter-increment: olc;
 }
 
-.note-body ol li::before {
+.note-body ol > li::before {
   content: counter(olc) ".";
   position: absolute;
   left: 0;
@@ -253,13 +255,31 @@
   font-weight: 600;
 }
 
-.note-body ol ol li::before {
+.note-body ol ol > li::before {
   content: counter(olc, lower-alpha) ".";
 }
 
-.note-body ol ol ol li::before {
+.note-body ol ol ol > li::before {
   content: counter(olc, lower-roman) ".";
   color: var(--muted);
+}
+
+/* ul items nested inside an ol must show a bullet, not the ol counter */
+.note-body ol ul > li::before {
+  content: "";
+  top: 0.72em;
+  width: 0.7rem;
+  height: 1px;
+  background: var(--hot);
+  font-family: unset;
+  font-size: unset;
+  color: unset;
+  font-weight: unset;
+}
+
+.note-body ol ul ul > li::before {
+  width: 0.42rem;
+  background: var(--muted);
 }
 
 /* Blockquote */

--- a/frontend/src/styles/note-content.css
+++ b/frontend/src/styles/note-content.css
@@ -6,6 +6,7 @@
   box-sizing: border-box;
   min-width: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Two-col layout: body + TOC

--- a/frontend/src/styles/note-content.css
+++ b/frontend/src/styles/note-content.css
@@ -5,6 +5,7 @@
   max-width: 100%;
   box-sizing: border-box;
   min-width: 0;
+  overflow-y: auto;
 }
 
 /* Two-col layout: body + TOC

--- a/frontend/src/styles/stats.css
+++ b/frontend/src/styles/stats.css
@@ -1,0 +1,568 @@
+/* ── STATS PAGE ─────────────────────────────────────────────── */
+.stats-page {
+  max-width: 900px;
+}
+
+.stats-page-header {
+  margin-bottom: 1.8rem;
+}
+
+.stats-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--hot);
+  margin-bottom: 0.35rem;
+}
+
+.stats-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 85, "wght" 700;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 0.96;
+  margin: 0;
+}
+
+.stats-subtitle {
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  color: var(--muted);
+  margin-top: 0.45rem;
+  line-height: 1.5;
+}
+
+/* ── METRIC STRIP ──────────────────────────────────────────── */
+.stats-metric-strip {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border: 1px solid var(--rule-strong);
+  margin-bottom: 2.5rem;
+}
+
+.stats-metric-cell {
+  padding: 1rem 1rem 0.85rem;
+  border-right: 1px solid var(--rule);
+  position: relative;
+}
+
+.stats-metric-cell:last-child {
+  border-right: none;
+}
+
+.stats-metric-cell::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--rule);
+}
+
+.stats-metric-cell:first-child::before {
+  background: var(--hot);
+}
+
+.stats-metric-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 80, "wght" 700;
+  font-size: 1.9rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  margin-bottom: 0.28rem;
+}
+
+.stats-metric-cell:first-child .stats-metric-num {
+  color: var(--hot);
+}
+
+.stats-metric-label {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ── SECTION BLOCK ─────────────────────────────────────────── */
+.stats-section {
+  border-top: 1px solid var(--rule);
+  padding-top: 1rem;
+}
+
+.stats-section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.85rem;
+}
+
+.stats-section-num {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  color: var(--hot);
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+}
+
+.stats-section-title {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 90, "wght" 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink);
+}
+
+/* ── TWO / THREE COL GRIDS ─────────────────────────────────── */
+.stats-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.stats-three-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2rem;
+}
+
+/* ── BAR LIST (tags) ────────────────────────────────────────── */
+.stats-bar-list {
+  display: grid;
+  gap: 0;
+}
+
+.stats-bar-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr 2.4rem;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.26rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.stats-bar-row:last-child {
+  border-bottom: none;
+}
+
+.stats-bar-label {
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-bar-track {
+  height: 6px;
+  background: var(--paper-2);
+  position: relative;
+}
+
+.stats-bar-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--hot);
+}
+
+.stats-bar-count {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted);
+  text-align: right;
+}
+
+/* ── RANKED LIST (most linked) ──────────────────────────────── */
+.stats-ranked-list {
+  display: grid;
+  gap: 0;
+}
+
+.stats-ranked-row {
+  display: grid;
+  grid-template-columns: 1.4rem 1fr auto;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.28rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.stats-ranked-row:last-child {
+  border-bottom: none;
+}
+
+.stats-ranked-rank {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  color: var(--tertiary);
+  text-align: right;
+}
+
+.stats-ranked-title {
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  color: var(--hot);
+  text-decoration: none;
+}
+
+.stats-ranked-title:hover {
+  color: var(--ink);
+}
+
+.stats-ranked-meta {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* ── ACTIVITY CHART ─────────────────────────────────────────── */
+.stats-activity {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  height: 88px;
+  padding-bottom: 1.5rem;
+  position: relative;
+  margin-bottom: 0.5rem;
+}
+
+.stats-activity::after {
+  content: "";
+  position: absolute;
+  bottom: 1.4rem;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--rule);
+}
+
+.stats-act-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.stats-act-bar {
+  width: 100%;
+  background: var(--hot);
+  min-height: 2px;
+}
+
+.stats-act-month {
+  font-family: var(--font-mono);
+  font-size: 0.57rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  position: absolute;
+  bottom: 0;
+  transform: translateY(1.3rem);
+}
+
+.stats-activity-meta {
+  display: flex;
+  gap: 1.5rem;
+  padding-top: 0.3rem;
+}
+
+.stats-activity-meta span {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+
+/* ── FOLDER LIST ────────────────────────────────────────────── */
+.stats-folder-list {
+  display: grid;
+  gap: 0;
+}
+
+.stats-folder-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 0.26rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.stats-folder-row:last-child {
+  border-bottom: none;
+}
+
+.stats-folder-name {
+  font-family: var(--font-sans);
+  font-size: 0.83rem;
+  color: var(--ink-soft);
+}
+
+.stats-folder-slash {
+  color: var(--tertiary);
+}
+
+.stats-folder-count {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+/* ── NOTE LIST ──────────────────────────────────────────────── */
+.stats-note-list {
+  display: grid;
+  gap: 0;
+}
+
+.stats-note-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.26rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.stats-note-row:last-child {
+  border-bottom: none;
+}
+
+.stats-note-title {
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  color: var(--hot);
+  text-decoration: none;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stats-note-title:hover {
+  color: var(--ink);
+}
+
+.stats-note-meta {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── SUBLABEL ────────────────────────────────────────────────── */
+.stats-sublabel {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.45rem;
+}
+
+.stats-sublabel.hot {
+  color: var(--hot);
+}
+
+/* ── PILL LIST (orphans / untagged) ─────────────────────────── */
+.stats-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.stats-pill {
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  color: var(--hot);
+  border: 1px solid var(--rule);
+  background: var(--paper);
+  padding: 0.16rem 0.55rem;
+  text-decoration: none;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+
+.stats-pill:hover {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+/* ── TWIN COUNTER ────────────────────────────────────────────── */
+.stats-twin {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+
+.stats-twin-cell {
+  background: var(--paper);
+  padding: 0.8rem 0.9rem;
+}
+
+.stats-twin-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 1.45rem;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: 0.2rem;
+}
+
+.stats-twin-lbl {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ── SINGLES ─────────────────────────────────────────────────── */
+.stats-single {
+  padding: 0.6rem 0;
+}
+
+.stats-single + .stats-single {
+  border-top: 1px solid var(--rule);
+}
+
+.stats-single-num {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--ink);
+  margin-bottom: 0.2rem;
+}
+
+.stats-single-lbl {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ── BIG COUNT ────────────────────────────────────────────────── */
+.stats-big-count {
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 82, "wght" 700;
+  font-size: 1.9rem;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--ink);
+  margin-bottom: 0.2rem;
+}
+
+.stats-big-count-lbl {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.7rem;
+}
+
+/* ── LOADING / ERROR ─────────────────────────────────────────── */
+.stats-loading {
+  display: grid;
+  gap: 1.2rem;
+  max-width: 900px;
+}
+
+.stats-loading-strip {
+  height: 4.5rem;
+  background: linear-gradient(90deg, var(--paper-2), var(--paper), var(--paper-2));
+  background-size: 200% 100%;
+  animation: shimmer 1.2s linear infinite;
+}
+
+.stats-loading-block {
+  height: 12rem;
+  background: linear-gradient(90deg, var(--paper-2), var(--paper), var(--paper-2));
+  background-size: 200% 100%;
+  animation: shimmer 1.2s linear infinite;
+}
+
+/* ── EXPLORER NAV LINKS ──────────────────────────────────────── */
+.explorer-page-links {
+  display: flex;
+  gap: 0.35rem;
+  margin-bottom: 1.1rem;
+}
+
+.explorer-page-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--font-display);
+  font-variation-settings: "wdth" 92, "wght" 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.38rem 0.7rem;
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  color: var(--ink-soft);
+  text-decoration: none;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+}
+
+.explorer-page-link:hover {
+  background: var(--paper-2);
+  color: var(--ink);
+  border-color: var(--rule-strong);
+}
+
+.explorer-page-link.active {
+  background: var(--hot-soft);
+  color: var(--ink);
+  border-color: var(--rule-strong);
+  box-shadow: inset 3px 0 0 var(--hot);
+}
+
+/* ── EXPLORER NOTES LABEL ────────────────────────────────────── */
+.explorer-notes-label {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--hot);
+  font-weight: 500;
+  margin: 0 0 0.45rem 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.explorer-notes-count {
+  color: var(--muted);
+}
+
+/* ── RESPONSIVE ──────────────────────────────────────────────── */
+@media (max-width: 700px) {
+  .stats-metric-strip {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .stats-metric-cell:nth-child(3) {
+    border-right: none;
+  }
+  .stats-metric-cell:nth-child(4) {
+    border-top: 1px solid var(--rule);
+  }
+  .stats-two-col,
+  .stats-three-col {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/styles/stats.css
+++ b/frontend/src/styles/stats.css
@@ -250,6 +250,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-end;
   position: relative;
 }
 
@@ -257,6 +258,15 @@
   width: 100%;
   background: var(--hot);
   min-height: 2px;
+}
+
+.stats-act-count {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--hot);
+  font-weight: 600;
+  line-height: 1;
+  margin-bottom: 0.2rem;
 }
 
 .stats-act-month {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -84,6 +84,36 @@ export type SearchResponse = {
   results: SearchResult[];
 };
 
+export type TagStat = { tag: string; note_count: number };
+export type NoteRef = { title: string; slug: string };
+export type NoteWordRef = NoteRef & { word_count: number };
+export type LinkedNoteRef = NoteRef & { backlink_count: number };
+export type MonthActivity = { month: string; modified_count: number };
+export type FolderStat = { folder: string; note_count: number };
+export type NoteList = { count: number; notes: NoteRef[] };
+
+export type VaultStats = {
+  note_count: number;
+  word_count: number;
+  tag_count: number;
+  link_count: number;
+  image_count: number;
+  avg_word_count: number;
+  vault_size_bytes: number;
+  total_outgoing_links: number;
+  total_backlinks: number;
+  top_tags: TagStat[];
+  most_linked: LinkedNoteRef[];
+  activity_by_month: MonthActivity[];
+  notes_per_folder: FolderStat[];
+  longest_notes: NoteWordRef[];
+  shortest_notes: NoteWordRef[];
+  orphan_notes: NoteRef[];
+  no_tag_notes: NoteRef[];
+  modified_this_week: NoteList;
+  modified_this_month: NoteList;
+};
+
 export type MermaidApi = {
   initialize: (config: {
     startOnLoad: boolean;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -114,6 +114,10 @@ export type VaultStats = {
   modified_this_month: NoteList;
 };
 
+export type GraphNode = { slug: string; title: string; primary_tag: string | null; backlink_count: number };
+export type GraphEdge = { source: string; target: string };
+export type GraphData = { nodes: GraphNode[]; edges: GraphEdge[] };
+
 export type MermaidApi = {
   initialize: (config: {
     startOnLoad: boolean;

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -3,6 +3,93 @@ use serde::{Deserialize, Serialize};
 use crate::vault::{ModifiedNote, Note, NoteLinks, SearchHit};
 
 #[derive(Debug, Serialize)]
+pub struct TagStat {
+    pub tag: String,
+    pub note_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NoteRef {
+    pub title: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NoteWordRef {
+    pub title: String,
+    pub slug: String,
+    pub word_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LinkedNoteRef {
+    pub title: String,
+    pub slug: String,
+    pub backlink_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MonthActivity {
+    pub month: String,
+    pub modified_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FolderStat {
+    pub folder: String,
+    pub note_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NoteList {
+    pub count: i64,
+    pub notes: Vec<NoteRef>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VaultStatsResponse {
+    pub note_count: i64,
+    pub word_count: usize,
+    pub tag_count: i64,
+    pub link_count: i64,
+    pub image_count: usize,
+    pub avg_word_count: usize,
+    pub vault_size_bytes: i64,
+    pub total_outgoing_links: i64,
+    pub total_backlinks: i64,
+    pub top_tags: Vec<TagStat>,
+    pub most_linked: Vec<LinkedNoteRef>,
+    pub activity_by_month: Vec<MonthActivity>,
+    pub notes_per_folder: Vec<FolderStat>,
+    pub longest_notes: Vec<NoteWordRef>,
+    pub shortest_notes: Vec<NoteWordRef>,
+    pub orphan_notes: Vec<NoteRef>,
+    pub no_tag_notes: Vec<NoteRef>,
+    pub modified_this_week: NoteList,
+    pub modified_this_month: NoteList,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphNode {
+    pub slug: String,
+    pub title: String,
+    pub primary_tag: Option<String>,
+    pub backlink_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphEdge {
+    pub source: String,
+    pub target: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GraphResponse {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ErrorResponse {
     pub error: String,
 }

--- a/src/cache/parse.rs
+++ b/src/cache/parse.rs
@@ -88,30 +88,79 @@ pub fn extract_headings(content: &str) -> Vec<HeadingRow> {
 }
 
 pub fn extract_tags(content: &str) -> HashSet<String> {
-    content
-        .split_whitespace()
-        .filter_map(|token| {
-            let token = token.trim_matches(|ch: char| {
-                matches!(
-                    ch,
-                    ',' | '.' | ';' | ':' | '!' | '?' | ')' | '(' | '[' | ']' | '{' | '}'
-                )
-            });
-            let tag = token.strip_prefix('#')?;
-            if tag.is_empty() || tag.starts_with('#') || tag.chars().all(|ch| ch == '-') {
-                return None;
+    let mut tags = HashSet::new();
+    let (frontmatter, body) = split_frontmatter(content);
+    extract_frontmatter_tags(frontmatter, &mut tags);
+    extract_inline_tags(body, &mut tags);
+    tags
+}
+
+fn split_frontmatter(content: &str) -> (&str, &str) {
+    let lines: Vec<&str> = content.splitn(3, '\n').collect();
+    if lines.len() < 2 || lines[0].trim() != "---" {
+        return ("", content);
+    }
+    let rest = &content[lines[0].len() + 1..];
+    if let Some(end) = rest.find("\n---") {
+        let fm_end = lines[0].len() + 1 + end;
+        let body_start = fm_end + 4; // skip "\n---"
+        let body = if body_start < content.len() { &content[body_start..] } else { "" };
+        (&content[lines[0].len() + 1..fm_end], body)
+    } else {
+        ("", content)
+    }
+}
+
+fn extract_frontmatter_tags(frontmatter: &str, tags: &mut HashSet<String>) {
+    // Find a line starting with "tags:"
+    let mut in_tags = false;
+    for line in frontmatter.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("tags:") {
+            in_tags = true;
+            // Inline array form: tags: [a, b, c]
+            let rest = rest.trim();
+            if rest.starts_with('[') {
+                let inner = rest.trim_matches(|c| c == '[' || c == ']');
+                for item in inner.split(',') {
+                    push_tag(item.trim().trim_matches('"').trim_matches('\''), tags);
+                }
+                in_tags = false; // inline array is self-contained
             }
-            let cleaned = tag
-                .chars()
-                .take_while(|ch| ch.is_alphanumeric() || matches!(ch, '-' | '_' | '/'))
-                .collect::<String>();
-            if cleaned.is_empty() {
-                None
-            } else {
-                Some(cleaned.to_lowercase())
+            // else: block sequence follows on subsequent lines
+        } else if in_tags {
+            // Block sequence item: "  - tagname"
+            if let Some(item) = trimmed.strip_prefix("- ") {
+                push_tag(item.trim().trim_matches('"').trim_matches('\''), tags);
+            } else if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                // Hit a non-list line — tags block is over
+                in_tags = false;
             }
-        })
-        .collect()
+        }
+    }
+}
+
+fn push_tag(raw: &str, tags: &mut HashSet<String>) {
+    let cleaned: String = raw
+        .chars()
+        .take_while(|ch| ch.is_alphanumeric() || matches!(ch, '-' | '_' | '/'))
+        .collect();
+    if !cleaned.is_empty() {
+        tags.insert(cleaned.to_lowercase());
+    }
+}
+
+fn extract_inline_tags(body: &str, tags: &mut HashSet<String>) {
+    for token in body.split_whitespace() {
+        let token = token.trim_matches(|ch: char| {
+            matches!(ch, ',' | '.' | ';' | ':' | '!' | '?' | ')' | '(' | '[' | ']' | '{' | '}')
+        });
+        let Some(tag) = token.strip_prefix('#') else { continue };
+        if tag.is_empty() || tag.starts_with('#') || tag.chars().all(|ch| ch == '-') {
+            continue;
+        }
+        push_tag(tag, tags);
+    }
 }
 
 pub fn build_fts_query(input: &str) -> Option<String> {
@@ -152,6 +201,31 @@ mod tests {
             build_fts_query("réseau dns"),
             Some("\"réseau\" OR \"dns\"".to_string())
         );
+    }
+
+    #[test]
+    fn extracts_frontmatter_tags_inline_array() {
+        let content = "---\ntags: [type/reference, topic/api, topic/foo-bar]\ncreated: 2026-01-01\n---\n\nBody text.";
+        let tags = extract_tags(content);
+        assert!(tags.contains("type/reference"), "missing type/reference");
+        assert!(tags.contains("topic/api"), "missing topic/api");
+        assert!(tags.contains("topic/foo-bar"), "missing topic/foo-bar");
+    }
+
+    #[test]
+    fn extracts_frontmatter_tags_block_sequence() {
+        let content = "---\ntags:\n  - programming\n  - philosophy\ncreated: 2026-01-01\n---\n\nBody text.";
+        let tags = extract_tags(content);
+        assert!(tags.contains("programming"), "missing programming");
+        assert!(tags.contains("philosophy"), "missing philosophy");
+    }
+
+    #[test]
+    fn inline_hashtags_still_work_in_body() {
+        let content = "---\ntags: [existing]\n---\n\nSome text with #inline-tag here.";
+        let tags = extract_tags(content);
+        assert!(tags.contains("existing"));
+        assert!(tags.contains("inline-tag"));
     }
 
     #[test]

--- a/src/cache/queries.rs
+++ b/src/cache/queries.rs
@@ -508,6 +508,344 @@ impl FolderBuilder {
     }
 }
 
+impl SqliteCache {
+    pub fn vault_stats(&self) -> Result<crate::api_types::VaultStatsResponse, String> {
+        use crate::api_types::{
+            FolderStat, LinkedNoteRef, MonthActivity, NoteList, NoteRef, NoteWordRef, TagStat,
+            VaultStatsResponse,
+        };
+
+        let conn = self.connection()?;
+
+        let note_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM notes", [], |row| row.get(0))
+            .map_err(|e| format!("vault_stats note_count: {e}"))?;
+
+        let tag_count: i64 = conn
+            .query_row("SELECT COUNT(DISTINCT tag) FROM tags", [], |row| row.get(0))
+            .map_err(|e| format!("vault_stats tag_count: {e}"))?;
+
+        let link_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM note_links", [], |row| row.get(0))
+            .map_err(|e| format!("vault_stats link_count: {e}"))?;
+
+        let vault_size_bytes: i64 = conn
+            .query_row("SELECT COALESCE(SUM(size_bytes), 0) FROM notes", [], |row| row.get(0))
+            .map_err(|e| format!("vault_stats vault_size_bytes: {e}"))?;
+
+        // Fetch all content for word/image count and word-rank computations.
+        struct ContentRow {
+            slug: String,
+            title: String,
+            content: String,
+        }
+        let mut content_stmt = conn
+            .prepare("SELECT slug, title, content FROM notes ORDER BY relative_path")
+            .map_err(|e| format!("vault_stats prepare content: {e}"))?;
+        let content_rows: Vec<ContentRow> = content_stmt
+            .query_map([], |row| {
+                Ok(ContentRow {
+                    slug: row.get(0)?,
+                    title: row.get(1)?,
+                    content: row.get(2)?,
+                })
+            })
+            .map_err(|e| format!("vault_stats query content: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read content: {e}"))?;
+        drop(content_stmt);
+
+        let mut total_word_count: usize = 0;
+        let mut total_image_count: usize = 0;
+        let mut word_counts: Vec<(String, String, usize)> = Vec::with_capacity(content_rows.len());
+        for row in &content_rows {
+            let wc = word_count_for_content(&row.content);
+            total_word_count += wc;
+            total_image_count += row.content.matches("![").count();
+            word_counts.push((row.slug.clone(), row.title.clone(), wc));
+        }
+
+        let avg_word_count = if note_count > 0 {
+            total_word_count / note_count as usize
+        } else {
+            0
+        };
+
+        word_counts.sort_by(|a, b| b.2.cmp(&a.2).then(a.0.cmp(&b.0)));
+        let longest_notes: Vec<NoteWordRef> = word_counts
+            .iter()
+            .take(5)
+            .map(|(slug, title, wc)| NoteWordRef {
+                title: title.clone(),
+                slug: slug.clone(),
+                word_count: *wc,
+            })
+            .collect();
+
+        word_counts.sort_by(|a, b| a.2.cmp(&b.2).then(a.0.cmp(&b.0)));
+        let shortest_notes: Vec<NoteWordRef> = word_counts
+            .iter()
+            .filter(|(_, _, wc)| *wc > 0)
+            .take(5)
+            .map(|(slug, title, wc)| NoteWordRef {
+                title: title.clone(),
+                slug: slug.clone(),
+                word_count: *wc,
+            })
+            .collect();
+
+        let mut tags_stmt = conn
+            .prepare(
+                "SELECT tag, COUNT(*) as note_count FROM tags GROUP BY tag \
+                 ORDER BY note_count DESC, tag LIMIT 20",
+            )
+            .map_err(|e| format!("vault_stats prepare top_tags: {e}"))?;
+        let top_tags: Vec<TagStat> = tags_stmt
+            .query_map([], |row| Ok(TagStat { tag: row.get(0)?, note_count: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query top_tags: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read top_tags: {e}"))?;
+        drop(tags_stmt);
+
+        let mut linked_stmt = conn
+            .prepare(
+                r#"
+                SELECT n.title, n.slug, COUNT(l.source_slug) as backlink_count
+                FROM notes n
+                LEFT JOIN note_links l ON l.target_slug = n.slug
+                GROUP BY n.slug
+                HAVING backlink_count > 0
+                ORDER BY backlink_count DESC, n.title
+                LIMIT 20
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare most_linked: {e}"))?;
+        let most_linked: Vec<LinkedNoteRef> = linked_stmt
+            .query_map([], |row| {
+                Ok(LinkedNoteRef {
+                    title: row.get(0)?,
+                    slug: row.get(1)?,
+                    backlink_count: row.get(2)?,
+                })
+            })
+            .map_err(|e| format!("vault_stats query most_linked: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read most_linked: {e}"))?;
+        drop(linked_stmt);
+
+        let mut activity_stmt = conn
+            .prepare(
+                r#"
+                SELECT strftime('%Y-%m', mtime_ns / 1000000000, 'unixepoch') as month,
+                       COUNT(*) as modified_count
+                FROM notes
+                GROUP BY month
+                ORDER BY month DESC
+                LIMIT 6
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare activity_by_month: {e}"))?;
+        let activity_by_month: Vec<MonthActivity> = activity_stmt
+            .query_map([], |row| Ok(MonthActivity { month: row.get(0)?, modified_count: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query activity_by_month: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read activity_by_month: {e}"))?;
+        drop(activity_stmt);
+
+        let mut folder_stmt = conn
+            .prepare(
+                r#"
+                SELECT
+                  CASE WHEN instr(relative_path, '/') > 0
+                    THEN substr(relative_path, 1, instr(relative_path, '/') - 1)
+                    ELSE ''
+                  END as folder,
+                  COUNT(*) as note_count
+                FROM notes
+                GROUP BY folder
+                ORDER BY note_count DESC, folder
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare notes_per_folder: {e}"))?;
+        let notes_per_folder: Vec<FolderStat> = folder_stmt
+            .query_map([], |row| Ok(FolderStat { folder: row.get(0)?, note_count: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query notes_per_folder: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read notes_per_folder: {e}"))?;
+        drop(folder_stmt);
+
+        let mut orphan_stmt = conn
+            .prepare(
+                r#"
+                SELECT title, slug FROM notes
+                WHERE slug NOT IN (SELECT DISTINCT source_slug FROM note_links)
+                  AND slug NOT IN (SELECT DISTINCT target_slug FROM note_links)
+                ORDER BY title
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare orphan_notes: {e}"))?;
+        let orphan_notes: Vec<NoteRef> = orphan_stmt
+            .query_map([], |row| Ok(NoteRef { title: row.get(0)?, slug: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query orphan_notes: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read orphan_notes: {e}"))?;
+        drop(orphan_stmt);
+
+        let mut no_tag_stmt = conn
+            .prepare(
+                r#"
+                SELECT title, slug FROM notes
+                WHERE slug NOT IN (SELECT DISTINCT note_slug FROM tags)
+                ORDER BY title
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare no_tag_notes: {e}"))?;
+        let no_tag_notes: Vec<NoteRef> = no_tag_stmt
+            .query_map([], |row| Ok(NoteRef { title: row.get(0)?, slug: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query no_tag_notes: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read no_tag_notes: {e}"))?;
+        drop(no_tag_stmt);
+
+        let week_total: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes \
+                 WHERE mtime_ns >= (unixepoch('now') - 7 * 86400) * 1000000000",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("vault_stats week_count: {e}"))?;
+        let mut week_stmt = conn
+            .prepare(
+                r#"
+                SELECT title, slug FROM notes
+                WHERE mtime_ns >= (unixepoch('now') - 7 * 86400) * 1000000000
+                ORDER BY mtime_ns DESC
+                LIMIT 20
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare modified_this_week: {e}"))?;
+        let week_notes: Vec<NoteRef> = week_stmt
+            .query_map([], |row| Ok(NoteRef { title: row.get(0)?, slug: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query modified_this_week: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read modified_this_week: {e}"))?;
+        drop(week_stmt);
+
+        let month_total: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes \
+                 WHERE mtime_ns >= (unixepoch('now') - 30 * 86400) * 1000000000",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("vault_stats month_count: {e}"))?;
+        let mut month_stmt = conn
+            .prepare(
+                r#"
+                SELECT title, slug FROM notes
+                WHERE mtime_ns >= (unixepoch('now') - 30 * 86400) * 1000000000
+                ORDER BY mtime_ns DESC
+                LIMIT 20
+                "#,
+            )
+            .map_err(|e| format!("vault_stats prepare modified_this_month: {e}"))?;
+        let month_notes: Vec<NoteRef> = month_stmt
+            .query_map([], |row| Ok(NoteRef { title: row.get(0)?, slug: row.get(1)? }))
+            .map_err(|e| format!("vault_stats query modified_this_month: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("vault_stats read modified_this_month: {e}"))?;
+        drop(month_stmt);
+
+        Ok(VaultStatsResponse {
+            note_count,
+            word_count: total_word_count,
+            tag_count,
+            link_count,
+            image_count: total_image_count,
+            avg_word_count,
+            vault_size_bytes,
+            total_outgoing_links: link_count,
+            total_backlinks: link_count,
+            top_tags,
+            most_linked,
+            activity_by_month,
+            notes_per_folder,
+            longest_notes,
+            shortest_notes,
+            orphan_notes,
+            no_tag_notes,
+            modified_this_week: NoteList { count: week_total, notes: week_notes },
+            modified_this_month: NoteList { count: month_total, notes: month_notes },
+        })
+    }
+
+    pub fn graph_data(&self) -> Result<crate::api_types::GraphResponse, String> {
+        use crate::api_types::{GraphEdge, GraphNode, GraphResponse};
+
+        let conn = self.connection()?;
+
+        let mut nodes_stmt = conn
+            .prepare(
+                r#"
+                SELECT n.slug, n.title,
+                  (SELECT tag FROM tags WHERE note_slug = n.slug ORDER BY tag LIMIT 1) as primary_tag,
+                  COUNT(l.source_slug) as backlink_count
+                FROM notes n
+                LEFT JOIN note_links l ON l.target_slug = n.slug
+                GROUP BY n.slug
+                ORDER BY n.title
+                "#,
+            )
+            .map_err(|e| format!("graph_data prepare nodes: {e}"))?;
+        let nodes: Vec<GraphNode> = nodes_stmt
+            .query_map([], |row| {
+                Ok(GraphNode {
+                    slug: row.get(0)?,
+                    title: row.get(1)?,
+                    primary_tag: row.get(2)?,
+                    backlink_count: row.get(3)?,
+                })
+            })
+            .map_err(|e| format!("graph_data query nodes: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("graph_data read nodes: {e}"))?;
+        drop(nodes_stmt);
+
+        let mut edges_stmt = conn
+            .prepare("SELECT source_slug, target_slug FROM note_links")
+            .map_err(|e| format!("graph_data prepare edges: {e}"))?;
+        let edges: Vec<GraphEdge> = edges_stmt
+            .query_map([], |row| Ok(GraphEdge { source: row.get(0)?, target: row.get(1)? }))
+            .map_err(|e| format!("graph_data query edges: {e}"))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("graph_data read edges: {e}"))?;
+        drop(edges_stmt);
+
+        Ok(GraphResponse { nodes, edges })
+    }
+}
+
+fn word_count_for_content(content: &str) -> usize {
+    strip_frontmatter(content).split_whitespace().count()
+}
+
+fn strip_frontmatter(content: &str) -> &str {
+    let s = content.trim_start_matches('\n');
+    let body = match s.strip_prefix("---\n") {
+        Some(rest) => rest,
+        None => return content,
+    };
+    if let Some(pos) = body.find("\n---\n") {
+        return &body[pos + 5..];
+    }
+    if let Some(stripped) = body.strip_suffix("\n---") {
+        let _ = stripped;
+        return "";
+    }
+    content
+}
+
 fn escape_like(input: &str) -> String {
     let mut escaped = String::with_capacity(input.len());
     for ch in input.chars() {

--- a/src/cache/schema.rs
+++ b/src/cache/schema.rs
@@ -1,8 +1,11 @@
 use rusqlite::OptionalExtension;
+use tracing::warn;
 
 use super::SqliteCache;
 
-const SCHEMA_VERSION: &str = "3";
+// Bump this when the schema structure or data-population logic changes to force
+// a full cache rebuild on next startup.
+const SCHEMA_VERSION: &str = "4";
 
 impl SqliteCache {
     pub fn ensure_schema(&self, embedding_dim: usize) -> Result<(), String> {
@@ -15,9 +18,16 @@ impl SqliteCache {
                 create_schema(&conn, embedding_dim)?;
                 Ok(())
             }
-            Some(version) => Err(format!(
-                "unsupported SQLite cache schema version '{version}' for expected version '{SCHEMA_VERSION}'. Delete the cache DB and restart Hatchdoor to rebuild it from Markdown."
-            )),
+            Some(version) => {
+                warn!(
+                    old = %version,
+                    new = SCHEMA_VERSION,
+                    "SQLite cache schema version mismatch; wiping cache for full rebuild"
+                );
+                wipe_schema(&conn)?;
+                create_schema(&conn, embedding_dim)?;
+                Ok(())
+            }
             None => {
                 create_schema(&conn, embedding_dim)?;
                 Ok(())
@@ -68,6 +78,22 @@ fn existing_schema_version(conn: &rusqlite::Connection) -> Result<Option<String>
                 .to_string(),
         ),
     }
+}
+
+fn wipe_schema(conn: &rusqlite::Connection) -> Result<(), String> {
+    conn.execute_batch(
+        r#"
+        DROP TABLE IF EXISTS chunk_vectors;
+        DROP TABLE IF EXISTS chunks;
+        DROP TABLE IF EXISTS headings;
+        DROP TABLE IF EXISTS tags;
+        DROP TABLE IF EXISTS note_links;
+        DROP TABLE IF EXISTS note_fts;
+        DROP TABLE IF EXISTS notes;
+        DROP TABLE IF EXISTS metadata;
+        "#,
+    )
+    .map_err(|e| format!("failed to wipe stale SQLite cache: {e}"))
 }
 
 fn create_schema(conn: &rusqlite::Connection, embedding_dim: usize) -> Result<(), String> {
@@ -157,10 +183,11 @@ fn create_schema(conn: &rusqlite::Connection, embedding_dim: usize) -> Result<()
         );
 
         INSERT INTO metadata(key, value)
-        VALUES ('schema_version', '3')
+        VALUES ('schema_version', '{version}')
         ON CONFLICT(key) DO NOTHING;
         "#,
-        dim = embedding_dim
+        dim = embedding_dim,
+        version = SCHEMA_VERSION
     );
     conn.execute_batch(&sql)
         .map_err(|error| format!("failed to initialise SQLite cache schema: {error}"))?;
@@ -196,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_cache_records_schema_version_3() {
+    fn fresh_cache_records_current_schema_version() {
         let cache = SqliteCache::in_memory(384).expect("open");
         let conn = cache.connection().expect("conn");
         let version: String = conn
@@ -206,7 +233,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("query");
-        assert_eq!(version, "3");
+        assert_eq!(version, "4");
     }
 
     #[test]

--- a/src/handlers/api.rs
+++ b/src/handlers/api.rs
@@ -15,6 +15,7 @@ use crate::api_types::{
     ResolveQuery, ResolveResponse, ResolveTargetResult, SearchQuery, SearchResponse,
     VaultEventResponse,
 };
+
 use crate::app_state::{AppState, refresh_if_needed, sqlite_cache};
 
 pub async fn health_handler() -> impl IntoResponse {
@@ -171,6 +172,30 @@ pub async fn search_handler(
     match cache.search(&search_query, include_content, limit) {
         Ok(results) => (StatusCode::OK, Json(SearchResponse { results })).into_response(),
         Err(error) => internal_error_response(format!("Search failed: {error}")),
+    }
+}
+
+pub async fn stats_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let cache = match sqlite_cache(&state).await {
+        Ok(cache) => cache,
+        Err(err) => return err.into_response(),
+    };
+
+    match cache.vault_stats() {
+        Ok(stats) => (StatusCode::OK, Json(stats)).into_response(),
+        Err(error) => internal_error_response(error),
+    }
+}
+
+pub async fn graph_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let cache = match sqlite_cache(&state).await {
+        Ok(cache) => cache,
+        Err(err) => return err.into_response(),
+    };
+
+    match cache.graph_data() {
+        Ok(data) => (StatusCode::OK, Json(data)).into_response(),
+        Err(error) => internal_error_response(error),
     }
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,8 +4,9 @@ mod downloads;
 mod spa;
 
 pub use api::{
-    health_handler, note_handler, note_links_handler, recently_modified_handler, refresh_handler,
-    resolve_batch_handler, resolve_handler, search_handler, tree_handler, vault_events_handler,
+    graph_handler, health_handler, note_handler, note_links_handler, recently_modified_handler,
+    refresh_handler, resolve_batch_handler, resolve_handler, search_handler, stats_handler,
+    tree_handler, vault_events_handler,
 };
 pub use assets::vault_asset_handler;
 pub use downloads::note_download_handler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,10 @@ use hatchdoor::app_state::{AppConfig, AppState, build_cache_with_sqlite, init_lo
 use hatchdoor::cache::SqliteCache;
 use hatchdoor::embed::{Embedder, FastembedEmbedder};
 use hatchdoor::handlers::{
-    health_handler, note_download_handler, note_handler, note_links_handler,
+    graph_handler, health_handler, note_download_handler, note_handler, note_links_handler,
     recently_modified_handler, refresh_handler, resolve_batch_handler, resolve_handler,
-    search_handler, spa_index_handler, tree_handler, vault_asset_handler, vault_events_handler,
+    search_handler, spa_index_handler, stats_handler, tree_handler, vault_asset_handler,
+    vault_events_handler,
 };
 use hatchdoor::mcp::{mcp_get_handler, mcp_post_handler};
 use hatchdoor::vault_watcher::spawn_vault_watcher;
@@ -46,9 +47,13 @@ fn build_router(state: AppState) -> Router {
         .route("/api/resolve", get(resolve_handler))
         .route("/api/resolve-batch", post(resolve_batch_handler))
         .route("/api/search", get(search_handler))
+        .route("/api/stats", get(stats_handler))
+        .route("/api/graph", get(graph_handler))
         .route("/api/refresh", post(refresh_handler))
         .route("/", get(spa_index_handler))
         .route("/n/{slug}", get(spa_index_handler))
+        .route("/stats", get(spa_index_handler))
+        .route("/graph", get(spa_index_handler))
         .route("/vault-assets/{*path}", get(vault_asset_handler))
         .route_service(
             "/manifest.webmanifest",


### PR DESCRIPTION
## Summary

- Adds `GET /api/stats` returning vault-wide statistics: note/word/tag/link/image counts, top tags, most linked notes, writing activity by month, notes per folder, longest/shortest notes, orphan notes, untagged notes, and notes modified this week/month
- Adds `GET /api/graph` returning all nodes (slug, title, primary tag, backlink count) and edges for the force graph view
- Registers `/stats` and `/graph` SPA routes
- **Stats page** — Ledger design with metric strip, tag distribution, top linked notes, writing activity, folder breakdown, orphans
- **Graph page** — canvas force graph with d3-force simulation, zoom/pan, node selection, hover labels
- **Graph interactions fix** — events never attached because canvas was conditionally rendered behind loading state; restructured to always mount canvas with overlay for loading/error
- **Touch support** — single-finger pan, node drag, tap/double-tap select+navigate, pinch-to-zoom with simultaneous pan
- **Smooth zoom** — log-space lerp animation toward target k; proportional wheel factor for trackpad compatibility
- **Adaptive labels** — shown when rendered radius × zoom ≥ 8px; constant 12px screen size regardless of zoom
- **Mobile header** — 44px HUD bar with slide-down tag filter overlay that never shrinks the canvas
- **Horizontal scroll fix** — `overflow-x: hidden` on `.note-pane`

## Test plan

- [ ] `cargo test` passes
- [ ] `GET /api/stats` and `GET /api/graph` return valid JSON
- [ ] Graph renders; pan, zoom, click, double-click work on desktop
- [ ] Touch interactions work on mobile PWA (pan, pinch, tap, double-tap)
- [ ] Mobile graph header shows 44px bar; TAGS toggle opens overlay
- [ ] Stats page has no horizontal scroll on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)