### PR TITLE
Improve indexing performance and startup progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "hatchdoor"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "ahash",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
  "dotenvy",
  "fastembed",
  "git2",
+ "libc",
  "notify",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dotenvy = "0.15"
 fastembed = "4"
 git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2", "vendored-openssl", "https"] }
+libc = "0.2"
 notify = "8"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hatchdoor"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 default-run = "hatchdoor"
 license = "AGPL-3.0-only"

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Enter the web bearer token when prompted.
 The image is published on [Docker Hub](https://hub.docker.com/r/battermanz/hatchdoor):
 
 ```text
-battermanz/hatchdoor:latest          # also version tags, e.g. 2.2.0
+battermanz/hatchdoor:latest          # also version tags, e.g. 2.2.1
 battermanz/hatchdoor:podman-latest   # for Podman users (podman-<version> too)
 ```
 
@@ -622,8 +622,8 @@ Build and publish the Docker image:
 
 ```bash
 docker build -t battermanz/hatchdoor:latest .
-docker tag battermanz/hatchdoor:latest battermanz/hatchdoor:2.2.0
-docker push battermanz/hatchdoor:2.2.0
+docker tag battermanz/hatchdoor:latest battermanz/hatchdoor:2.2.1
+docker push battermanz/hatchdoor:2.2.1
 docker push battermanz/hatchdoor:latest
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "d3-force": "^3.0.0",
         "mermaid": "^11.12.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.content-rendering.test.tsx
+++ b/frontend/src/App.content-rendering.test.tsx
@@ -8,7 +8,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 
 const mermaidInitialize = vi.fn();
 const mermaidRender = vi.fn(async (id: string, chart: string) => ({

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,6 +7,7 @@
 @import "./styles/responsive.css";
 @import "./styles/stats.css";
 @import "./styles/graph.css";
+@import "./styles/startup.css";
 
 .write-notice {
   display: flex;

--- a/frontend/src/App.enhancements.test.tsx
+++ b/frontend/src/App.enhancements.test.tsx
@@ -9,7 +9,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/App.links-download.test.tsx
+++ b/frontend/src/App.links-download.test.tsx
@@ -8,7 +8,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 import { escapeMarkdownLabel } from "./lib/markdown";
 
 afterEach(() => {

--- a/frontend/src/App.navigation-search.test.tsx
+++ b/frontend/src/App.navigation-search.test.tsx
@@ -10,7 +10,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/App.topbar-mobile-actions.test.tsx
+++ b/frontend/src/App.topbar-mobile-actions.test.tsx
@@ -8,7 +8,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 
 const originalOnLine = navigator.onLine;
 const originalClipboard = navigator.clipboard;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,8 +46,9 @@ import { useVaultTree } from "./hooks/useVaultTree";
 import { useWriteMode } from "./hooks/useWriteMode";
 import { pruneNoteDrafts } from "./lib/writeDrafts";
 import type { ActiveNoteMeta, RecentNote } from "./types";
+import { StartupGate } from "./startup/StartupGate";
 
-function App() {
+export function VaultApp() {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(() => {
     return window.localStorage.getItem(DRAWER_OPEN_KEY) === "1";
   });
@@ -87,8 +88,13 @@ function App() {
     loadModifiedNotes,
     refreshVault,
   } = useVaultTree();
-  const { writeEnabled, writeWarnings, setWriteWarnings, writeNotice, setWriteNotice } =
-    useWriteMode();
+  const {
+    writeEnabled,
+    writeWarnings,
+    setWriteWarnings,
+    writeNotice,
+    setWriteNotice,
+  } = useWriteMode();
   const {
     searchOpen,
     setSearchOpen,
@@ -582,6 +588,14 @@ function App() {
         />
       ) : null}
     </div>
+  );
+}
+
+function App() {
+  return (
+    <StartupGate>
+      <VaultApp />
+    </StartupGate>
   );
 }
 

--- a/frontend/src/App.write-mode.test.tsx
+++ b/frontend/src/App.write-mode.test.tsx
@@ -9,7 +9,7 @@ import {
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import App from "./App";
+import { VaultApp as App } from "./App";
 import { noteDraftKey } from "./lib/writeDrafts";
 
 afterEach(() => {

--- a/frontend/src/startup/StartupGate.test.tsx
+++ b/frontend/src/startup/StartupGate.test.tsx
@@ -1,0 +1,122 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StartupGate } from "./StartupGate";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function statusResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("StartupGate", () => {
+  it("shows understandable indexing progress without mounting the vault", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      statusResponse({
+        state: "indexing",
+        notes_completed: 12,
+        notes_total: 40,
+        chunks_completed: 18,
+        chunks_total: 70,
+        tokens_completed: 4_000,
+        tokens_total: 20_000,
+        percent: 20,
+        eta_seconds: 80,
+      }),
+    );
+
+    render(
+      <StartupGate>
+        <div>Private vault</div>
+      </StartupGate>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Preparing your vault" }),
+    ).toBeVisible();
+    expect(screen.queryByText("Private vault")).not.toBeInTheDocument();
+    expect(screen.getByText("12 of 40 notes")).toBeVisible();
+    expect(screen.getByText("18 of 70 chunks")).toBeVisible();
+    expect(screen.getByText("About 1 min remaining")).toBeVisible();
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "20",
+    );
+  });
+
+  it("mounts the vault immediately when indexing is ready", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      statusResponse({ state: "ready" }),
+    );
+
+    render(
+      <StartupGate>
+        <div>Private vault</div>
+      </StartupGate>,
+    );
+
+    expect(await screen.findByText("Private vault")).toBeVisible();
+  });
+
+  it("polls until the backend becomes ready", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        statusResponse({
+          state: "indexing",
+          notes_completed: 1,
+          notes_total: 2,
+          chunks_completed: 1,
+          chunks_total: 2,
+          tokens_completed: 10,
+          tokens_total: 20,
+          percent: 50,
+          eta_seconds: 2,
+        }),
+      )
+      .mockResolvedValue(statusResponse({ state: "ready" }));
+
+    render(
+      <StartupGate>
+        <div>Private vault</div>
+      </StartupGate>,
+    );
+    await act(async () => {});
+    expect(screen.queryByText("Private vault")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(screen.getByText("Private vault")).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a safe error when indexing fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      statusResponse({
+        state: "failed",
+        message: "Indexing could not be completed.",
+      }),
+    );
+
+    render(
+      <StartupGate>
+        <div>Private vault</div>
+      </StartupGate>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Vault unavailable" }),
+    ).toBeVisible();
+    expect(screen.queryByText("Private vault")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/startup/StartupGate.tsx
+++ b/frontend/src/startup/StartupGate.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import { useTheme } from "../hooks/useTheme";
+
+type StartupStatus =
+  | { state: "scanning" }
+  | {
+      state: "indexing";
+      notes_completed: number;
+      notes_total: number;
+      chunks_completed: number;
+      chunks_total: number;
+      tokens_completed: number;
+      tokens_total: number;
+      percent: number;
+      eta_seconds?: number;
+    }
+  | { state: "ready" }
+  | { state: "failed"; message?: string };
+
+const POLL_INTERVAL_MS = 1_000;
+const THEME_ICON = { auto: "◑", light: "○", dark: "●" } as const;
+
+export function StartupGate({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<StartupStatus | null>(null);
+  const [connectionIssue, setConnectionIssue] = useState(false);
+  const { theme, cycleTheme } = useTheme();
+
+  useEffect(() => {
+    let active = true;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      let shouldPoll = true;
+      try {
+        const response = await fetch("/api/startup-status", {
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error(`startup status returned ${response.status}`);
+        }
+        const next = (await response.json()) as StartupStatus;
+        if (!active) return;
+        setStatus(next);
+        setConnectionIssue(false);
+        shouldPoll = next.state !== "ready" && next.state !== "failed";
+      } catch {
+        if (!active) return;
+        setConnectionIssue(true);
+      }
+
+      if (active && shouldPoll) {
+        timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+
+    void poll();
+    return () => {
+      active = false;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  if (status?.state === "ready") {
+    return children;
+  }
+
+  const failed = status?.state === "failed";
+  const indexing = status?.state === "indexing" ? status : null;
+  const percent = indexing?.percent ?? 0;
+  const eta = indexing?.eta_seconds;
+  const progressLabel = indexing
+    ? `${percent}% of embedding work complete`
+    : "Measuring the vault";
+
+  return (
+    <div className="startup-shell">
+      <div className="hotbar" aria-hidden="true" />
+      <header className="startup-topbar">
+        <div className="startup-brand" aria-label="Hatchdoor">
+          <span className="startup-brand-mark" aria-hidden="true">
+            [<i />]
+          </span>
+          <span>HATCHDOOR</span>
+        </div>
+        <span className="startup-crumb">Preparing vault</span>
+        <button
+          type="button"
+          className="icon-button startup-theme"
+          onClick={cycleTheme}
+          aria-label={`Theme: ${theme}`}
+        >
+          {THEME_ICON[theme]}
+        </button>
+      </header>
+
+      <main className="startup-main">
+        <p className="startup-kicker">SEARCH INDEX</p>
+        <h1>{failed ? "Vault unavailable" : "Preparing your vault"}</h1>
+        <p className="startup-lede" aria-live="polite">
+          {failed
+            ? (status.message ?? "Indexing could not be completed.")
+            : connectionIssue
+              ? "Waiting for Hatchdoor to respond…"
+              : indexing
+                ? "Building the search index. Your notes stay locked until it is ready."
+                : "Scanning notes and measuring the work ahead…"}
+        </p>
+
+        {!failed ? (
+          <>
+            <div
+              className={`startup-progress ${indexing ? "" : "is-indeterminate"}`}
+              role="progressbar"
+              aria-label={progressLabel}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={indexing ? percent : undefined}
+            >
+              <span style={{ transform: `scaleX(${percent / 100})` }} />
+            </div>
+
+            <div className="startup-progress-line" aria-live="polite">
+              <strong>{indexing ? `${percent}%` : "Scanning"}</strong>
+              <span>{formatEta(eta)}</span>
+            </div>
+
+            {indexing ? (
+              <dl className="startup-measures">
+                <div>
+                  <dt>Notes</dt>
+                  <dd>
+                    {formatCount(indexing.notes_completed)} of{" "}
+                    {formatCount(indexing.notes_total)} notes
+                  </dd>
+                </div>
+                <div>
+                  <dt>Chunks</dt>
+                  <dd>
+                    {formatCount(indexing.chunks_completed)} of{" "}
+                    {formatCount(indexing.chunks_total)} chunks
+                  </dd>
+                </div>
+              </dl>
+            ) : null}
+          </>
+        ) : (
+          <p className="startup-failure-help">
+            Check the Hatchdoor logs, correct the indexing error, then restart
+            the service.
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function formatCount(value: number) {
+  return value.toLocaleString();
+}
+
+function formatEta(seconds?: number) {
+  if (seconds === undefined) return "Estimating time remaining";
+  if (seconds < 45) return "Less than a minute remaining";
+  const minutes = Math.max(1, Math.round(seconds / 60));
+  return `About ${minutes} min remaining`;
+}

--- a/frontend/src/styles/startup.css
+++ b/frontend/src/styles/startup.css
@@ -1,0 +1,200 @@
+.startup-shell {
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.startup-topbar {
+  min-height: 70px;
+  display: grid;
+  grid-template-columns: minmax(190px, 268px) 1fr auto;
+  align-items: center;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+}
+
+.startup-brand,
+.startup-crumb,
+.startup-theme {
+  margin: 0 var(--space-5);
+}
+
+.startup-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.startup-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 1.45rem;
+  font-weight: 800;
+  letter-spacing: -0.3em;
+}
+
+.startup-brand-mark i {
+  width: 0.42rem;
+  height: 0.42rem;
+  margin: 0 0.28rem 0 0.12rem;
+  background: var(--hot);
+}
+
+.startup-crumb {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.startup-theme {
+  justify-self: end;
+}
+
+.startup-main {
+  width: min(780px, calc(100% - 2rem));
+  margin: clamp(4rem, 12vh, 9rem) auto 3rem;
+}
+
+.startup-kicker {
+  margin: 0 0 var(--space-4);
+  color: var(--hot);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.startup-main h1 {
+  max-width: 650px;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.6rem, 7vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: -0.065em;
+}
+
+.startup-lede {
+  max-width: 580px;
+  min-height: 2.8em;
+  margin: var(--space-6) 0 var(--space-10);
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.startup-progress {
+  position: relative;
+  height: 8px;
+  overflow: hidden;
+  border-top: 1px solid var(--rule-strong);
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.startup-progress span {
+  position: absolute;
+  inset: 0;
+  background: var(--hot);
+  transform-origin: left;
+  transition: transform 500ms var(--ease);
+}
+
+.startup-progress.is-indeterminate span {
+  width: 28%;
+  animation: startup-scan 1.4s ease-in-out infinite;
+}
+
+.startup-progress-line {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.startup-progress-line span {
+  color: var(--muted);
+}
+
+.startup-measures {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: var(--space-12) 0 0;
+  border-top: 1px solid var(--rule);
+}
+
+.startup-measures div {
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.startup-measures div + div {
+  padding-left: var(--space-6);
+  border-left: 1px solid var(--rule);
+}
+
+.startup-measures dt {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.startup-measures dd {
+  margin: var(--space-2) 0 0;
+  font-size: 0.95rem;
+}
+
+.startup-failure-help {
+  max-width: 580px;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--err-border);
+  color: var(--err-fg);
+}
+
+@keyframes startup-scan {
+  from {
+    transform: translateX(-110%);
+  }
+  to {
+    transform: translateX(370%);
+  }
+}
+
+@media (max-width: 640px) {
+  .startup-topbar {
+    grid-template-columns: 1fr auto;
+  }
+
+  .startup-crumb {
+    display: none;
+  }
+
+  .startup-main {
+    margin-top: 4rem;
+  }
+
+  .startup-measures {
+    grid-template-columns: 1fr;
+  }
+
+  .startup-measures div + div {
+    padding-left: 0;
+    border-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .startup-progress span {
+    transition: none;
+  }
+
+  .startup-progress.is-indeterminate span {
+    animation-duration: 3s;
+  }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use axum::Json;
 use axum::http::StatusCode;
@@ -65,7 +66,14 @@ pub fn build_cache_with_sqlite(
             "Seeded fresh vault with Hatchdoor starter notes"
         );
     }
+    info!("Scanning vault for notes…");
+    let scan_started = Instant::now();
     let index = VaultIndex::build(vault_path).map_err(|e| e.to_string())?;
+    debug!(
+        notes = index.ordered_slugs.len(),
+        elapsed_ms = scan_started.elapsed().as_secs_f64() * 1_000.0,
+        "Vault scan performance"
+    );
     sqlite.replace_from_index_with_embedder(&index, embedder)?;
 
     Ok(VaultCache { sqlite })
@@ -136,12 +144,19 @@ async fn run_reindex(state: &AppState) -> Result<(), (StatusCode, Json<ErrorResp
     // pooled connections keep serving the prior snapshot until it commits, so we
     // no longer hold the cache write lock for the whole rebuild (F-03).
     run_blocking(move || {
+        info!("Scanning vault for notes…");
+        let scan_started = Instant::now();
         let index = VaultIndex::build(&vault_path).map_err(|e| e.to_string())?;
+        debug!(
+            notes = index.ordered_slugs.len(),
+            elapsed_ms = scan_started.elapsed().as_secs_f64() * 1_000.0,
+            "Vault scan performance"
+        );
         sqlite.replace_from_index_with_embedder(&index, embedder.as_ref())
     })
     .await?;
 
-    info!(vault_path = %state.vault_path.display(), "SQLite vault cache refreshed");
+    debug!(vault_path = %state.vault_path.display(), "SQLite vault cache refreshed");
     broadcast_vault_revision(state);
     Ok(())
 }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
 use axum::Json;
@@ -11,6 +11,7 @@ use tracing::{debug, error, info};
 use crate::api_types::ErrorResponse;
 use crate::cache::SqliteCache;
 use crate::embed::Embedder;
+use crate::startup::{IndexingProgressSnapshot, StartupTracker};
 use crate::vault::{VaultIndex, seed_empty_vault};
 
 #[derive(Clone)]
@@ -27,19 +28,20 @@ pub struct AppState {
     /// Serializes vault file mutations against git sync tree operations.
     pub vault_write_lock: Arc<tokio::sync::Mutex<()>>,
     /// Present only when git sync is enabled.
-    pub git_sync: Option<crate::git::GitSyncHandle>,
+    pub git_sync: Arc<OnceLock<crate::git::GitSyncHandle>>,
     /// Validated MCP configuration, parsed once at startup.
     pub mcp_config: Arc<crate::mcp::McpConfig>,
     /// Folder prefix treated as archived in resolve results.
     pub archive_prefix: Arc<str>,
     /// Held while a reindex runs so concurrent refreshes coalesce into one.
     pub refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    pub startup: StartupTracker,
 }
 
 impl AppState {
     /// Record a vault write for git sync. No-op when sync is disabled.
     pub fn record_vault_write(&self, record: crate::git::WriteRecord) {
-        if let Some(handle) = &self.git_sync {
+        if let Some(handle) = self.git_sync.get() {
             handle.record(record);
         }
     }
@@ -59,6 +61,15 @@ pub fn build_cache_with_sqlite(
     sqlite: Arc<SqliteCache>,
     embedder: &dyn Embedder,
 ) -> Result<VaultCache, String> {
+    build_cache_with_sqlite_and_progress(vault_path, sqlite, embedder, None)
+}
+
+pub fn build_cache_with_sqlite_and_progress(
+    vault_path: &PathBuf,
+    sqlite: Arc<SqliteCache>,
+    embedder: &dyn Embedder,
+    on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
+) -> Result<VaultCache, String> {
     debug!(vault_path = %vault_path.display(), "Building SQLite vault cache");
     if seed_empty_vault(vault_path).map_err(|e| e.to_string())? {
         info!(
@@ -74,7 +85,7 @@ pub fn build_cache_with_sqlite(
         elapsed_ms = scan_started.elapsed().as_secs_f64() * 1_000.0,
         "Vault scan performance"
     );
-    sqlite.replace_from_index_with_embedder(&index, embedder)?;
+    sqlite.replace_from_index_with_embedder_and_progress(&index, embedder, on_progress)?;
 
     Ok(VaultCache { sqlite })
 }
@@ -207,10 +218,11 @@ mod tests {
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            git_sync: None,
+            git_sync: Arc::new(OnceLock::new()),
             mcp_config: Arc::new(crate::mcp::McpConfig::disabled()),
             archive_prefix: Arc::from("90-archive/"),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            startup: StartupTracker::ready(),
         }
     }
 

--- a/src/bin/index_microbench.rs
+++ b/src/bin/index_microbench.rs
@@ -1,0 +1,312 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::time::{Duration, Instant};
+
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use rusqlite::{Connection, OpenFlags};
+use tokenizers::Tokenizer;
+
+const DOC_PREFIX: &str = "search_document: ";
+const DEFAULT_CACHE: &str = "data/cache/hatchdoor-cache.sqlite3";
+const SAMPLE_NOTES: usize = 16;
+
+#[derive(Clone)]
+struct CachedChunk {
+    note_slug: String,
+    ordinal: i64,
+    content: String,
+    raw_tokens: usize,
+}
+
+struct BenchResult {
+    elapsed: Duration,
+    vectors: Vec<Vec<f32>>,
+}
+
+fn main() -> Result<(), String> {
+    let cache_path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_CACHE.to_string());
+    let rows = read_chunks(&cache_path)?;
+    if rows.is_empty() {
+        return Err(format!("cache contains no chunks: {cache_path}"));
+    }
+
+    println!("Index microbenchmark (read-only; cache will not be modified)");
+    println!("cache={cache_path} chunks={}", rows.len());
+
+    let model_512 = load_model(512)?;
+    let raw_tokenizer = untruncated_tokenizer(&model_512.tokenizer)?;
+    let chunks = measure_raw_tokens(rows, &raw_tokenizer)?;
+    print_truncation_report(&chunks);
+
+    let sample = select_note_sample(&chunks, SAMPLE_NOTES);
+    let sample_chunk_count: usize = sample.iter().map(Vec::len).sum();
+    let sample_raw_tokens: usize = sample.iter().flatten().map(|chunk| chunk.raw_tokens).sum();
+    println!(
+        "sample_notes={} sample_chunks={} sample_raw_tokens={}",
+        sample.len(),
+        sample_chunk_count,
+        sample_raw_tokens
+    );
+
+    warm_up(&model_512)?;
+    let current = bench_per_note(&model_512, &sample)?;
+    let no_padding_512 = bench_individual(&model_512, &sample)?;
+    drop(model_512);
+
+    let model_1024 = load_model(1024)?;
+    warm_up(&model_1024)?;
+    let expanded = bench_per_note(&model_1024, &sample)?;
+    let no_padding_1024 = bench_individual(&model_1024, &sample)?;
+
+    println!();
+    println!("Paired inference timings on the same sample:");
+    print_timing(
+        "512 / current per-note batches",
+        &current,
+        sample_chunk_count,
+    );
+    print_timing(
+        "512 / one chunk per call",
+        &no_padding_512,
+        sample_chunk_count,
+    );
+    print_timing(
+        "1024 / current per-note batches",
+        &expanded,
+        sample_chunk_count,
+    );
+    print_timing(
+        "1024 / one chunk per call",
+        &no_padding_1024,
+        sample_chunk_count,
+    );
+
+    println!();
+    print_ratio(
+        "1024/current vs 512/current",
+        expanded.elapsed,
+        current.elapsed,
+    );
+    print_ratio(
+        "512/individual vs 512/current",
+        no_padding_512.elapsed,
+        current.elapsed,
+    );
+    print_ratio(
+        "1024/individual vs 512/current",
+        no_padding_1024.elapsed,
+        current.elapsed,
+    );
+    println!(
+        "mean_cosine_same_chunk_512_vs_1024={:.6}",
+        mean_matching_cosine(&no_padding_512.vectors, &no_padding_1024.vectors)
+    );
+
+    Ok(())
+}
+
+fn load_model(max_length: usize) -> Result<TextEmbedding, String> {
+    println!("loading_model=NomicEmbedTextV15 max_length={max_length}");
+    TextEmbedding::try_new(
+        InitOptions::new(EmbeddingModel::NomicEmbedTextV15)
+            .with_max_length(max_length)
+            .with_show_download_progress(false),
+    )
+    .map_err(|error| format!("failed loading Nomic model at max_length={max_length}: {error}"))
+}
+
+fn read_chunks(path: &str) -> Result<Vec<(String, i64, String)>, String> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| format!("failed opening cache read-only: {error}"))?;
+    let mut statement = connection
+        .prepare("SELECT note_slug, ordinal, content FROM chunks ORDER BY note_slug, ordinal")
+        .map_err(|error| format!("failed preparing chunk query: {error}"))?;
+    let rows = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .map_err(|error| format!("failed querying chunks: {error}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed reading chunks: {error}"))
+}
+
+fn untruncated_tokenizer(tokenizer: &Tokenizer) -> Result<Tokenizer, String> {
+    let mut tokenizer = tokenizer.clone();
+    tokenizer
+        .with_truncation(None)
+        .map_err(|error| format!("failed disabling tokenizer truncation: {error}"))?;
+    tokenizer.with_padding(None);
+    Ok(tokenizer)
+}
+
+fn measure_raw_tokens(
+    rows: Vec<(String, i64, String)>,
+    tokenizer: &Tokenizer,
+) -> Result<Vec<CachedChunk>, String> {
+    rows.into_iter()
+        .map(|(note_slug, ordinal, content)| {
+            let input = format!("{DOC_PREFIX}{content}");
+            let raw_tokens = tokenizer
+                .encode(input, true)
+                .map_err(|error| format!("failed tokenizing {note_slug}#{ordinal}: {error}"))?
+                .get_ids()
+                .len();
+            Ok(CachedChunk {
+                note_slug,
+                ordinal,
+                content,
+                raw_tokens,
+            })
+        })
+        .collect()
+}
+
+fn print_truncation_report(chunks: &[CachedChunk]) {
+    let raw_total: usize = chunks.iter().map(|chunk| chunk.raw_tokens).sum();
+    let over_512 = chunks.iter().filter(|chunk| chunk.raw_tokens > 512).count();
+    let discarded_512: usize = chunks
+        .iter()
+        .map(|chunk| chunk.raw_tokens.saturating_sub(512))
+        .sum();
+    let over_1024 = chunks
+        .iter()
+        .filter(|chunk| chunk.raw_tokens > 1024)
+        .count();
+    let discarded_1024: usize = chunks
+        .iter()
+        .map(|chunk| chunk.raw_tokens.saturating_sub(1024))
+        .sum();
+    let max_raw = chunks
+        .iter()
+        .map(|chunk| chunk.raw_tokens)
+        .max()
+        .unwrap_or(0);
+    println!(
+        "raw_tokens={} max_chunk_tokens={} over_512={} discarded_at_512={} ({:.2}%) over_1024={} discarded_at_1024={} ({:.2}%)",
+        raw_total,
+        max_raw,
+        over_512,
+        discarded_512,
+        percent(discarded_512, raw_total),
+        over_1024,
+        discarded_1024,
+        percent(discarded_1024, raw_total),
+    );
+}
+
+fn select_note_sample(chunks: &[CachedChunk], target_notes: usize) -> Vec<Vec<CachedChunk>> {
+    let mut notes: BTreeMap<&str, Vec<CachedChunk>> = BTreeMap::new();
+    for chunk in chunks {
+        notes
+            .entry(chunk.note_slug.as_str())
+            .or_default()
+            .push(chunk.clone());
+    }
+    let mut notes: Vec<Vec<CachedChunk>> = notes.into_values().collect();
+    notes.sort_by_key(|note| {
+        let longest = note.iter().map(|chunk| chunk.raw_tokens).max().unwrap_or(0);
+        longest * note.len()
+    });
+    let count = target_notes.min(notes.len());
+    if count <= 1 {
+        return notes.into_iter().take(count).collect();
+    }
+    (0..count)
+        .map(|index| {
+            let source_index = index * (notes.len() - 1) / (count - 1);
+            notes[source_index].clone()
+        })
+        .collect()
+}
+
+fn warm_up(model: &TextEmbedding) -> Result<(), String> {
+    model
+        .embed(vec![format!("{DOC_PREFIX}warm up")], None)
+        .map(|_| ())
+        .map_err(|error| format!("warm-up embed failed: {error}"))
+}
+
+fn bench_per_note(
+    model: &TextEmbedding,
+    notes: &[Vec<CachedChunk>],
+) -> Result<BenchResult, String> {
+    let started = Instant::now();
+    let mut vectors = Vec::new();
+    for note in notes {
+        let inputs = note
+            .iter()
+            .map(|chunk| format!("{DOC_PREFIX}{}", chunk.content))
+            .collect::<Vec<_>>();
+        vectors.extend(
+            model
+                .embed(inputs, None)
+                .map_err(|error| format!("per-note benchmark embed failed: {error}"))?,
+        );
+    }
+    Ok(BenchResult {
+        elapsed: started.elapsed(),
+        vectors,
+    })
+}
+
+fn bench_individual(
+    model: &TextEmbedding,
+    notes: &[Vec<CachedChunk>],
+) -> Result<BenchResult, String> {
+    let started = Instant::now();
+    let mut vectors = Vec::new();
+    for chunk in notes.iter().flatten() {
+        vectors.extend(
+            model
+                .embed(vec![format!("{DOC_PREFIX}{}", chunk.content)], None)
+                .map_err(|error| {
+                    format!(
+                        "individual benchmark embed failed for {}#{}: {error}",
+                        chunk.note_slug, chunk.ordinal
+                    )
+                })?,
+        );
+    }
+    Ok(BenchResult {
+        elapsed: started.elapsed(),
+        vectors,
+    })
+}
+
+fn print_timing(label: &str, result: &BenchResult, chunks: usize) {
+    println!(
+        "{label}: {:.3}s ({:.3} chunks/s)",
+        result.elapsed.as_secs_f64(),
+        chunks as f64 / result.elapsed.as_secs_f64()
+    );
+}
+
+fn print_ratio(label: &str, candidate: Duration, baseline: Duration) {
+    let ratio = candidate.as_secs_f64() / baseline.as_secs_f64();
+    println!("{label}: {ratio:.3}x ({:+.1}%)", (ratio - 1.0) * 100.0);
+}
+
+fn mean_matching_cosine(left: &[Vec<f32>], right: &[Vec<f32>]) -> f64 {
+    let sum: f64 = left
+        .iter()
+        .zip(right)
+        .map(|(left, right)| {
+            left.iter()
+                .zip(right)
+                .map(|(a, b)| (*a as f64) * (*b as f64))
+                .sum::<f64>()
+        })
+        .sum();
+    sum / left.len().max(1) as f64
+}
+
+fn percent(part: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        part as f64 * 100.0 / total as f64
+    }
+}

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -11,7 +11,7 @@ use rusqlite::{OptionalExtension, Transaction, params};
 use crate::cache::chunk_ops::{
     ChunkRow, delete_orphan_vectors, existing_chunk_hashes, replace_chunks_for_note,
 };
-use crate::chunk::{ChunkOptions, chunk_note};
+use crate::chunk::{ChunkOptions, NoteChunking, chunk_note};
 use crate::embed::Embedder;
 use crate::vault::{NoteEntry, VaultIndex, normalize_title};
 
@@ -78,45 +78,80 @@ impl SqliteCache {
         let mut notes_changed: usize = 0;
         let mut notes_unchanged: usize = 0;
         let mut metrics = IndexingMetrics::default();
-        let (progress, stop_heartbeat, heartbeat) =
-            start_indexing_heartbeat(total_notes, started_at);
+        let mut prepared_notes = Vec::new();
 
-        let indexing_result = (|| -> Result<(), String> {
-            for (position, entry) in entries.iter().enumerate() {
-                let note_sync_started = Instant::now();
-                let upsert_outcome = upsert_note_if_changed(&tx, entry, now)?;
-                metrics.note_sync += note_sync_started.elapsed();
-                match upsert_outcome {
-                    UpsertOutcome::Wrote { slug, content } => {
-                        match chunk_and_embed_note(&tx, &slug, &content, embedder) {
-                            Ok(stats) => {
-                                notes_changed += 1;
-                                chunks_embedded += stats.embedded;
-                                chunks_reused += stats.reused;
-                                metrics.record_chunk_stats(&stats);
-                            }
-                            Err(e) => {
-                                per_note_failures += 1;
-                                progress
-                                    .failures
-                                    .store(per_note_failures, Ordering::Relaxed);
-                                tracing::warn!(slug = %slug, error = %e, "Per-note embedding failed; marking note for re-embed on next reindex");
-                                // The notes row was just written with the new content_hash,
-                                // but chunk/vector tables are now stale (or empty for a new
-                                // note). Change-detection keys off content_hash, so without
-                                // this the note would look Unchanged forever and never be
-                                // re-chunked. Invalidate the stored hash so the next reindex
-                                // re-processes the note once the embedder recovers.
-                                invalidate_note_content_hash(&tx, &slug)?;
-                            }
+        // Chunk and measure changed notes up front. Chunking was less than 0.5%
+        // of the measured full-vault runtime, and retaining these results gives
+        // the heartbeat an exact embedding-work denominator without chunking
+        // notes twice.
+        for entry in &entries {
+            let note_sync_started = Instant::now();
+            let upsert_outcome = upsert_note_if_changed(&tx, entry, now)?;
+            metrics.note_sync += note_sync_started.elapsed();
+            match upsert_outcome {
+                UpsertOutcome::Wrote { slug, content } => {
+                    match prepare_note_for_embedding(&tx, slug, content, embedder) {
+                        Ok(prepared) => prepared_notes.push(prepared),
+                        Err(error) => {
+                            per_note_failures += 1;
+                            tracing::warn!(slug = %entry.slug, error = %error, "Per-note embedding preparation failed; marking note for re-embed on next reindex");
+                            invalidate_note_content_hash(&tx, &entry.slug)?;
                         }
                     }
-                    UpsertOutcome::Unchanged => notes_unchanged += 1,
                 }
+                UpsertOutcome::Unchanged => notes_unchanged += 1,
+            }
+        }
 
-                progress
-                    .notes_processed
-                    .store(position + 1, Ordering::Relaxed);
+        let total_chunks_to_embed: usize = prepared_notes
+            .iter()
+            .map(|note| note.texts_to_embed.len())
+            .sum();
+        let total_tokens_to_embed: usize = prepared_notes
+            .iter()
+            .flat_map(|note| note.embedding_input_token_lengths.iter())
+            .sum();
+        tracing::debug!(
+            changed_notes = prepared_notes.len(),
+            total_chunks_to_embed,
+            total_tokens_to_embed,
+            "Prepared indexing workload"
+        );
+
+        let embedding_started_at = Instant::now();
+        let (progress, stop_heartbeat, heartbeat) = start_indexing_heartbeat(
+            total_notes,
+            total_chunks_to_embed,
+            total_tokens_to_embed,
+            embedding_started_at,
+        );
+        progress
+            .notes_processed
+            .store(notes_unchanged + per_note_failures, Ordering::Relaxed);
+        progress
+            .failures
+            .store(per_note_failures, Ordering::Relaxed);
+
+        let indexing_result = (|| -> Result<(), String> {
+            for prepared in prepared_notes {
+                let slug = prepared.slug.clone();
+                match embed_prepared_note(&tx, prepared, embedder, progress.as_ref()) {
+                    Ok(stats) => {
+                        notes_changed += 1;
+                        chunks_embedded += stats.embedded;
+                        chunks_reused += stats.reused;
+                        metrics.record_chunk_stats(&stats);
+                    }
+                    Err(error) => {
+                        per_note_failures += 1;
+                        progress
+                            .failures
+                            .store(per_note_failures, Ordering::Relaxed);
+                        tracing::warn!(slug = %slug, error = %error, "Per-note embedding failed; marking note for re-embed on next reindex");
+                        invalidate_note_content_hash(&tx, &slug)?;
+                    }
+                }
+                progress.notes_processed.fetch_add(1, Ordering::Relaxed);
             }
             Ok(())
         })();
@@ -425,11 +460,15 @@ fn duration_ms(duration: Duration) -> f64 {
 #[derive(Default)]
 struct IndexingProgress {
     notes_processed: AtomicUsize,
+    chunks_processed: AtomicUsize,
+    tokens_processed: AtomicUsize,
     failures: AtomicUsize,
 }
 
 fn start_indexing_heartbeat(
     total_notes: usize,
+    total_chunks: usize,
+    total_tokens: usize,
     started_at: Instant,
 ) -> (
     Arc<IndexingProgress>,
@@ -447,6 +486,10 @@ fn start_indexing_heartbeat(
                     log_indexing_progress(
                         heartbeat_progress.notes_processed.load(Ordering::Relaxed),
                         total_notes,
+                        heartbeat_progress.chunks_processed.load(Ordering::Relaxed),
+                        total_chunks,
+                        heartbeat_progress.tokens_processed.load(Ordering::Relaxed),
+                        total_tokens,
                         started_at.elapsed(),
                         heartbeat_progress.failures.load(Ordering::Relaxed),
                     );
@@ -469,25 +512,55 @@ fn progress_log_delay(has_logged: bool) -> Duration {
 
 fn estimated_remaining(
     elapsed: Duration,
-    notes_processed: usize,
-    total_notes: usize,
+    tokens_processed: usize,
+    total_tokens: usize,
 ) -> Option<Duration> {
-    if notes_processed == 0 || notes_processed >= total_notes {
+    if tokens_processed == 0 || tokens_processed >= total_tokens {
         return None;
     }
-    let notes_remaining = total_notes - notes_processed;
-    Some(elapsed.mul_f64(notes_remaining as f64 / notes_processed as f64))
+    let tokens_remaining = total_tokens - tokens_processed;
+    Some(elapsed.mul_f64(tokens_remaining as f64 / tokens_processed as f64))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn log_indexing_progress(
     notes_processed: usize,
     total_notes: usize,
+    chunks_processed: usize,
+    total_chunks: usize,
+    tokens_processed: usize,
+    total_tokens: usize,
     elapsed: Duration,
     failures: usize,
 ) {
-    let notes_remaining = total_notes.saturating_sub(notes_processed);
-    let percent = notes_processed.saturating_mul(100) / total_notes.max(1);
-    let eta = estimated_remaining(elapsed, notes_processed, total_notes)
+    tracing::info!(
+        "{}",
+        indexing_progress_message(
+            notes_processed,
+            total_notes,
+            chunks_processed,
+            total_chunks,
+            tokens_processed,
+            total_tokens,
+            elapsed,
+            failures,
+        )
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn indexing_progress_message(
+    notes_processed: usize,
+    total_notes: usize,
+    chunks_processed: usize,
+    total_chunks: usize,
+    tokens_processed: usize,
+    total_tokens: usize,
+    elapsed: Duration,
+    failures: usize,
+) -> String {
+    let percent = tokens_processed.saturating_mul(100) / total_tokens.max(1);
+    let eta = estimated_remaining(elapsed, tokens_processed, total_tokens)
         .map(format_eta)
         .unwrap_or_else(|| "estimating time remaining…".to_string());
     let failure_summary = if failures == 0 {
@@ -496,15 +569,16 @@ fn log_indexing_progress(
         format!(" — {} failed", format_count(failures))
     };
 
-    tracing::info!(
-        "Indexing notes: {} of {} ({}%) — {} left — {}{}",
+    format!(
+        "Indexing: {} of {} notes — {} of {} chunks — {}% of embedding work — {}{}",
         format_count(notes_processed),
         format_count(total_notes),
+        format_count(chunks_processed),
+        format_count(total_chunks),
         percent,
-        format_count(notes_remaining),
         eta,
         failure_summary,
-    );
+    )
 }
 
 fn format_count(value: usize) -> String {
@@ -949,41 +1023,33 @@ struct ChunkMeasurement {
     input_tokens: usize,
 }
 
-fn chunk_and_embed_note(
+struct PreparedNote {
+    slug: String,
+    chunking: NoteChunking,
+    preserved: HashMap<String, Vec<f32>>,
+    texts_to_embed: Vec<String>,
+    indices_needing_embed: Vec<usize>,
+    embedding_input_bytes: usize,
+    embedding_input_token_lengths: Vec<usize>,
+    chunk_measurements: Vec<ChunkMeasurement>,
+    chunking_elapsed: Duration,
+    vector_reuse_elapsed: Duration,
+}
+
+fn prepare_note_for_embedding(
     tx: &Transaction<'_>,
-    slug: &str,
-    content: &str,
+    slug: String,
+    content: String,
     embedder: &dyn Embedder,
-) -> Result<ChunkStats, String> {
-    let pipeline_started = Instant::now();
+) -> Result<PreparedNote, String> {
     let chunking_started = Instant::now();
     let tokenizer = embedder.tokenizer();
-    let chunking = chunk_note(content, tokenizer.clone(), ChunkOptions::default());
+    let chunking = chunk_note(&content, tokenizer.clone(), ChunkOptions::default());
     let chunking_elapsed = chunking_started.elapsed();
-    if chunking.chunks.is_empty() {
-        let sqlite_started = Instant::now();
-        replace_chunks_for_note(tx, slug, &[], None, None)?;
-        return Ok(ChunkStats {
-            embedded: 0,
-            reused: 0,
-            embedder_calls: 0,
-            embedding_input_bytes: 0,
-            embedding_input_tokens: 0,
-            embedding_padded_tokens: 0,
-            embedding_input_token_lengths: Vec::new(),
-            embedding_call_durations: Vec::new(),
-            chunk_measurements: Vec::new(),
-            pipeline: pipeline_started.elapsed(),
-            chunking: chunking_elapsed,
-            vector_reuse: Duration::ZERO,
-            embedding: Duration::ZERO,
-            sqlite_write: sqlite_started.elapsed(),
-        });
-    }
 
     let reuse_started = Instant::now();
-    let existing = existing_chunk_hashes(tx, slug)?;
-    let preserved = preserve_existing_vectors(tx, slug, &chunking.chunks, &existing)?;
+    let existing = existing_chunk_hashes(tx, &slug)?;
+    let preserved = preserve_existing_vectors(tx, &slug, &chunking.chunks, &existing)?;
     let vector_reuse_elapsed = reuse_started.elapsed();
 
     let doc_prefix = embedder.doc_prefix();
@@ -1031,6 +1097,61 @@ fn chunk_and_embed_note(
         .iter()
         .map(|index| chunk_measurements[*index].clone())
         .collect();
+
+    Ok(PreparedNote {
+        slug,
+        chunking,
+        preserved,
+        texts_to_embed,
+        indices_needing_embed,
+        embedding_input_bytes,
+        embedding_input_token_lengths,
+        chunk_measurements: embedded_chunk_measurements,
+        chunking_elapsed,
+        vector_reuse_elapsed,
+    })
+}
+
+fn embed_prepared_note(
+    tx: &Transaction<'_>,
+    prepared: PreparedNote,
+    embedder: &dyn Embedder,
+    progress: &IndexingProgress,
+) -> Result<ChunkStats, String> {
+    let pipeline_started = Instant::now();
+    let PreparedNote {
+        slug,
+        chunking,
+        preserved,
+        texts_to_embed,
+        indices_needing_embed,
+        embedding_input_bytes,
+        embedding_input_token_lengths,
+        chunk_measurements,
+        chunking_elapsed,
+        vector_reuse_elapsed,
+    } = prepared;
+    if chunking.chunks.is_empty() {
+        let sqlite_started = Instant::now();
+        replace_chunks_for_note(tx, &slug, &[], None, None)?;
+        return Ok(ChunkStats {
+            embedded: 0,
+            reused: 0,
+            embedder_calls: 0,
+            embedding_input_bytes: 0,
+            embedding_input_tokens: 0,
+            embedding_padded_tokens: 0,
+            embedding_input_token_lengths: Vec::new(),
+            embedding_call_durations: Vec::new(),
+            chunk_measurements: Vec::new(),
+            pipeline: pipeline_started.elapsed() + chunking_elapsed + vector_reuse_elapsed,
+            chunking: chunking_elapsed,
+            vector_reuse: vector_reuse_elapsed,
+            embedding: Duration::ZERO,
+            sqlite_write: sqlite_started.elapsed(),
+        });
+    }
+
     let embedding_input_tokens: usize = embedding_input_token_lengths.iter().sum();
     // Each chunk is embedded in its own call. This avoids BatchLongest padding
     // short chunks to the longest sibling chunk in the same note.
@@ -1038,7 +1159,10 @@ fn chunk_and_embed_note(
     let embedding_started = Instant::now();
     let mut new_vectors = Vec::with_capacity(texts_to_embed.len());
     let mut embedding_call_durations = Vec::with_capacity(texts_to_embed.len());
-    for text in &texts_to_embed {
+    for (text, input_tokens) in texts_to_embed
+        .iter()
+        .zip(embedding_input_token_lengths.iter().copied())
+    {
         let call_started = Instant::now();
         let mut vectors = embedder.embed(std::slice::from_ref(text))?;
         embedding_call_durations.push(call_started.elapsed());
@@ -1049,6 +1173,10 @@ fn chunk_and_embed_note(
             ));
         }
         new_vectors.push(vectors.remove(0));
+        progress.chunks_processed.fetch_add(1, Ordering::Relaxed);
+        progress
+            .tokens_processed
+            .fetch_add(input_tokens, Ordering::Relaxed);
     }
     let embedding_elapsed = embedding_started.elapsed();
     if !texts_to_embed.is_empty() {
@@ -1110,7 +1238,7 @@ fn chunk_and_embed_note(
     let sqlite_started = Instant::now();
     replace_chunks_for_note(
         tx,
-        slug,
+        &slug,
         &rows,
         tags_json.as_deref(),
         aliases_json.as_deref(),
@@ -1124,8 +1252,8 @@ fn chunk_and_embed_note(
         embedding_padded_tokens,
         embedding_input_token_lengths,
         embedding_call_durations,
-        chunk_measurements: embedded_chunk_measurements,
-        pipeline: pipeline_started.elapsed(),
+        chunk_measurements,
+        pipeline: pipeline_started.elapsed() + chunking_elapsed + vector_reuse_elapsed,
         chunking: chunking_elapsed,
         vector_reuse: vector_reuse_elapsed,
         embedding: embedding_elapsed,
@@ -1287,7 +1415,7 @@ mod chunk_integration_tests {
 
     use super::{
         estimated_remaining, format_count, format_elapsed, format_eta, format_note_count,
-        progress_log_delay,
+        indexing_progress_message, progress_log_delay,
     };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
@@ -1603,13 +1731,36 @@ mod chunk_integration_tests {
     }
 
     #[test]
-    fn remaining_time_is_extrapolated_from_processed_notes() {
+    fn remaining_time_is_extrapolated_from_processed_tokens() {
         assert_eq!(
-            estimated_remaining(Duration::from_secs(30), 25, 100),
+            estimated_remaining(Duration::from_secs(30), 25_000, 100_000),
             Some(Duration::from_secs(90))
         );
-        assert_eq!(estimated_remaining(Duration::from_secs(30), 0, 100), None);
-        assert_eq!(estimated_remaining(Duration::from_secs(30), 100, 100), None);
+        assert_eq!(
+            estimated_remaining(Duration::from_secs(30), 0, 100_000),
+            None
+        );
+        assert_eq!(
+            estimated_remaining(Duration::from_secs(30), 100_000, 100_000),
+            None
+        );
+    }
+
+    #[test]
+    fn progress_message_keeps_note_counts_but_percent_and_eta_follow_tokens() {
+        assert_eq!(
+            indexing_progress_message(
+                45,
+                309,
+                80,
+                573,
+                50_000,
+                247_202,
+                Duration::from_secs(60),
+                0,
+            ),
+            "Indexing: 45 of 309 notes — 80 of 573 chunks — 20% of embedding work — about 4 minutes remaining"
+        );
     }
 
     #[test]

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -1,5 +1,9 @@
 use std::collections::HashSet;
 use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use rusqlite::{OptionalExtension, Transaction, params};
 
@@ -28,6 +32,9 @@ pub enum UpsertOutcome {
     Unchanged,
 }
 
+const FIRST_PROGRESS_LOG_AFTER: Duration = Duration::from_secs(10);
+const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
 impl SqliteCache {
     pub fn replace_from_index_with_embedder(
         &self,
@@ -49,61 +56,88 @@ impl SqliteCache {
             .transaction()
             .map_err(|e| format!("failed to start SQLite cache refresh: {e}"))?;
 
-        for cached_path in cached_relative_paths(&tx)? {
+        let cached_paths = cached_relative_paths(&tx)?;
+        let is_incremental_refresh = !cached_paths.is_empty();
+        for cached_path in cached_paths {
             if !current_paths.contains(&cached_path) {
                 delete_note_by_relative_path(&tx, &cached_path)?;
             }
         }
 
-        let started_at = std::time::Instant::now();
+        let started_at = Instant::now();
+        let total_notes = entries.len();
         tracing::info!(
-            notes = entries.len(),
-            "Indexing vault: chunking and embedding"
+            "Preparing search index for {}…",
+            format_note_count(total_notes)
         );
         let mut chunks_embedded: usize = 0;
         let mut chunks_reused: usize = 0;
         let mut per_note_failures: usize = 0;
+        let mut notes_changed: usize = 0;
+        let mut notes_unchanged: usize = 0;
+        let mut metrics = IndexingMetrics::default();
+        let (progress, stop_heartbeat, heartbeat) =
+            start_indexing_heartbeat(total_notes, started_at);
 
-        for entry in &entries {
-            if let UpsertOutcome::Wrote { slug, content } = upsert_note_if_changed(&tx, entry, now)?
-            {
-                match chunk_and_embed_note(&tx, &slug, &content, embedder) {
-                    Ok(stats) => {
-                        chunks_embedded += stats.embedded;
-                        chunks_reused += stats.reused;
+        let indexing_result = (|| -> Result<(), String> {
+            for (position, entry) in entries.iter().enumerate() {
+                let note_sync_started = Instant::now();
+                let upsert_outcome = upsert_note_if_changed(&tx, entry, now)?;
+                metrics.note_sync += note_sync_started.elapsed();
+                match upsert_outcome {
+                    UpsertOutcome::Wrote { slug, content } => {
+                        match chunk_and_embed_note(&tx, &slug, &content, embedder) {
+                            Ok(stats) => {
+                                notes_changed += 1;
+                                chunks_embedded += stats.embedded;
+                                chunks_reused += stats.reused;
+                                metrics.record_chunk_stats(&stats);
+                            }
+                            Err(e) => {
+                                per_note_failures += 1;
+                                progress
+                                    .failures
+                                    .store(per_note_failures, Ordering::Relaxed);
+                                tracing::warn!(slug = %slug, error = %e, "Per-note embedding failed; marking note for re-embed on next reindex");
+                                // The notes row was just written with the new content_hash,
+                                // but chunk/vector tables are now stale (or empty for a new
+                                // note). Change-detection keys off content_hash, so without
+                                // this the note would look Unchanged forever and never be
+                                // re-chunked. Invalidate the stored hash so the next reindex
+                                // re-processes the note once the embedder recovers.
+                                invalidate_note_content_hash(&tx, &slug)?;
+                            }
+                        }
                     }
-                    Err(e) => {
-                        per_note_failures += 1;
-                        tracing::warn!(slug = %slug, error = %e, "Per-note embedding failed; marking note for re-embed on next reindex");
-                        // The notes row was just written with the new content_hash,
-                        // but chunk/vector tables are now stale (or empty for a new
-                        // note). Change-detection keys off content_hash, so without
-                        // this the note would look Unchanged forever and never be
-                        // re-chunked. Invalidate the stored hash so the next reindex
-                        // re-processes the note once the embedder recovers.
-                        invalidate_note_content_hash(&tx, &slug)?;
-                    }
+                    UpsertOutcome::Unchanged => notes_unchanged += 1,
                 }
+
+                progress
+                    .notes_processed
+                    .store(position + 1, Ordering::Relaxed);
             }
+            Ok(())
+        })();
+
+        let _ = stop_heartbeat.send(());
+        if heartbeat.join().is_err() {
+            tracing::warn!("Indexing progress heartbeat stopped unexpectedly");
         }
+        indexing_result?;
 
-        tracing::info!(
-            notes = entries.len(),
-            chunks_embedded,
-            chunks_reused,
-            per_note_failures,
-            elapsed_ms = started_at.elapsed().as_millis(),
-            "Indexing complete"
-        );
-
+        tracing::info!("Updating links between notes…");
+        let links_started = Instant::now();
         rebuild_links(&tx, index, &entries)?;
+        metrics.link_rebuild = links_started.elapsed();
         let removed = delete_orphan_vectors(&tx)?;
         if removed > 0 {
             tracing::debug!(removed, "Swept orphan chunk vectors");
         }
 
+        let commit_started = Instant::now();
         tx.commit()
             .map_err(|e| format!("failed to commit SQLite cache refresh: {e}"))?;
+        metrics.commit = commit_started.elapsed();
 
         // Release the writer lock before set_metadata re-acquires it, otherwise
         // this self-deadlocks (the guard `conn` still holds the same Mutex).
@@ -112,6 +146,30 @@ impl SqliteCache {
         // Record which model produced these vectors so a future build with a
         // different model triggers reset_if_embedder_changed above.
         self.set_metadata("embedder_id", &embedder.identity())?;
+
+        let elapsed = started_at.elapsed();
+        let failure_summary = if per_note_failures == 0 {
+            String::new()
+        } else {
+            format!(", {} failed", format_count(per_note_failures))
+        };
+        let changed_action = if is_incremental_refresh {
+            "updated"
+        } else {
+            "indexed"
+        };
+        tracing::info!(
+            chunks_embedded,
+            chunks_reused,
+            "Search index ready: {} checked, {} {}, {} unchanged{} in {}",
+            format_note_count(total_notes),
+            format_count(notes_changed),
+            changed_action,
+            format_count(notes_unchanged),
+            failure_summary,
+            format_elapsed(elapsed),
+        );
+        log_indexing_performance(&metrics, total_notes, notes_changed, elapsed);
         Ok(())
     }
 
@@ -127,6 +185,223 @@ impl SqliteCache {
         self.set_metadata("embedder_id", embedder_id)?;
         self.set_metadata("build_duration_secs", &format!("{secs:.3}"))?;
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct IndexingMetrics {
+    note_sync: Duration,
+    chunking: Duration,
+    chunk_pipeline: Duration,
+    vector_reuse: Duration,
+    embedding: Duration,
+    sqlite_chunk_write: Duration,
+    link_rebuild: Duration,
+    commit: Duration,
+    chunks_total: usize,
+    embedder_calls: usize,
+    embedding_input_bytes: usize,
+}
+
+impl IndexingMetrics {
+    fn record_chunk_stats(&mut self, stats: &ChunkStats) {
+        self.chunking += stats.chunking;
+        self.chunk_pipeline += stats.pipeline;
+        self.vector_reuse += stats.vector_reuse;
+        self.embedding += stats.embedding;
+        self.sqlite_chunk_write += stats.sqlite_write;
+        self.chunks_total += stats.embedded + stats.reused;
+        self.embedder_calls += stats.embedder_calls;
+        self.embedding_input_bytes += stats.embedding_input_bytes;
+    }
+}
+
+fn log_indexing_performance(
+    metrics: &IndexingMetrics,
+    notes_total: usize,
+    notes_changed: usize,
+    elapsed: Duration,
+) {
+    let elapsed_seconds = elapsed.as_secs_f64();
+    let embedding_share_percent = if elapsed_seconds > 0.0 {
+        metrics.embedding.as_secs_f64() / elapsed_seconds * 100.0
+    } else {
+        0.0
+    };
+    let chunks_per_second = if elapsed_seconds > 0.0 {
+        metrics.chunks_total as f64 / elapsed_seconds
+    } else {
+        0.0
+    };
+
+    tracing::debug!(
+        notes_total,
+        notes_changed,
+        chunks_total = metrics.chunks_total,
+        embedder_calls = metrics.embedder_calls,
+        embedding_input_bytes = metrics.embedding_input_bytes,
+        note_sync_ms = duration_ms(metrics.note_sync),
+        chunking_ms = duration_ms(metrics.chunking),
+        chunk_pipeline_ms = duration_ms(metrics.chunk_pipeline),
+        vector_reuse_ms = duration_ms(metrics.vector_reuse),
+        embedding_ms = duration_ms(metrics.embedding),
+        sqlite_chunk_write_ms = duration_ms(metrics.sqlite_chunk_write),
+        link_rebuild_ms = duration_ms(metrics.link_rebuild),
+        commit_ms = duration_ms(metrics.commit),
+        total_ms = duration_ms(elapsed),
+        embedding_share_percent,
+        chunks_per_second,
+        "Indexing performance summary"
+    );
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+#[derive(Default)]
+struct IndexingProgress {
+    notes_processed: AtomicUsize,
+    failures: AtomicUsize,
+}
+
+fn start_indexing_heartbeat(
+    total_notes: usize,
+    started_at: Instant,
+) -> (
+    Arc<IndexingProgress>,
+    mpsc::Sender<()>,
+    thread::JoinHandle<()>,
+) {
+    let progress = Arc::new(IndexingProgress::default());
+    let heartbeat_progress = progress.clone();
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let heartbeat = thread::spawn(move || {
+        let mut has_logged = false;
+        loop {
+            match stop_rx.recv_timeout(progress_log_delay(has_logged)) {
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    log_indexing_progress(
+                        heartbeat_progress.notes_processed.load(Ordering::Relaxed),
+                        total_notes,
+                        started_at.elapsed(),
+                        heartbeat_progress.failures.load(Ordering::Relaxed),
+                    );
+                    has_logged = true;
+                }
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    });
+    (progress, stop_tx, heartbeat)
+}
+
+fn progress_log_delay(has_logged: bool) -> Duration {
+    if has_logged {
+        PROGRESS_LOG_INTERVAL
+    } else {
+        FIRST_PROGRESS_LOG_AFTER
+    }
+}
+
+fn estimated_remaining(
+    elapsed: Duration,
+    notes_processed: usize,
+    total_notes: usize,
+) -> Option<Duration> {
+    if notes_processed == 0 || notes_processed >= total_notes {
+        return None;
+    }
+    let notes_remaining = total_notes - notes_processed;
+    Some(elapsed.mul_f64(notes_remaining as f64 / notes_processed as f64))
+}
+
+fn log_indexing_progress(
+    notes_processed: usize,
+    total_notes: usize,
+    elapsed: Duration,
+    failures: usize,
+) {
+    let notes_remaining = total_notes.saturating_sub(notes_processed);
+    let percent = notes_processed.saturating_mul(100) / total_notes.max(1);
+    let eta = estimated_remaining(elapsed, notes_processed, total_notes)
+        .map(format_eta)
+        .unwrap_or_else(|| "estimating time remaining…".to_string());
+    let failure_summary = if failures == 0 {
+        String::new()
+    } else {
+        format!(" — {} failed", format_count(failures))
+    };
+
+    tracing::info!(
+        "Indexing notes: {} of {} ({}%) — {} left — {}{}",
+        format_count(notes_processed),
+        format_count(total_notes),
+        percent,
+        format_count(notes_remaining),
+        eta,
+        failure_summary,
+    );
+}
+
+fn format_count(value: usize) -> String {
+    let digits = value.to_string();
+    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
+    for (position, character) in digits.chars().enumerate() {
+        if position > 0 && (digits.len() - position) % 3 == 0 {
+            formatted.push(',');
+        }
+        formatted.push(character);
+    }
+    formatted
+}
+
+fn format_note_count(value: usize) -> String {
+    format!(
+        "{} {}",
+        format_count(value),
+        if value == 1 { "note" } else { "notes" }
+    )
+}
+
+fn format_eta(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds < 10 {
+        "less than 10 seconds remaining".to_string()
+    } else if seconds < 60 {
+        format!("about {seconds} seconds remaining")
+    } else if seconds < 3_600 {
+        let minutes = seconds.div_ceil(60);
+        format!("about {minutes} {} remaining", pluralize(minutes, "minute"))
+    } else {
+        let hours = seconds / 3_600;
+        let minutes = (seconds % 3_600) / 60;
+        if minutes == 0 {
+            format!("about {hours} {} remaining", pluralize(hours, "hour"))
+        } else {
+            format!("about {hours}h {minutes}m remaining")
+        }
+    }
+}
+
+fn format_elapsed(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds == 0 {
+        "less than 1s".to_string()
+    } else if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3_600 {
+        format!("{}m {}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {}m", seconds / 3_600, (seconds % 3_600) / 60)
+    }
+}
+
+fn pluralize(value: u64, singular: &str) -> String {
+    if value == 1 {
+        singular.to_string()
+    } else {
+        format!("{singular}s")
     }
 }
 
@@ -490,6 +765,13 @@ pub struct ChunkStats {
     pub embedded: usize,
     #[allow(dead_code)]
     pub reused: usize,
+    pub embedder_calls: usize,
+    pub embedding_input_bytes: usize,
+    pub pipeline: Duration,
+    pub chunking: Duration,
+    pub vector_reuse: Duration,
+    pub embedding: Duration,
+    pub sqlite_write: Duration,
 }
 
 fn chunk_and_embed_note(
@@ -498,18 +780,31 @@ fn chunk_and_embed_note(
     content: &str,
     embedder: &dyn Embedder,
 ) -> Result<ChunkStats, String> {
+    let pipeline_started = Instant::now();
+    let chunking_started = Instant::now();
     let tokenizer = embedder.tokenizer();
     let chunking = chunk_note(content, tokenizer, ChunkOptions::default());
+    let chunking_elapsed = chunking_started.elapsed();
     if chunking.chunks.is_empty() {
+        let sqlite_started = Instant::now();
         replace_chunks_for_note(tx, slug, &[], None, None)?;
         return Ok(ChunkStats {
             embedded: 0,
             reused: 0,
+            embedder_calls: 0,
+            embedding_input_bytes: 0,
+            pipeline: pipeline_started.elapsed(),
+            chunking: chunking_elapsed,
+            vector_reuse: Duration::ZERO,
+            embedding: Duration::ZERO,
+            sqlite_write: sqlite_started.elapsed(),
         });
     }
 
+    let reuse_started = Instant::now();
     let existing = existing_chunk_hashes(tx, slug)?;
     let preserved = preserve_existing_vectors(tx, slug, &chunking.chunks, &existing)?;
+    let vector_reuse_elapsed = reuse_started.elapsed();
 
     let doc_prefix = embedder.doc_prefix();
     let mut texts_to_embed: Vec<String> = Vec::new();
@@ -530,11 +825,14 @@ fn chunk_and_embed_note(
         );
     }
 
+    let embedding_input_bytes = texts_to_embed.iter().map(String::len).sum();
+    let embedding_started = Instant::now();
     let new_vectors = if texts_to_embed.is_empty() {
         Vec::new()
     } else {
         embedder.embed(&texts_to_embed)?
     };
+    let embedding_elapsed = embedding_started.elapsed();
 
     let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(chunking.chunks.len());
     let mut need_new: std::collections::HashSet<usize> =
@@ -562,6 +860,7 @@ fn chunk_and_embed_note(
         .map(|(chunk, vector)| ChunkRow { chunk, vector })
         .collect();
 
+    let sqlite_started = Instant::now();
     replace_chunks_for_note(
         tx,
         slug,
@@ -572,6 +871,13 @@ fn chunk_and_embed_note(
     Ok(ChunkStats {
         embedded: indices_needing_embed.len(),
         reused: chunking.chunks.len() - indices_needing_embed.len(),
+        embedder_calls: usize::from(!texts_to_embed.is_empty()),
+        embedding_input_bytes,
+        pipeline: pipeline_started.elapsed(),
+        chunking: chunking_elapsed,
+        vector_reuse: vector_reuse_elapsed,
+        embedding: embedding_elapsed,
+        sqlite_write: sqlite_started.elapsed(),
     })
 }
 
@@ -679,9 +985,14 @@ mod tests {
 #[cfg(test)]
 mod chunk_integration_tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use tempfile::TempDir;
 
+    use super::{
+        estimated_remaining, format_count, format_elapsed, format_eta, format_note_count,
+        progress_log_delay,
+    };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
     use crate::vault::VaultIndex;
@@ -935,5 +1246,37 @@ mod chunk_integration_tests {
             total_vectors, total_chunks,
             "no orphan vectors after delete"
         );
+    }
+
+    #[test]
+    fn progress_logging_starts_after_ten_seconds_then_repeats_each_minute() {
+        assert_eq!(progress_log_delay(false), Duration::from_secs(10));
+        assert_eq!(progress_log_delay(true), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn remaining_time_is_extrapolated_from_processed_notes() {
+        assert_eq!(
+            estimated_remaining(Duration::from_secs(30), 25, 100),
+            Some(Duration::from_secs(90))
+        );
+        assert_eq!(estimated_remaining(Duration::from_secs(30), 0, 100), None);
+        assert_eq!(estimated_remaining(Duration::from_secs(30), 100, 100), None);
+    }
+
+    #[test]
+    fn progress_values_are_formatted_for_people() {
+        assert_eq!(format_count(12_481), "12,481");
+        assert_eq!(format_note_count(1), "1 note");
+        assert_eq!(format_note_count(12_481), "12,481 notes");
+        assert_eq!(
+            format_eta(Duration::from_secs(8)),
+            "less than 10 seconds remaining"
+        );
+        assert_eq!(
+            format_eta(Duration::from_secs(125)),
+            "about 3 minutes remaining"
+        );
+        assert_eq!(format_elapsed(Duration::from_secs(166)), "2m 46s");
     }
 }

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
@@ -65,6 +66,7 @@ impl SqliteCache {
         }
 
         let started_at = Instant::now();
+        let process_cpu_started = process_cpu_time();
         let total_notes = entries.len();
         tracing::info!(
             "Preparing search index for {}…",
@@ -169,7 +171,16 @@ impl SqliteCache {
             failure_summary,
             format_elapsed(elapsed),
         );
-        log_indexing_performance(&metrics, total_notes, notes_changed, elapsed);
+        let process_cpu_elapsed = process_cpu_started
+            .zip(process_cpu_time())
+            .and_then(|(start, end)| end.checked_sub(start));
+        log_indexing_performance(
+            &metrics,
+            total_notes,
+            notes_changed,
+            elapsed,
+            process_cpu_elapsed,
+        );
         Ok(())
     }
 
@@ -201,6 +212,17 @@ struct IndexingMetrics {
     chunks_total: usize,
     embedder_calls: usize,
     embedding_input_bytes: usize,
+    embedding_input_tokens: usize,
+    embedding_padded_tokens: usize,
+    embedding_input_token_lengths: Vec<usize>,
+    embedding_call_input_counts: Vec<usize>,
+    embedding_call_token_counts: Vec<usize>,
+    embedding_call_padded_token_counts: Vec<usize>,
+    embedding_call_durations: Vec<Duration>,
+    unique_chunk_hashes: HashSet<String>,
+    duplicate_chunks: usize,
+    duplicate_input_bytes: usize,
+    duplicate_input_tokens: usize,
 }
 
 impl IndexingMetrics {
@@ -213,6 +235,29 @@ impl IndexingMetrics {
         self.chunks_total += stats.embedded + stats.reused;
         self.embedder_calls += stats.embedder_calls;
         self.embedding_input_bytes += stats.embedding_input_bytes;
+        self.embedding_input_tokens += stats.embedding_input_tokens;
+        self.embedding_padded_tokens += stats.embedding_padded_tokens;
+        self.embedding_input_token_lengths
+            .extend(stats.embedding_input_token_lengths.iter().copied());
+        if stats.embedder_calls > 0 {
+            self.embedding_call_input_counts.push(stats.embedded);
+            self.embedding_call_token_counts
+                .push(stats.embedding_input_tokens);
+            self.embedding_call_padded_token_counts
+                .push(stats.embedding_padded_tokens);
+            self.embedding_call_durations.push(stats.embedding);
+        }
+        for chunk in &stats.chunk_measurements {
+            self.record_chunk_measurement(chunk);
+        }
+    }
+
+    fn record_chunk_measurement(&mut self, chunk: &ChunkMeasurement) {
+        if !self.unique_chunk_hashes.insert(chunk.content_hash.clone()) {
+            self.duplicate_chunks += 1;
+            self.duplicate_input_bytes += chunk.input_bytes;
+            self.duplicate_input_tokens += chunk.input_tokens;
+        }
     }
 }
 
@@ -221,6 +266,7 @@ fn log_indexing_performance(
     notes_total: usize,
     notes_changed: usize,
     elapsed: Duration,
+    process_cpu_elapsed: Option<Duration>,
 ) {
     let elapsed_seconds = elapsed.as_secs_f64();
     let embedding_share_percent = if elapsed_seconds > 0.0 {
@@ -233,6 +279,24 @@ fn log_indexing_performance(
     } else {
         0.0
     };
+    let process_cpu_ms = process_cpu_elapsed.map(duration_ms).unwrap_or(-1.0);
+    let process_cpu_utilization_percent = process_cpu_elapsed
+        .filter(|_| elapsed_seconds > 0.0)
+        .map(|cpu| cpu.as_secs_f64() / elapsed_seconds * 100.0)
+        .unwrap_or(-1.0);
+    let duplicate_token_share_percent = if metrics.embedding_input_tokens > 0 {
+        metrics.duplicate_input_tokens as f64 / metrics.embedding_input_tokens as f64 * 100.0
+    } else {
+        0.0
+    };
+    let padding_tokens = metrics
+        .embedding_padded_tokens
+        .saturating_sub(metrics.embedding_input_tokens);
+    let padding_token_share_percent = if metrics.embedding_padded_tokens > 0 {
+        padding_tokens as f64 / metrics.embedding_padded_tokens as f64 * 100.0
+    } else {
+        0.0
+    };
 
     tracing::debug!(
         notes_total,
@@ -240,6 +304,62 @@ fn log_indexing_performance(
         chunks_total = metrics.chunks_total,
         embedder_calls = metrics.embedder_calls,
         embedding_input_bytes = metrics.embedding_input_bytes,
+        embedding_input_tokens = metrics.embedding_input_tokens,
+        embedding_padded_tokens = metrics.embedding_padded_tokens,
+        padding_tokens,
+        padding_token_share_percent,
+        input_tokens_p50 = percentile_usize(&metrics.embedding_input_token_lengths, 50),
+        input_tokens_p95 = percentile_usize(&metrics.embedding_input_token_lengths, 95),
+        input_tokens_p99 = percentile_usize(&metrics.embedding_input_token_lengths, 99),
+        input_tokens_max = metrics
+            .embedding_input_token_lengths
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0),
+        inputs_at_512_token_limit = metrics
+            .embedding_input_token_lengths
+            .iter()
+            .filter(|tokens| **tokens == 512)
+            .count(),
+        call_inputs_p50 = percentile_usize(&metrics.embedding_call_input_counts, 50),
+        call_inputs_p95 = percentile_usize(&metrics.embedding_call_input_counts, 95),
+        call_inputs_max = metrics
+            .embedding_call_input_counts
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0),
+        call_tokens_p50 = percentile_usize(&metrics.embedding_call_token_counts, 50),
+        call_tokens_p95 = percentile_usize(&metrics.embedding_call_token_counts, 95),
+        call_tokens_max = metrics
+            .embedding_call_token_counts
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0),
+        call_padded_tokens_p50 = percentile_usize(&metrics.embedding_call_padded_token_counts, 50),
+        call_padded_tokens_p95 = percentile_usize(&metrics.embedding_call_padded_token_counts, 95),
+        call_padded_tokens_max = metrics
+            .embedding_call_padded_token_counts
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0),
+        call_duration_ms_p50 = percentile_duration_ms(&metrics.embedding_call_durations, 50),
+        call_duration_ms_p95 = percentile_duration_ms(&metrics.embedding_call_durations, 95),
+        call_duration_ms_max = metrics
+            .embedding_call_durations
+            .iter()
+            .copied()
+            .max()
+            .map(duration_ms)
+            .unwrap_or(0.0),
+        unique_chunk_hashes = metrics.unique_chunk_hashes.len(),
+        duplicate_chunks = metrics.duplicate_chunks,
+        duplicate_input_bytes = metrics.duplicate_input_bytes,
+        duplicate_input_tokens = metrics.duplicate_input_tokens,
+        duplicate_token_share_percent,
         note_sync_ms = duration_ms(metrics.note_sync),
         chunking_ms = duration_ms(metrics.chunking),
         chunk_pipeline_ms = duration_ms(metrics.chunk_pipeline),
@@ -251,8 +371,49 @@ fn log_indexing_performance(
         total_ms = duration_ms(elapsed),
         embedding_share_percent,
         chunks_per_second,
+        process_cpu_ms,
+        process_cpu_utilization_percent,
         "Indexing performance summary"
     );
+}
+
+fn percentile_usize(values: &[usize], percentile: usize) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let index = percentile_index(sorted.len(), percentile);
+    sorted[index]
+}
+
+fn percentile_duration_ms(values: &[Duration], percentile: usize) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let index = percentile_index(sorted.len(), percentile);
+    duration_ms(sorted[index])
+}
+
+fn percentile_index(len: usize, percentile: usize) -> usize {
+    let rank = len.saturating_mul(percentile.min(100)).div_ceil(100);
+    rank.saturating_sub(1).min(len - 1)
+}
+
+fn process_cpu_time() -> Option<Duration> {
+    let mut usage = MaybeUninit::<libc::rusage>::uninit();
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    let usage = unsafe { usage.assume_init() };
+    timeval_duration(usage.ru_utime).checked_add(timeval_duration(usage.ru_stime))
+}
+
+fn timeval_duration(value: libc::timeval) -> Duration {
+    Duration::from_secs(value.tv_sec.max(0) as u64)
+        + Duration::from_micros(value.tv_usec.max(0) as u64)
 }
 
 fn duration_ms(duration: Duration) -> f64 {
@@ -767,11 +928,22 @@ pub struct ChunkStats {
     pub reused: usize,
     pub embedder_calls: usize,
     pub embedding_input_bytes: usize,
+    pub embedding_input_tokens: usize,
+    pub embedding_padded_tokens: usize,
+    pub embedding_input_token_lengths: Vec<usize>,
+    chunk_measurements: Vec<ChunkMeasurement>,
     pub pipeline: Duration,
     pub chunking: Duration,
     pub vector_reuse: Duration,
     pub embedding: Duration,
     pub sqlite_write: Duration,
+}
+
+#[derive(Clone)]
+struct ChunkMeasurement {
+    content_hash: String,
+    input_bytes: usize,
+    input_tokens: usize,
 }
 
 fn chunk_and_embed_note(
@@ -783,7 +955,7 @@ fn chunk_and_embed_note(
     let pipeline_started = Instant::now();
     let chunking_started = Instant::now();
     let tokenizer = embedder.tokenizer();
-    let chunking = chunk_note(content, tokenizer, ChunkOptions::default());
+    let chunking = chunk_note(content, tokenizer.clone(), ChunkOptions::default());
     let chunking_elapsed = chunking_started.elapsed();
     if chunking.chunks.is_empty() {
         let sqlite_started = Instant::now();
@@ -793,6 +965,10 @@ fn chunk_and_embed_note(
             reused: 0,
             embedder_calls: 0,
             embedding_input_bytes: 0,
+            embedding_input_tokens: 0,
+            embedding_padded_tokens: 0,
+            embedding_input_token_lengths: Vec::new(),
+            chunk_measurements: Vec::new(),
             pipeline: pipeline_started.elapsed(),
             chunking: chunking_elapsed,
             vector_reuse: Duration::ZERO,
@@ -807,6 +983,23 @@ fn chunk_and_embed_note(
     let vector_reuse_elapsed = reuse_started.elapsed();
 
     let doc_prefix = embedder.doc_prefix();
+    let chunk_measurements = chunking
+        .chunks
+        .iter()
+        .map(|chunk| {
+            let input = format!("{doc_prefix}{}", chunk.content);
+            let input_tokens = tokenizer
+                .encode(input.as_str(), true)
+                .map_err(|error| format!("failed measuring tokens for '{slug}': {error}"))?
+                .get_ids()
+                .len();
+            Ok(ChunkMeasurement {
+                content_hash: chunk.content_hash.clone(),
+                input_bytes: input.len(),
+                input_tokens,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
     let mut texts_to_embed: Vec<String> = Vec::new();
     let mut indices_needing_embed: Vec<usize> = Vec::new();
     for (idx, chunk) in chunking.chunks.iter().enumerate() {
@@ -826,6 +1019,21 @@ fn chunk_and_embed_note(
     }
 
     let embedding_input_bytes = texts_to_embed.iter().map(String::len).sum();
+    let embedding_input_token_lengths: Vec<usize> = indices_needing_embed
+        .iter()
+        .map(|index| chunk_measurements[*index].input_tokens)
+        .collect();
+    let embedded_chunk_measurements: Vec<ChunkMeasurement> = indices_needing_embed
+        .iter()
+        .map(|index| chunk_measurements[*index].clone())
+        .collect();
+    let embedding_input_tokens = embedding_input_token_lengths.iter().sum();
+    let embedding_padded_tokens = embedding_input_token_lengths
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(0)
+        * embedding_input_token_lengths.len();
     let embedding_started = Instant::now();
     let new_vectors = if texts_to_embed.is_empty() {
         Vec::new()
@@ -833,6 +1041,34 @@ fn chunk_and_embed_note(
         embedder.embed(&texts_to_embed)?
     };
     let embedding_elapsed = embedding_started.elapsed();
+    if !texts_to_embed.is_empty() {
+        let tokens_per_second = if embedding_elapsed.is_zero() {
+            0.0
+        } else {
+            embedding_input_tokens as f64 / embedding_elapsed.as_secs_f64()
+        };
+        tracing::debug!(
+            slug,
+            inputs = texts_to_embed.len(),
+            input_bytes = embedding_input_bytes,
+            input_tokens = embedding_input_tokens,
+            padded_tokens = embedding_padded_tokens,
+            padding_tokens = embedding_padded_tokens.saturating_sub(embedding_input_tokens),
+            min_input_tokens = embedding_input_token_lengths
+                .iter()
+                .copied()
+                .min()
+                .unwrap_or(0),
+            max_input_tokens = embedding_input_token_lengths
+                .iter()
+                .copied()
+                .max()
+                .unwrap_or(0),
+            elapsed_ms = duration_ms(embedding_elapsed),
+            tokens_per_second,
+            "Embedding call performance"
+        );
+    }
 
     let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(chunking.chunks.len());
     let mut need_new: std::collections::HashSet<usize> =
@@ -873,6 +1109,10 @@ fn chunk_and_embed_note(
         reused: chunking.chunks.len() - indices_needing_embed.len(),
         embedder_calls: usize::from(!texts_to_embed.is_empty()),
         embedding_input_bytes,
+        embedding_input_tokens,
+        embedding_padded_tokens,
+        embedding_input_token_lengths,
+        chunk_measurements: embedded_chunk_measurements,
         pipeline: pipeline_started.elapsed(),
         chunking: chunking_elapsed,
         vector_reuse: vector_reuse_elapsed,
@@ -911,6 +1151,50 @@ mod tests {
     use crate::vault::VaultIndex;
     use std::sync::Arc;
     use tempfile::tempdir;
+
+    #[test]
+    fn performance_percentiles_use_nearest_rank() {
+        let values = [10, 20, 30, 40, 50];
+        assert_eq!(percentile_usize(&values, 50), 30);
+        assert_eq!(percentile_usize(&values, 95), 50);
+        assert_eq!(percentile_usize(&[], 95), 0);
+    }
+
+    #[test]
+    fn duplicate_measurements_count_only_repeated_embedding_inputs() {
+        let first = ChunkMeasurement {
+            content_hash: "same".to_string(),
+            input_bytes: 100,
+            input_tokens: 25,
+        };
+        let repeated = ChunkMeasurement {
+            content_hash: "same".to_string(),
+            input_bytes: 100,
+            input_tokens: 25,
+        };
+        let unique = ChunkMeasurement {
+            content_hash: "different".to_string(),
+            input_bytes: 80,
+            input_tokens: 20,
+        };
+        let mut metrics = IndexingMetrics::default();
+
+        metrics.record_chunk_measurement(&first);
+        metrics.record_chunk_measurement(&repeated);
+        metrics.record_chunk_measurement(&unique);
+
+        assert_eq!(metrics.unique_chunk_hashes.len(), 2);
+        assert_eq!(metrics.duplicate_chunks, 1);
+        assert_eq!(metrics.duplicate_input_bytes, 100);
+        assert_eq!(metrics.duplicate_input_tokens, 25);
+    }
+
+    #[test]
+    fn process_cpu_measurement_is_available_and_monotonic() {
+        let before = process_cpu_time().expect("process CPU time");
+        let after = process_cpu_time().expect("process CPU time");
+        assert!(after >= before);
+    }
 
     #[test]
     fn replace_from_index_stamps_embedder_id_and_build_duration() {

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -10,7 +10,7 @@ use rusqlite::{OptionalExtension, Transaction, params};
 use crate::cache::chunk_ops::{
     ChunkRow, delete_orphan_vectors, existing_chunk_hashes, replace_chunks_for_note,
 };
-use crate::chunk::{Chunk, ChunkOptions, chunk_note};
+use crate::chunk::{ChunkOptions, chunk_note};
 use crate::embed::Embedder;
 use crate::vault::{NoteEntry, VaultIndex, normalize_title};
 
@@ -34,7 +34,6 @@ pub enum UpsertOutcome {
 
 const FIRST_PROGRESS_LOG_AFTER: Duration = Duration::from_secs(10);
 const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(60);
-const EMBEDDING_BATCH_SIZE: usize = 32;
 
 impl SqliteCache {
     pub fn replace_from_index_with_embedder(
@@ -76,78 +75,46 @@ impl SqliteCache {
         let mut per_note_failures: usize = 0;
         let mut notes_changed: usize = 0;
         let mut notes_unchanged: usize = 0;
-        let mut notes_completed: usize = 0;
         let mut metrics = IndexingMetrics::default();
-        let mut prepared_notes = Vec::new();
-        let mut pending_embeddings = 0usize;
         let (progress, stop_heartbeat, heartbeat) =
             start_indexing_heartbeat(total_notes, started_at);
 
         let indexing_result = (|| -> Result<(), String> {
-            for entry in &entries {
+            for (position, entry) in entries.iter().enumerate() {
                 let note_sync_started = Instant::now();
                 let upsert_outcome = upsert_note_if_changed(&tx, entry, now)?;
                 metrics.note_sync += note_sync_started.elapsed();
                 match upsert_outcome {
                     UpsertOutcome::Wrote { slug, content } => {
-                        match prepare_note_for_embedding(&tx, &slug, &content, embedder) {
-                            Ok(prepared) => {
-                                metrics.record_prepared_note(&prepared);
-                                pending_embeddings += prepared.missing.len();
-                                prepared_notes.push(prepared);
-
-                                if pending_embeddings >= EMBEDDING_BATCH_SIZE {
-                                    let queued_notes = prepared_notes.len();
-                                    let outcome = flush_prepared_notes(
-                                        &tx,
-                                        &mut prepared_notes,
-                                        embedder,
-                                        &mut metrics,
-                                    )?;
-                                    notes_completed += queued_notes;
-                                    notes_changed += outcome.notes_succeeded;
-                                    per_note_failures += outcome.notes_failed;
-                                    chunks_embedded += outcome.chunks_embedded;
-                                    chunks_reused += outcome.chunks_reused;
-                                    pending_embeddings = 0;
-                                }
+                        match chunk_and_embed_note(&tx, &slug, &content, embedder) {
+                            Ok(stats) => {
+                                notes_changed += 1;
+                                chunks_embedded += stats.embedded;
+                                chunks_reused += stats.reused;
+                                metrics.record_chunk_stats(&stats);
                             }
                             Err(e) => {
                                 per_note_failures += 1;
-                                notes_completed += 1;
-                                mark_note_for_retry(&tx, &slug, &e)?;
+                                progress
+                                    .failures
+                                    .store(per_note_failures, Ordering::Relaxed);
+                                tracing::warn!(slug = %slug, error = %e, "Per-note embedding failed; marking note for re-embed on next reindex");
+                                // The notes row was just written with the new content_hash,
+                                // but chunk/vector tables are now stale (or empty for a new
+                                // note). Change-detection keys off content_hash, so without
+                                // this the note would look Unchanged forever and never be
+                                // re-chunked. Invalidate the stored hash so the next reindex
+                                // re-processes the note once the embedder recovers.
+                                invalidate_note_content_hash(&tx, &slug)?;
                             }
                         }
                     }
-                    UpsertOutcome::Unchanged => {
-                        notes_unchanged += 1;
-                        notes_completed += 1;
-                    }
+                    UpsertOutcome::Unchanged => notes_unchanged += 1,
                 }
 
                 progress
-                    .failures
-                    .store(per_note_failures, Ordering::Relaxed);
-                progress
                     .notes_processed
-                    .store(notes_completed, Ordering::Relaxed);
-            }
-
-            if !prepared_notes.is_empty() {
-                let queued_notes = prepared_notes.len();
-                let outcome =
-                    flush_prepared_notes(&tx, &mut prepared_notes, embedder, &mut metrics)?;
-                notes_completed += queued_notes;
-                notes_changed += outcome.notes_succeeded;
-                per_note_failures += outcome.notes_failed;
-                chunks_embedded += outcome.chunks_embedded;
-                chunks_reused += outcome.chunks_reused;
-                progress
-                    .failures
-                    .store(per_note_failures, Ordering::Relaxed);
-                progress
-                    .notes_processed
-                    .store(notes_completed, Ordering::Relaxed);
+                    .store(position + 1, Ordering::Relaxed);
             }
             Ok(())
         })();
@@ -237,11 +204,15 @@ struct IndexingMetrics {
 }
 
 impl IndexingMetrics {
-    fn record_prepared_note(&mut self, note: &PreparedNote) {
-        self.chunking += note.chunking;
-        self.chunk_pipeline += note.preparation;
-        self.vector_reuse += note.vector_reuse;
-        self.chunks_total += note.chunks.len();
+    fn record_chunk_stats(&mut self, stats: &ChunkStats) {
+        self.chunking += stats.chunking;
+        self.chunk_pipeline += stats.pipeline;
+        self.vector_reuse += stats.vector_reuse;
+        self.embedding += stats.embedding;
+        self.sqlite_chunk_write += stats.sqlite_write;
+        self.chunks_total += stats.embedded + stats.reused;
+        self.embedder_calls += stats.embedder_calls;
+        self.embedding_input_bytes += stats.embedding_input_bytes;
     }
 }
 
@@ -789,43 +760,46 @@ fn rebuild_links(
     Ok(())
 }
 
-struct MissingEmbedding {
-    chunk_index: usize,
-    text: String,
+pub struct ChunkStats {
+    #[allow(dead_code)]
+    pub embedded: usize,
+    #[allow(dead_code)]
+    pub reused: usize,
+    pub embedder_calls: usize,
+    pub embedding_input_bytes: usize,
+    pub pipeline: Duration,
+    pub chunking: Duration,
+    pub vector_reuse: Duration,
+    pub embedding: Duration,
+    pub sqlite_write: Duration,
 }
 
-struct PreparedNote {
-    slug: String,
-    chunks: Vec<Chunk>,
-    tags_json: Option<String>,
-    aliases_json: Option<String>,
-    vectors: Vec<Option<Vec<f32>>>,
-    missing: Vec<MissingEmbedding>,
-    failure: Option<String>,
-    preparation: Duration,
-    chunking: Duration,
-    vector_reuse: Duration,
-}
-
-#[derive(Default)]
-struct FlushOutcome {
-    notes_succeeded: usize,
-    notes_failed: usize,
-    chunks_embedded: usize,
-    chunks_reused: usize,
-}
-
-fn prepare_note_for_embedding(
+fn chunk_and_embed_note(
     tx: &Transaction<'_>,
     slug: &str,
     content: &str,
     embedder: &dyn Embedder,
-) -> Result<PreparedNote, String> {
-    let preparation_started = Instant::now();
+) -> Result<ChunkStats, String> {
+    let pipeline_started = Instant::now();
     let chunking_started = Instant::now();
     let tokenizer = embedder.tokenizer();
     let chunking = chunk_note(content, tokenizer, ChunkOptions::default());
     let chunking_elapsed = chunking_started.elapsed();
+    if chunking.chunks.is_empty() {
+        let sqlite_started = Instant::now();
+        replace_chunks_for_note(tx, slug, &[], None, None)?;
+        return Ok(ChunkStats {
+            embedded: 0,
+            reused: 0,
+            embedder_calls: 0,
+            embedding_input_bytes: 0,
+            pipeline: pipeline_started.elapsed(),
+            chunking: chunking_elapsed,
+            vector_reuse: Duration::ZERO,
+            embedding: Duration::ZERO,
+            sqlite_write: sqlite_started.elapsed(),
+        });
+    }
 
     let reuse_started = Instant::now();
     let existing = existing_chunk_hashes(tx, slug)?;
@@ -833,208 +807,78 @@ fn prepare_note_for_embedding(
     let vector_reuse_elapsed = reuse_started.elapsed();
 
     let doc_prefix = embedder.doc_prefix();
-    let mut vectors = Vec::with_capacity(chunking.chunks.len());
-    let mut missing = Vec::new();
+    let mut texts_to_embed: Vec<String> = Vec::new();
+    let mut indices_needing_embed: Vec<usize> = Vec::new();
     for (idx, chunk) in chunking.chunks.iter().enumerate() {
-        if let Some(vector) = preserved.get(&chunk.content_hash) {
-            vectors.push(Some(vector.clone()));
+        if !preserved.contains_key(&chunk.content_hash) {
+            texts_to_embed.push(format!("{doc_prefix}{}", chunk.content));
+            indices_needing_embed.push(idx);
+        }
+    }
+
+    if !texts_to_embed.is_empty() {
+        tracing::debug!(
+            slug,
+            new = texts_to_embed.len(),
+            reused = chunking.chunks.len() - texts_to_embed.len(),
+            "Embedding chunks for note"
+        );
+    }
+
+    let embedding_input_bytes = texts_to_embed.iter().map(String::len).sum();
+    let embedding_started = Instant::now();
+    let new_vectors = if texts_to_embed.is_empty() {
+        Vec::new()
+    } else {
+        embedder.embed(&texts_to_embed)?
+    };
+    let embedding_elapsed = embedding_started.elapsed();
+
+    let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(chunking.chunks.len());
+    let mut need_new: std::collections::HashSet<usize> =
+        indices_needing_embed.iter().copied().collect();
+    let mut new_iter = new_vectors.into_iter();
+    for (idx, chunk) in chunking.chunks.iter().enumerate() {
+        if need_new.remove(&idx) {
+            vectors.push(new_iter.next().ok_or("embedder returned too few vectors")?);
         } else {
-            vectors.push(None);
-            missing.push(MissingEmbedding {
-                chunk_index: idx,
-                text: format!("{doc_prefix}{}", chunk.content),
-            });
+            vectors.push(
+                preserved
+                    .get(&chunk.content_hash)
+                    .cloned()
+                    .ok_or("preserved vector missing for unchanged chunk")?,
+            );
         }
     }
 
     let tags_json = serde_json::to_string(&chunking.tags).ok();
     let aliases_json = serde_json::to_string(&chunking.aliases).ok();
-
-    Ok(PreparedNote {
-        slug: slug.to_string(),
-        chunks: chunking.chunks,
-        tags_json,
-        aliases_json,
-        vectors,
-        missing,
-        failure: None,
-        preparation: preparation_started.elapsed(),
-        chunking: chunking_elapsed,
-        vector_reuse: vector_reuse_elapsed,
-    })
-}
-
-fn flush_prepared_notes(
-    tx: &Transaction<'_>,
-    notes: &mut Vec<PreparedNote>,
-    embedder: &dyn Embedder,
-    metrics: &mut IndexingMetrics,
-) -> Result<FlushOutcome, String> {
-    let flush_started = Instant::now();
-    let work: Vec<(usize, usize)> = notes
-        .iter()
-        .enumerate()
-        .flat_map(|(note_index, note)| {
-            (0..note.missing.len()).map(move |missing_index| (note_index, missing_index))
-        })
-        .collect();
-
-    if !work.is_empty() {
-        tracing::debug!(
-            notes = notes.len(),
-            chunks = work.len(),
-            batch_size = EMBEDDING_BATCH_SIZE,
-            "Embedding prepared note batch"
-        );
-    }
-
-    let mut batch_error = None;
-    for batch in work.chunks(EMBEDDING_BATCH_SIZE) {
-        let texts: Vec<String> = batch
-            .iter()
-            .map(|(note_index, missing_index)| {
-                notes[*note_index].missing[*missing_index].text.clone()
-            })
-            .collect();
-        metrics.embedder_calls += 1;
-        metrics.embedding_input_bytes += texts.iter().map(String::len).sum::<usize>();
-        let embedding_started = Instant::now();
-        let result = embedder.embed(&texts);
-        metrics.embedding += embedding_started.elapsed();
-
-        match result {
-            Ok(vectors) if vectors.len() == batch.len() => {
-                for ((note_index, missing_index), vector) in batch.iter().copied().zip(vectors) {
-                    let chunk_index = notes[note_index].missing[missing_index].chunk_index;
-                    notes[note_index].vectors[chunk_index] = Some(vector);
-                }
-            }
-            Ok(vectors) => {
-                batch_error = Some(format!(
-                    "embedder returned {} vectors for {} inputs",
-                    vectors.len(),
-                    batch.len()
-                ));
-                break;
-            }
-            Err(error) => {
-                batch_error = Some(error);
-                break;
-            }
-        }
-    }
-
-    if let Some(error) = batch_error {
-        tracing::warn!(
-            error = %error,
-            "Cross-note embedding batch failed; retrying affected notes individually"
-        );
-        retry_incomplete_notes(notes, embedder, metrics);
-    }
-
-    let mut outcome = FlushOutcome::default();
-    for mut note in notes.drain(..) {
-        let embedded = note.missing.len();
-        let reused = note.chunks.len().saturating_sub(embedded);
-        let result = if let Some(error) = note.failure.take() {
-            Err(error)
-        } else {
-            write_prepared_note(tx, &mut note, metrics)
-        };
-
-        match result {
-            Ok(()) => {
-                outcome.notes_succeeded += 1;
-                outcome.chunks_embedded += embedded;
-                outcome.chunks_reused += reused;
-            }
-            Err(error) => {
-                outcome.notes_failed += 1;
-                mark_note_for_retry(tx, &note.slug, &error)?;
-            }
-        }
-    }
-    metrics.chunk_pipeline += flush_started.elapsed();
-    Ok(outcome)
-}
-
-fn retry_incomplete_notes(
-    notes: &mut [PreparedNote],
-    embedder: &dyn Embedder,
-    metrics: &mut IndexingMetrics,
-) {
-    for note in notes {
-        if note
-            .missing
-            .iter()
-            .all(|missing| note.vectors[missing.chunk_index].is_some())
-        {
-            continue;
-        }
-
-        let texts: Vec<String> = note
-            .missing
-            .iter()
-            .map(|missing| missing.text.clone())
-            .collect();
-        metrics.embedder_calls += 1;
-        metrics.embedding_input_bytes += texts.iter().map(String::len).sum::<usize>();
-        let embedding_started = Instant::now();
-        let result = embedder.embed(&texts);
-        metrics.embedding += embedding_started.elapsed();
-
-        match result {
-            Ok(vectors) if vectors.len() == note.missing.len() => {
-                for (missing, vector) in note.missing.iter().zip(vectors) {
-                    note.vectors[missing.chunk_index] = Some(vector);
-                }
-            }
-            Ok(vectors) => {
-                note.failure = Some(format!(
-                    "embedder returned {} vectors for {} inputs",
-                    vectors.len(),
-                    note.missing.len()
-                ));
-            }
-            Err(error) => note.failure = Some(error),
-        }
-    }
-}
-
-fn write_prepared_note(
-    tx: &Transaction<'_>,
-    note: &mut PreparedNote,
-    metrics: &mut IndexingMetrics,
-) -> Result<(), String> {
-    let vectors = note
-        .vectors
-        .drain(..)
-        .map(|vector| vector.ok_or_else(|| "embedding vector missing after batch".to_string()))
-        .collect::<Result<Vec<_>, _>>()?;
-    let rows: Vec<ChunkRow<'_>> = note
+    let rows: Vec<ChunkRow<'_>> = chunking
         .chunks
         .iter()
         .zip(vectors.iter())
         .map(|(chunk, vector)| ChunkRow { chunk, vector })
         .collect();
-    let sqlite_started = Instant::now();
-    let result = replace_chunks_for_note(
-        tx,
-        &note.slug,
-        &rows,
-        note.tags_json.as_deref(),
-        note.aliases_json.as_deref(),
-    );
-    metrics.sqlite_chunk_write += sqlite_started.elapsed();
-    result
-}
 
-fn mark_note_for_retry(tx: &Transaction<'_>, slug: &str, error: &str) -> Result<(), String> {
-    tracing::warn!(slug = %slug, error = %error, "Per-note embedding failed; marking note for re-embed on next reindex");
-    // The note row now carries the new content hash while its chunks are stale or
-    // absent. Clear the hash so the next refresh retries it instead of treating it
-    // as unchanged forever.
-    invalidate_note_content_hash(tx, slug)
+    let sqlite_started = Instant::now();
+    replace_chunks_for_note(
+        tx,
+        slug,
+        &rows,
+        tags_json.as_deref(),
+        aliases_json.as_deref(),
+    )?;
+    Ok(ChunkStats {
+        embedded: indices_needing_embed.len(),
+        reused: chunking.chunks.len() - indices_needing_embed.len(),
+        embedder_calls: usize::from(!texts_to_embed.is_empty()),
+        embedding_input_bytes,
+        pipeline: pipeline_started.elapsed(),
+        chunking: chunking_elapsed,
+        vector_reuse: vector_reuse_elapsed,
+        embedding: embedding_elapsed,
+        sqlite_write: sqlite_started.elapsed(),
+    })
 }
 
 fn preserve_existing_vectors(
@@ -1146,8 +990,8 @@ mod chunk_integration_tests {
     use tempfile::TempDir;
 
     use super::{
-        EMBEDDING_BATCH_SIZE, estimated_remaining, format_count, format_elapsed, format_eta,
-        format_note_count, progress_log_delay,
+        estimated_remaining, format_count, format_elapsed, format_eta, format_note_count,
+        progress_log_delay,
     };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
@@ -1320,55 +1164,6 @@ mod chunk_integration_tests {
             .query_row("SELECT COUNT(*) FROM chunk_vectors", [], |r| r.get(0))
             .expect("count");
         assert_eq!(vector_count, chunk_count);
-    }
-
-    #[test]
-    fn changed_notes_are_embedded_in_cross_note_batches_of_32() {
-        struct BatchRecordingEmbedder {
-            inner: StubEmbedder,
-            batch_sizes: std::sync::Mutex<Vec<usize>>,
-        }
-        impl Embedder for BatchRecordingEmbedder {
-            fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
-                self.batch_sizes
-                    .lock()
-                    .expect("batch sizes lock")
-                    .push(texts.len());
-                self.inner.embed(texts)
-            }
-            fn embedding_dim(&self) -> usize {
-                self.inner.embedding_dim()
-            }
-            fn tokenizer(&self) -> std::sync::Arc<tokenizers::Tokenizer> {
-                self.inner.tokenizer()
-            }
-        }
-
-        let dir = TempDir::new().expect("tempdir");
-        for index in 0..40 {
-            std::fs::write(
-                dir.path().join(format!("note-{index:02}.md")),
-                format!("# Note {index}\n\nA short body."),
-            )
-            .expect("write note");
-        }
-        let cache = SqliteCache::in_memory(384).expect("open");
-        let embedder = BatchRecordingEmbedder {
-            inner: StubEmbedder::new(384),
-            batch_sizes: std::sync::Mutex::new(Vec::new()),
-        };
-        let index = VaultIndex::build(dir.path()).expect("build");
-
-        cache
-            .replace_from_index_with_embedder(&index, &embedder)
-            .expect("replace");
-
-        assert_eq!(EMBEDDING_BATCH_SIZE, 32);
-        assert_eq!(
-            *embedder.batch_sizes.lock().expect("batch sizes lock"),
-            vec![32, 8],
-            "40 single-chunk notes should require one full batch and one final partial batch"
-        );
     }
 
     #[test]

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -240,12 +240,14 @@ impl IndexingMetrics {
         self.embedding_input_token_lengths
             .extend(stats.embedding_input_token_lengths.iter().copied());
         if stats.embedder_calls > 0 {
-            self.embedding_call_input_counts.push(stats.embedded);
+            self.embedding_call_input_counts
+                .extend(std::iter::repeat_n(1, stats.embedder_calls));
             self.embedding_call_token_counts
-                .push(stats.embedding_input_tokens);
+                .extend(stats.embedding_input_token_lengths.iter().copied());
             self.embedding_call_padded_token_counts
-                .push(stats.embedding_padded_tokens);
-            self.embedding_call_durations.push(stats.embedding);
+                .extend(stats.embedding_input_token_lengths.iter().copied());
+            self.embedding_call_durations
+                .extend(stats.embedding_call_durations.iter().copied());
         }
         for chunk in &stats.chunk_measurements {
             self.record_chunk_measurement(chunk);
@@ -931,6 +933,7 @@ pub struct ChunkStats {
     pub embedding_input_tokens: usize,
     pub embedding_padded_tokens: usize,
     pub embedding_input_token_lengths: Vec<usize>,
+    embedding_call_durations: Vec<Duration>,
     chunk_measurements: Vec<ChunkMeasurement>,
     pub pipeline: Duration,
     pub chunking: Duration,
@@ -968,6 +971,7 @@ fn chunk_and_embed_note(
             embedding_input_tokens: 0,
             embedding_padded_tokens: 0,
             embedding_input_token_lengths: Vec::new(),
+            embedding_call_durations: Vec::new(),
             chunk_measurements: Vec::new(),
             pipeline: pipeline_started.elapsed(),
             chunking: chunking_elapsed,
@@ -1027,19 +1031,25 @@ fn chunk_and_embed_note(
         .iter()
         .map(|index| chunk_measurements[*index].clone())
         .collect();
-    let embedding_input_tokens = embedding_input_token_lengths.iter().sum();
-    let embedding_padded_tokens = embedding_input_token_lengths
-        .iter()
-        .copied()
-        .max()
-        .unwrap_or(0)
-        * embedding_input_token_lengths.len();
+    let embedding_input_tokens: usize = embedding_input_token_lengths.iter().sum();
+    // Each chunk is embedded in its own call. This avoids BatchLongest padding
+    // short chunks to the longest sibling chunk in the same note.
+    let embedding_padded_tokens = embedding_input_tokens;
     let embedding_started = Instant::now();
-    let new_vectors = if texts_to_embed.is_empty() {
-        Vec::new()
-    } else {
-        embedder.embed(&texts_to_embed)?
-    };
+    let mut new_vectors = Vec::with_capacity(texts_to_embed.len());
+    let mut embedding_call_durations = Vec::with_capacity(texts_to_embed.len());
+    for text in &texts_to_embed {
+        let call_started = Instant::now();
+        let mut vectors = embedder.embed(std::slice::from_ref(text))?;
+        embedding_call_durations.push(call_started.elapsed());
+        if vectors.len() != 1 {
+            return Err(format!(
+                "embedder returned {} vectors for one input",
+                vectors.len()
+            ));
+        }
+        new_vectors.push(vectors.remove(0));
+    }
     let embedding_elapsed = embedding_started.elapsed();
     if !texts_to_embed.is_empty() {
         let tokens_per_second = if embedding_elapsed.is_zero() {
@@ -1066,7 +1076,8 @@ fn chunk_and_embed_note(
                 .unwrap_or(0),
             elapsed_ms = duration_ms(embedding_elapsed),
             tokens_per_second,
-            "Embedding call performance"
+            calls = texts_to_embed.len(),
+            "Embedding note performance"
         );
     }
 
@@ -1107,11 +1118,12 @@ fn chunk_and_embed_note(
     Ok(ChunkStats {
         embedded: indices_needing_embed.len(),
         reused: chunking.chunks.len() - indices_needing_embed.len(),
-        embedder_calls: usize::from(!texts_to_embed.is_empty()),
+        embedder_calls: texts_to_embed.len(),
         embedding_input_bytes,
         embedding_input_tokens,
         embedding_padded_tokens,
         embedding_input_token_lengths,
+        embedding_call_durations,
         chunk_measurements: embedded_chunk_measurements,
         pipeline: pipeline_started.elapsed(),
         chunking: chunking_elapsed,
@@ -1491,6 +1503,58 @@ mod chunk_integration_tests {
         assert_eq!(
             second_calls, first_calls,
             "unchanged note must not re-embed"
+        );
+    }
+
+    #[test]
+    fn new_chunks_are_embedded_one_per_call() {
+        struct BatchRecordingEmbedder {
+            inner: StubEmbedder,
+            calls: std::sync::atomic::AtomicUsize,
+            largest_batch: std::sync::atomic::AtomicUsize,
+        }
+        impl Embedder for BatchRecordingEmbedder {
+            fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.largest_batch
+                    .fetch_max(texts.len(), std::sync::atomic::Ordering::SeqCst);
+                self.inner.embed(texts)
+            }
+            fn embedding_dim(&self) -> usize {
+                self.inner.embedding_dim()
+            }
+            fn tokenizer(&self) -> std::sync::Arc<tokenizers::Tokenizer> {
+                self.inner.tokenizer()
+            }
+        }
+
+        let body = (0..1_700)
+            .map(|index| format!("word{index}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let dir = make_vault(&[("long.md", &body)]);
+        let cache = SqliteCache::in_memory(384).expect("open");
+        let embedder = BatchRecordingEmbedder {
+            inner: StubEmbedder::new(384),
+            calls: 0.into(),
+            largest_batch: 0.into(),
+        };
+        let index = VaultIndex::build(dir.path()).expect("build");
+
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("populate");
+
+        assert!(
+            embedder.calls.load(std::sync::atomic::Ordering::SeqCst) > 1,
+            "fixture must produce multiple chunks"
+        );
+        assert_eq!(
+            embedder
+                .largest_batch
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "indexing must avoid cross-chunk padding"
         );
     }
 

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -10,7 +10,7 @@ use rusqlite::{OptionalExtension, Transaction, params};
 use crate::cache::chunk_ops::{
     ChunkRow, delete_orphan_vectors, existing_chunk_hashes, replace_chunks_for_note,
 };
-use crate::chunk::{ChunkOptions, chunk_note};
+use crate::chunk::{Chunk, ChunkOptions, chunk_note};
 use crate::embed::Embedder;
 use crate::vault::{NoteEntry, VaultIndex, normalize_title};
 
@@ -34,6 +34,7 @@ pub enum UpsertOutcome {
 
 const FIRST_PROGRESS_LOG_AFTER: Duration = Duration::from_secs(10);
 const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(60);
+const EMBEDDING_BATCH_SIZE: usize = 32;
 
 impl SqliteCache {
     pub fn replace_from_index_with_embedder(
@@ -75,46 +76,78 @@ impl SqliteCache {
         let mut per_note_failures: usize = 0;
         let mut notes_changed: usize = 0;
         let mut notes_unchanged: usize = 0;
+        let mut notes_completed: usize = 0;
         let mut metrics = IndexingMetrics::default();
+        let mut prepared_notes = Vec::new();
+        let mut pending_embeddings = 0usize;
         let (progress, stop_heartbeat, heartbeat) =
             start_indexing_heartbeat(total_notes, started_at);
 
         let indexing_result = (|| -> Result<(), String> {
-            for (position, entry) in entries.iter().enumerate() {
+            for entry in &entries {
                 let note_sync_started = Instant::now();
                 let upsert_outcome = upsert_note_if_changed(&tx, entry, now)?;
                 metrics.note_sync += note_sync_started.elapsed();
                 match upsert_outcome {
                     UpsertOutcome::Wrote { slug, content } => {
-                        match chunk_and_embed_note(&tx, &slug, &content, embedder) {
-                            Ok(stats) => {
-                                notes_changed += 1;
-                                chunks_embedded += stats.embedded;
-                                chunks_reused += stats.reused;
-                                metrics.record_chunk_stats(&stats);
+                        match prepare_note_for_embedding(&tx, &slug, &content, embedder) {
+                            Ok(prepared) => {
+                                metrics.record_prepared_note(&prepared);
+                                pending_embeddings += prepared.missing.len();
+                                prepared_notes.push(prepared);
+
+                                if pending_embeddings >= EMBEDDING_BATCH_SIZE {
+                                    let queued_notes = prepared_notes.len();
+                                    let outcome = flush_prepared_notes(
+                                        &tx,
+                                        &mut prepared_notes,
+                                        embedder,
+                                        &mut metrics,
+                                    )?;
+                                    notes_completed += queued_notes;
+                                    notes_changed += outcome.notes_succeeded;
+                                    per_note_failures += outcome.notes_failed;
+                                    chunks_embedded += outcome.chunks_embedded;
+                                    chunks_reused += outcome.chunks_reused;
+                                    pending_embeddings = 0;
+                                }
                             }
                             Err(e) => {
                                 per_note_failures += 1;
-                                progress
-                                    .failures
-                                    .store(per_note_failures, Ordering::Relaxed);
-                                tracing::warn!(slug = %slug, error = %e, "Per-note embedding failed; marking note for re-embed on next reindex");
-                                // The notes row was just written with the new content_hash,
-                                // but chunk/vector tables are now stale (or empty for a new
-                                // note). Change-detection keys off content_hash, so without
-                                // this the note would look Unchanged forever and never be
-                                // re-chunked. Invalidate the stored hash so the next reindex
-                                // re-processes the note once the embedder recovers.
-                                invalidate_note_content_hash(&tx, &slug)?;
+                                notes_completed += 1;
+                                mark_note_for_retry(&tx, &slug, &e)?;
                             }
                         }
                     }
-                    UpsertOutcome::Unchanged => notes_unchanged += 1,
+                    UpsertOutcome::Unchanged => {
+                        notes_unchanged += 1;
+                        notes_completed += 1;
+                    }
                 }
 
                 progress
+                    .failures
+                    .store(per_note_failures, Ordering::Relaxed);
+                progress
                     .notes_processed
-                    .store(position + 1, Ordering::Relaxed);
+                    .store(notes_completed, Ordering::Relaxed);
+            }
+
+            if !prepared_notes.is_empty() {
+                let queued_notes = prepared_notes.len();
+                let outcome =
+                    flush_prepared_notes(&tx, &mut prepared_notes, embedder, &mut metrics)?;
+                notes_completed += queued_notes;
+                notes_changed += outcome.notes_succeeded;
+                per_note_failures += outcome.notes_failed;
+                chunks_embedded += outcome.chunks_embedded;
+                chunks_reused += outcome.chunks_reused;
+                progress
+                    .failures
+                    .store(per_note_failures, Ordering::Relaxed);
+                progress
+                    .notes_processed
+                    .store(notes_completed, Ordering::Relaxed);
             }
             Ok(())
         })();
@@ -204,15 +237,11 @@ struct IndexingMetrics {
 }
 
 impl IndexingMetrics {
-    fn record_chunk_stats(&mut self, stats: &ChunkStats) {
-        self.chunking += stats.chunking;
-        self.chunk_pipeline += stats.pipeline;
-        self.vector_reuse += stats.vector_reuse;
-        self.embedding += stats.embedding;
-        self.sqlite_chunk_write += stats.sqlite_write;
-        self.chunks_total += stats.embedded + stats.reused;
-        self.embedder_calls += stats.embedder_calls;
-        self.embedding_input_bytes += stats.embedding_input_bytes;
+    fn record_prepared_note(&mut self, note: &PreparedNote) {
+        self.chunking += note.chunking;
+        self.chunk_pipeline += note.preparation;
+        self.vector_reuse += note.vector_reuse;
+        self.chunks_total += note.chunks.len();
     }
 }
 
@@ -760,46 +789,43 @@ fn rebuild_links(
     Ok(())
 }
 
-pub struct ChunkStats {
-    #[allow(dead_code)]
-    pub embedded: usize,
-    #[allow(dead_code)]
-    pub reused: usize,
-    pub embedder_calls: usize,
-    pub embedding_input_bytes: usize,
-    pub pipeline: Duration,
-    pub chunking: Duration,
-    pub vector_reuse: Duration,
-    pub embedding: Duration,
-    pub sqlite_write: Duration,
+struct MissingEmbedding {
+    chunk_index: usize,
+    text: String,
 }
 
-fn chunk_and_embed_note(
+struct PreparedNote {
+    slug: String,
+    chunks: Vec<Chunk>,
+    tags_json: Option<String>,
+    aliases_json: Option<String>,
+    vectors: Vec<Option<Vec<f32>>>,
+    missing: Vec<MissingEmbedding>,
+    failure: Option<String>,
+    preparation: Duration,
+    chunking: Duration,
+    vector_reuse: Duration,
+}
+
+#[derive(Default)]
+struct FlushOutcome {
+    notes_succeeded: usize,
+    notes_failed: usize,
+    chunks_embedded: usize,
+    chunks_reused: usize,
+}
+
+fn prepare_note_for_embedding(
     tx: &Transaction<'_>,
     slug: &str,
     content: &str,
     embedder: &dyn Embedder,
-) -> Result<ChunkStats, String> {
-    let pipeline_started = Instant::now();
+) -> Result<PreparedNote, String> {
+    let preparation_started = Instant::now();
     let chunking_started = Instant::now();
     let tokenizer = embedder.tokenizer();
     let chunking = chunk_note(content, tokenizer, ChunkOptions::default());
     let chunking_elapsed = chunking_started.elapsed();
-    if chunking.chunks.is_empty() {
-        let sqlite_started = Instant::now();
-        replace_chunks_for_note(tx, slug, &[], None, None)?;
-        return Ok(ChunkStats {
-            embedded: 0,
-            reused: 0,
-            embedder_calls: 0,
-            embedding_input_bytes: 0,
-            pipeline: pipeline_started.elapsed(),
-            chunking: chunking_elapsed,
-            vector_reuse: Duration::ZERO,
-            embedding: Duration::ZERO,
-            sqlite_write: sqlite_started.elapsed(),
-        });
-    }
 
     let reuse_started = Instant::now();
     let existing = existing_chunk_hashes(tx, slug)?;
@@ -807,78 +833,208 @@ fn chunk_and_embed_note(
     let vector_reuse_elapsed = reuse_started.elapsed();
 
     let doc_prefix = embedder.doc_prefix();
-    let mut texts_to_embed: Vec<String> = Vec::new();
-    let mut indices_needing_embed: Vec<usize> = Vec::new();
+    let mut vectors = Vec::with_capacity(chunking.chunks.len());
+    let mut missing = Vec::new();
     for (idx, chunk) in chunking.chunks.iter().enumerate() {
-        if !preserved.contains_key(&chunk.content_hash) {
-            texts_to_embed.push(format!("{doc_prefix}{}", chunk.content));
-            indices_needing_embed.push(idx);
-        }
-    }
-
-    if !texts_to_embed.is_empty() {
-        tracing::debug!(
-            slug,
-            new = texts_to_embed.len(),
-            reused = chunking.chunks.len() - texts_to_embed.len(),
-            "Embedding chunks for note"
-        );
-    }
-
-    let embedding_input_bytes = texts_to_embed.iter().map(String::len).sum();
-    let embedding_started = Instant::now();
-    let new_vectors = if texts_to_embed.is_empty() {
-        Vec::new()
-    } else {
-        embedder.embed(&texts_to_embed)?
-    };
-    let embedding_elapsed = embedding_started.elapsed();
-
-    let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(chunking.chunks.len());
-    let mut need_new: std::collections::HashSet<usize> =
-        indices_needing_embed.iter().copied().collect();
-    let mut new_iter = new_vectors.into_iter();
-    for (idx, chunk) in chunking.chunks.iter().enumerate() {
-        if need_new.remove(&idx) {
-            vectors.push(new_iter.next().ok_or("embedder returned too few vectors")?);
+        if let Some(vector) = preserved.get(&chunk.content_hash) {
+            vectors.push(Some(vector.clone()));
         } else {
-            vectors.push(
-                preserved
-                    .get(&chunk.content_hash)
-                    .cloned()
-                    .ok_or("preserved vector missing for unchanged chunk")?,
-            );
+            vectors.push(None);
+            missing.push(MissingEmbedding {
+                chunk_index: idx,
+                text: format!("{doc_prefix}{}", chunk.content),
+            });
         }
     }
 
     let tags_json = serde_json::to_string(&chunking.tags).ok();
     let aliases_json = serde_json::to_string(&chunking.aliases).ok();
-    let rows: Vec<ChunkRow<'_>> = chunking
+
+    Ok(PreparedNote {
+        slug: slug.to_string(),
+        chunks: chunking.chunks,
+        tags_json,
+        aliases_json,
+        vectors,
+        missing,
+        failure: None,
+        preparation: preparation_started.elapsed(),
+        chunking: chunking_elapsed,
+        vector_reuse: vector_reuse_elapsed,
+    })
+}
+
+fn flush_prepared_notes(
+    tx: &Transaction<'_>,
+    notes: &mut Vec<PreparedNote>,
+    embedder: &dyn Embedder,
+    metrics: &mut IndexingMetrics,
+) -> Result<FlushOutcome, String> {
+    let flush_started = Instant::now();
+    let work: Vec<(usize, usize)> = notes
+        .iter()
+        .enumerate()
+        .flat_map(|(note_index, note)| {
+            (0..note.missing.len()).map(move |missing_index| (note_index, missing_index))
+        })
+        .collect();
+
+    if !work.is_empty() {
+        tracing::debug!(
+            notes = notes.len(),
+            chunks = work.len(),
+            batch_size = EMBEDDING_BATCH_SIZE,
+            "Embedding prepared note batch"
+        );
+    }
+
+    let mut batch_error = None;
+    for batch in work.chunks(EMBEDDING_BATCH_SIZE) {
+        let texts: Vec<String> = batch
+            .iter()
+            .map(|(note_index, missing_index)| {
+                notes[*note_index].missing[*missing_index].text.clone()
+            })
+            .collect();
+        metrics.embedder_calls += 1;
+        metrics.embedding_input_bytes += texts.iter().map(String::len).sum::<usize>();
+        let embedding_started = Instant::now();
+        let result = embedder.embed(&texts);
+        metrics.embedding += embedding_started.elapsed();
+
+        match result {
+            Ok(vectors) if vectors.len() == batch.len() => {
+                for ((note_index, missing_index), vector) in batch.iter().copied().zip(vectors) {
+                    let chunk_index = notes[note_index].missing[missing_index].chunk_index;
+                    notes[note_index].vectors[chunk_index] = Some(vector);
+                }
+            }
+            Ok(vectors) => {
+                batch_error = Some(format!(
+                    "embedder returned {} vectors for {} inputs",
+                    vectors.len(),
+                    batch.len()
+                ));
+                break;
+            }
+            Err(error) => {
+                batch_error = Some(error);
+                break;
+            }
+        }
+    }
+
+    if let Some(error) = batch_error {
+        tracing::warn!(
+            error = %error,
+            "Cross-note embedding batch failed; retrying affected notes individually"
+        );
+        retry_incomplete_notes(notes, embedder, metrics);
+    }
+
+    let mut outcome = FlushOutcome::default();
+    for mut note in notes.drain(..) {
+        let embedded = note.missing.len();
+        let reused = note.chunks.len().saturating_sub(embedded);
+        let result = if let Some(error) = note.failure.take() {
+            Err(error)
+        } else {
+            write_prepared_note(tx, &mut note, metrics)
+        };
+
+        match result {
+            Ok(()) => {
+                outcome.notes_succeeded += 1;
+                outcome.chunks_embedded += embedded;
+                outcome.chunks_reused += reused;
+            }
+            Err(error) => {
+                outcome.notes_failed += 1;
+                mark_note_for_retry(tx, &note.slug, &error)?;
+            }
+        }
+    }
+    metrics.chunk_pipeline += flush_started.elapsed();
+    Ok(outcome)
+}
+
+fn retry_incomplete_notes(
+    notes: &mut [PreparedNote],
+    embedder: &dyn Embedder,
+    metrics: &mut IndexingMetrics,
+) {
+    for note in notes {
+        if note
+            .missing
+            .iter()
+            .all(|missing| note.vectors[missing.chunk_index].is_some())
+        {
+            continue;
+        }
+
+        let texts: Vec<String> = note
+            .missing
+            .iter()
+            .map(|missing| missing.text.clone())
+            .collect();
+        metrics.embedder_calls += 1;
+        metrics.embedding_input_bytes += texts.iter().map(String::len).sum::<usize>();
+        let embedding_started = Instant::now();
+        let result = embedder.embed(&texts);
+        metrics.embedding += embedding_started.elapsed();
+
+        match result {
+            Ok(vectors) if vectors.len() == note.missing.len() => {
+                for (missing, vector) in note.missing.iter().zip(vectors) {
+                    note.vectors[missing.chunk_index] = Some(vector);
+                }
+            }
+            Ok(vectors) => {
+                note.failure = Some(format!(
+                    "embedder returned {} vectors for {} inputs",
+                    vectors.len(),
+                    note.missing.len()
+                ));
+            }
+            Err(error) => note.failure = Some(error),
+        }
+    }
+}
+
+fn write_prepared_note(
+    tx: &Transaction<'_>,
+    note: &mut PreparedNote,
+    metrics: &mut IndexingMetrics,
+) -> Result<(), String> {
+    let vectors = note
+        .vectors
+        .drain(..)
+        .map(|vector| vector.ok_or_else(|| "embedding vector missing after batch".to_string()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let rows: Vec<ChunkRow<'_>> = note
         .chunks
         .iter()
         .zip(vectors.iter())
         .map(|(chunk, vector)| ChunkRow { chunk, vector })
         .collect();
-
     let sqlite_started = Instant::now();
-    replace_chunks_for_note(
+    let result = replace_chunks_for_note(
         tx,
-        slug,
+        &note.slug,
         &rows,
-        tags_json.as_deref(),
-        aliases_json.as_deref(),
-    )?;
-    Ok(ChunkStats {
-        embedded: indices_needing_embed.len(),
-        reused: chunking.chunks.len() - indices_needing_embed.len(),
-        embedder_calls: usize::from(!texts_to_embed.is_empty()),
-        embedding_input_bytes,
-        pipeline: pipeline_started.elapsed(),
-        chunking: chunking_elapsed,
-        vector_reuse: vector_reuse_elapsed,
-        embedding: embedding_elapsed,
-        sqlite_write: sqlite_started.elapsed(),
-    })
+        note.tags_json.as_deref(),
+        note.aliases_json.as_deref(),
+    );
+    metrics.sqlite_chunk_write += sqlite_started.elapsed();
+    result
+}
+
+fn mark_note_for_retry(tx: &Transaction<'_>, slug: &str, error: &str) -> Result<(), String> {
+    tracing::warn!(slug = %slug, error = %error, "Per-note embedding failed; marking note for re-embed on next reindex");
+    // The note row now carries the new content hash while its chunks are stale or
+    // absent. Clear the hash so the next refresh retries it instead of treating it
+    // as unchanged forever.
+    invalidate_note_content_hash(tx, slug)
 }
 
 fn preserve_existing_vectors(
@@ -990,8 +1146,8 @@ mod chunk_integration_tests {
     use tempfile::TempDir;
 
     use super::{
-        estimated_remaining, format_count, format_elapsed, format_eta, format_note_count,
-        progress_log_delay,
+        EMBEDDING_BATCH_SIZE, estimated_remaining, format_count, format_elapsed, format_eta,
+        format_note_count, progress_log_delay,
     };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
@@ -1164,6 +1320,55 @@ mod chunk_integration_tests {
             .query_row("SELECT COUNT(*) FROM chunk_vectors", [], |r| r.get(0))
             .expect("count");
         assert_eq!(vector_count, chunk_count);
+    }
+
+    #[test]
+    fn changed_notes_are_embedded_in_cross_note_batches_of_32() {
+        struct BatchRecordingEmbedder {
+            inner: StubEmbedder,
+            batch_sizes: std::sync::Mutex<Vec<usize>>,
+        }
+        impl Embedder for BatchRecordingEmbedder {
+            fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+                self.batch_sizes
+                    .lock()
+                    .expect("batch sizes lock")
+                    .push(texts.len());
+                self.inner.embed(texts)
+            }
+            fn embedding_dim(&self) -> usize {
+                self.inner.embedding_dim()
+            }
+            fn tokenizer(&self) -> std::sync::Arc<tokenizers::Tokenizer> {
+                self.inner.tokenizer()
+            }
+        }
+
+        let dir = TempDir::new().expect("tempdir");
+        for index in 0..40 {
+            std::fs::write(
+                dir.path().join(format!("note-{index:02}.md")),
+                format!("# Note {index}\n\nA short body."),
+            )
+            .expect("write note");
+        }
+        let cache = SqliteCache::in_memory(384).expect("open");
+        let embedder = BatchRecordingEmbedder {
+            inner: StubEmbedder::new(384),
+            batch_sizes: std::sync::Mutex::new(Vec::new()),
+        };
+        let index = VaultIndex::build(dir.path()).expect("build");
+
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("replace");
+
+        assert_eq!(EMBEDDING_BATCH_SIZE, 32);
+        assert_eq!(
+            *embedder.batch_sizes.lock().expect("batch sizes lock"),
+            vec![32, 8],
+            "40 single-chunk notes should require one full batch and one final partial batch"
+        );
     }
 
     #[test]

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -13,6 +13,7 @@ use crate::cache::chunk_ops::{
 };
 use crate::chunk::{ChunkOptions, NoteChunking, chunk_note};
 use crate::embed::Embedder;
+use crate::startup::IndexingProgressSnapshot;
 use crate::vault::{NoteEntry, VaultIndex, normalize_title};
 
 use super::SqliteCache;
@@ -41,6 +42,15 @@ impl SqliteCache {
         &self,
         index: &VaultIndex,
         embedder: &dyn Embedder,
+    ) -> Result<(), String> {
+        self.replace_from_index_with_embedder_and_progress(index, embedder, None)
+    }
+
+    pub fn replace_from_index_with_embedder_and_progress(
+        &self,
+        index: &VaultIndex,
+        embedder: &dyn Embedder,
+        on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
     ) -> Result<(), String> {
         // If the embedding model changed since the last build, rebuild from
         // scratch so no vectors from the old model are reused (mixed-model vector
@@ -131,11 +141,20 @@ impl SqliteCache {
         progress
             .failures
             .store(per_note_failures, Ordering::Relaxed);
+        let progress_reporter = ProgressReporter {
+            progress: progress.as_ref(),
+            on_progress: on_progress.as_ref(),
+            notes_total: total_notes,
+            chunks_total: total_chunks_to_embed,
+            tokens_total: total_tokens_to_embed,
+            started_at: embedding_started_at,
+        };
+        progress_reporter.notify();
 
         let indexing_result = (|| -> Result<(), String> {
             for prepared in prepared_notes {
                 let slug = prepared.slug.clone();
-                match embed_prepared_note(&tx, prepared, embedder, progress.as_ref()) {
+                match embed_prepared_note(&tx, prepared, embedder, &progress_reporter) {
                     Ok(stats) => {
                         notes_changed += 1;
                         chunks_embedded += stats.embedded;
@@ -152,6 +171,7 @@ impl SqliteCache {
                     }
                 }
                 progress.notes_processed.fetch_add(1, Ordering::Relaxed);
+                progress_reporter.notify();
             }
             Ok(())
         })();
@@ -463,6 +483,32 @@ struct IndexingProgress {
     chunks_processed: AtomicUsize,
     tokens_processed: AtomicUsize,
     failures: AtomicUsize,
+}
+
+struct ProgressReporter<'a> {
+    progress: &'a IndexingProgress,
+    on_progress: Option<&'a Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
+    notes_total: usize,
+    chunks_total: usize,
+    tokens_total: usize,
+    started_at: Instant,
+}
+
+impl ProgressReporter<'_> {
+    fn notify(&self) {
+        let Some(on_progress) = self.on_progress else {
+            return;
+        };
+        on_progress(IndexingProgressSnapshot {
+            notes_completed: self.progress.notes_processed.load(Ordering::Relaxed),
+            notes_total: self.notes_total,
+            chunks_completed: self.progress.chunks_processed.load(Ordering::Relaxed),
+            chunks_total: self.chunks_total,
+            tokens_completed: self.progress.tokens_processed.load(Ordering::Relaxed),
+            tokens_total: self.tokens_total,
+            elapsed_seconds: self.started_at.elapsed().as_secs(),
+        });
+    }
 }
 
 fn start_indexing_heartbeat(
@@ -1116,8 +1162,9 @@ fn embed_prepared_note(
     tx: &Transaction<'_>,
     prepared: PreparedNote,
     embedder: &dyn Embedder,
-    progress: &IndexingProgress,
+    progress_reporter: &ProgressReporter<'_>,
 ) -> Result<ChunkStats, String> {
+    let progress = progress_reporter.progress;
     let pipeline_started = Instant::now();
     let PreparedNote {
         slug,
@@ -1177,6 +1224,7 @@ fn embed_prepared_note(
         progress
             .tokens_processed
             .fetch_add(input_tokens, Ordering::Relaxed);
+        progress_reporter.notify();
     }
     let embedding_elapsed = embedding_started.elapsed();
     if !texts_to_embed.is_empty() {
@@ -1327,6 +1375,42 @@ mod tests {
         assert_eq!(metrics.duplicate_chunks, 1);
         assert_eq!(metrics.duplicate_input_bytes, 100);
         assert_eq!(metrics.duplicate_input_tokens, 25);
+    }
+
+    #[test]
+    fn progress_observer_receives_exact_workload_and_completion() {
+        let dir = tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Long note.md"),
+            format!("# Long note\n\n{}", "measured indexing work ".repeat(900)),
+        )
+        .expect("write note");
+        let index = VaultIndex::build(dir.path()).expect("index");
+        let cache = SqliteCache::in_memory(384).expect("cache");
+        let snapshots = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed = snapshots.clone();
+        let observer = Arc::new(move |snapshot| {
+            observed.lock().expect("snapshots lock").push(snapshot);
+        });
+
+        cache
+            .replace_from_index_with_embedder_and_progress(
+                &index,
+                &StubEmbedder::new(384),
+                Some(observer),
+            )
+            .expect("populate cache");
+
+        let snapshots = snapshots.lock().expect("snapshots lock");
+        let first = snapshots.first().expect("initial snapshot");
+        let last = snapshots.last().expect("final snapshot");
+        assert_eq!(first.notes_total, 1);
+        assert!(first.chunks_total > 1);
+        assert!(first.tokens_total > 0);
+        assert_eq!(first.tokens_completed, 0);
+        assert_eq!(last.notes_completed, last.notes_total);
+        assert_eq!(last.chunks_completed, last.chunks_total);
+        assert_eq!(last.tokens_completed, last.tokens_total);
     }
 
     #[test]

--- a/src/embed/fastembed_embedder.rs
+++ b/src/embed/fastembed_embedder.rs
@@ -9,6 +9,7 @@ pub struct FastembedEmbedder {
     model: TextEmbedding,
     tokenizer: Arc<Tokenizer>,
     dim: usize,
+    max_length: usize,
     id: &'static str,
     doc_prefix: &'static str,
     query_prefix: &'static str,
@@ -18,18 +19,23 @@ impl FastembedEmbedder {
     fn load(
         model: EmbeddingModel,
         dim: usize,
+        max_length: usize,
         id: &'static str,
         doc_prefix: &'static str,
         query_prefix: &'static str,
     ) -> Result<Self, String> {
-        let model =
-            TextEmbedding::try_new(InitOptions::new(model).with_show_download_progress(false))
-                .map_err(|e| format!("failed to load embedding model {id}: {e}"))?;
+        let model = TextEmbedding::try_new(
+            InitOptions::new(model)
+                .with_max_length(max_length)
+                .with_show_download_progress(false),
+        )
+        .map_err(|e| format!("failed to load embedding model {id}: {e}"))?;
         let tokenizer = Arc::new(model.tokenizer.clone());
         Ok(Self {
             model,
             tokenizer,
             dim,
+            max_length,
             id,
             doc_prefix,
             query_prefix,
@@ -41,7 +47,14 @@ impl FastembedEmbedder {
     }
 
     pub fn bge_small() -> Result<Self, String> {
-        Self::load(EmbeddingModel::BGESmallENV15, 384, "BGESmallENV15", "", "")
+        Self::load(
+            EmbeddingModel::BGESmallENV15,
+            384,
+            512,
+            "BGESmallENV15",
+            "",
+            "",
+        )
     }
 
     pub fn nomic_v1_5() -> Result<Self, String> {
@@ -50,6 +63,7 @@ impl FastembedEmbedder {
         Self::load(
             EmbeddingModel::NomicEmbedTextV15,
             768,
+            1024,
             "NomicEmbedTextV15",
             "search_document: ",
             "search_query: ",
@@ -60,6 +74,7 @@ impl FastembedEmbedder {
         Self::load(
             EmbeddingModel::MxbaiEmbedLargeV1,
             1024,
+            512,
             "MxbaiEmbedLargeV1",
             "",
             "",
@@ -82,7 +97,9 @@ impl Embedder for FastembedEmbedder {
     }
 
     fn identity(&self) -> String {
-        format!("{}-{}", self.id, self.dim)
+        // Sequence length affects embeddings when inputs exceed the old limit,
+        // so it is part of the persisted cache identity.
+        format!("{}-{}-max{}", self.id, self.dim, self.max_length)
     }
 
     fn tokenizer(&self) -> Arc<Tokenizer> {

--- a/src/handlers/write_api.rs
+++ b/src/handlers/write_api.rs
@@ -651,7 +651,7 @@ async fn refresh_after_write(state: &AppState) -> Result<(), (StatusCode, Json<E
 }
 
 async fn git_sync_warning(state: &AppState) -> Option<String> {
-    let handle = state.git_sync.as_ref()?;
+    let handle = state.git_sync.get()?;
     let guard = handle.status();
     let snapshot = guard.read().await;
     if snapshot.last_ok {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,6 @@ pub mod mcp;
 pub mod rerank;
 pub mod search;
 pub mod server;
+pub mod startup;
 pub mod vault;
 pub mod vault_watcher;

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -184,10 +184,11 @@ mod tests {
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            git_sync: None,
+            git_sync: Arc::new(std::sync::OnceLock::new()),
             mcp_config: Arc::new(McpConfig::disabled()),
             archive_prefix: Arc::from("90-archive/"),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            startup: crate::startup::StartupTracker::ready(),
         };
         (state, tmp)
     }

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -133,7 +133,7 @@ pub(super) async fn refresh_index_tool(
 }
 
 pub(super) async fn get_git_sync_status_tool(state: AppState) -> Result<Value, JsonRpcFailure> {
-    let status = match &state.git_sync {
+    let status = match state.git_sync.get() {
         Some(handle) => {
             let guard = handle.status();
             let snapshot = guard.read().await;

--- a/src/mcp/tools/write.rs
+++ b/src/mcp/tools/write.rs
@@ -410,7 +410,7 @@ fn slug_for_relative_path(index: &VaultIndex, relative_path: &str) -> Option<Str
 
 /// Returns the last sync error message when the most recent sync failed.
 async fn git_sync_warning(state: &AppState) -> Option<String> {
-    let handle = state.git_sync.as_ref()?;
+    let handle = state.git_sync.get()?;
     let guard = handle.status();
     let snapshot = guard.read().await;
     if snapshot.last_ok {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,17 +2,21 @@
 //! checks, and the `serve` run loop. Kept in the library (rather than the binary
 //! root) so the HTTP surface is reachable from integration tests.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use axum::Router;
 use axum::extract::DefaultBodyLimit;
+use axum::extract::{Request, State};
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
+use axum::{Json, Router};
 use tokio::sync::RwLock;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tracing::{error, info};
 
-use crate::app_state::{AppState, build_cache_with_sqlite};
+use crate::app_state::{AppState, VaultCache, build_cache_with_sqlite_and_progress};
 use crate::auth::{WebToken, require_web_token};
 use crate::cache::SqliteCache;
 use crate::config::AppConfig;
@@ -27,6 +31,7 @@ use crate::handlers::{
     vault_events_handler, write_capabilities_handler,
 };
 use crate::mcp::{McpConfig, mcp_get_handler, mcp_post_handler};
+use crate::startup::StartupTracker;
 use crate::vault_watcher::spawn_vault_watcher;
 
 /// Hosts that only accept connections from the local machine. Binding to any
@@ -94,8 +99,8 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
         .saturating_add(ATTACHMENT_MULTIPART_OVERHEAD)
         .min(usize::MAX as u64) as usize;
 
-    // Routes that expose vault data. When a web token is configured they sit
-    // behind the auth layer; the SPA shell, /health, and /mcp stay open.
+    // Routes that expose vault data sit behind startup readiness and, when
+    // configured, web authentication. The SPA shell and status routes stay open.
     let protected = Router::new()
         .route("/api/tree", get(tree_handler))
         .route("/api/vault-events", get(vault_events_handler))
@@ -136,10 +141,22 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
         )),
         None => protected,
     };
+    let protected = protected.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        require_vault_ready,
+    ));
+    let mcp = Router::new()
+        .route("/mcp", get(mcp_get_handler).post(mcp_post_handler))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_vault_ready,
+        ));
 
     Router::new()
         .route("/health", get(health_handler))
-        .route("/mcp", get(mcp_get_handler).post(mcp_post_handler))
+        .route("/ready", get(readiness_handler))
+        .route("/api/startup-status", get(startup_status_handler))
+        .merge(mcp)
         .merge(protected)
         .route("/", get(spa_index_handler))
         .route("/n/{slug}", get(spa_index_handler))
@@ -179,6 +196,40 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
                 .on_response(DefaultOnResponse::new().include_headers(false)),
         )
         .with_state(state)
+}
+
+async fn startup_status_handler(State(state): State<AppState>) -> Response {
+    let mut response = Json(state.startup.status()).into_response();
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+
+async fn readiness_handler(State(state): State<AppState>) -> Response {
+    if state.startup.is_ready() {
+        (StatusCode::OK, "ready").into_response()
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "not ready").into_response()
+    }
+}
+
+async fn require_vault_ready(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.startup.is_ready() {
+        return next.run(request).await;
+    }
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "Vault is still being indexed",
+            "code": "vault_indexing"
+        })),
+    )
+        .into_response()
 }
 
 pub async fn run_server() {
@@ -231,66 +282,36 @@ pub async fn run_server() {
             std::process::exit(1);
         }));
 
-    let cache = build_cache_with_sqlite(&config.vault_path, sqlite, embedder.as_ref())
-        .unwrap_or_else(|e| {
-            error!(
-                "Failed to index vault at {} into SQLite cache {}: {e}",
-                config.vault_path.display(),
-                config.cache_db_path.display()
-            );
-            std::process::exit(1);
-        });
-
     let vault_write_lock = Arc::new(tokio::sync::Mutex::new(()));
-
-    let git_sync = match git_sync_config {
-        None => None,
-        Some(git_config) => {
-            if let Err(e) = git::validate_repo(&git_config) {
-                error!("Git sync configuration invalid: {e}");
-                std::process::exit(1);
-            }
-            // The background task flushes any commits stranded by an earlier
-            // outage immediately on startup (see spawn_sync_task).
-            let handle = git::spawn_sync_task(
-                git_config.clone(),
-                vault_write_lock.clone(),
-                git::SyncOps {
-                    commit: Box::new(git::commit_local),
-                    fetch: Box::new(git::fetch_remote),
-                    integrate: Box::new(git::integrate_fetched),
-                    push: Box::new(git::push_branch),
-                },
-            );
-            info!("Git sync enabled");
-            Some(handle)
-        }
-    };
+    if let Some(git_config) = &git_sync_config
+        && let Err(e) = git::validate_repo(git_config)
+    {
+        error!("Git sync configuration invalid: {e}");
+        std::process::exit(1);
+    }
 
     let (vault_events, _) = tokio::sync::broadcast::channel(64);
+    let startup = StartupTracker::scanning();
     let state = AppState {
         vault_path: config.vault_path.clone(),
-        cache: Arc::new(RwLock::new(cache)),
+        cache: Arc::new(RwLock::new(VaultCache {
+            sqlite: sqlite.clone(),
+        })),
         vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         vault_events,
         embedder,
         web_auth_enabled: config.web_bearer_token.is_some(),
         demo_mode: config.demo_mode,
         vault_write_lock,
-        git_sync,
+        git_sync: Arc::new(OnceLock::new()),
         mcp_config,
         archive_prefix: Arc::from(config.archive_prefix.as_str()),
         refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+        startup,
     };
 
-    spawn_vault_watcher(
-        state.clone(),
-        config.vault_path.clone(),
-        config.cache_db_path.clone(),
-    );
-
     let web_bearer_token = config.web_bearer_token.clone().map(Arc::from);
-    let app = build_router(state, web_bearer_token);
+    let app = build_router(state.clone(), web_bearer_token);
 
     let addr = config.socket_addr().unwrap_or_else(|e| {
         error!("Address error: {e}");
@@ -311,6 +332,63 @@ pub async fn run_server() {
             error!("Failed to bind: {e}");
             std::process::exit(1);
         });
+
+    let indexing_state = state.clone();
+    let vault_path = config.vault_path.clone();
+    let cache_db_path = config.cache_db_path.clone();
+    let indexing_sqlite = sqlite.clone();
+    let indexing_embedder = state.embedder.clone();
+    tokio::spawn(async move {
+        let tracker = indexing_state.startup.clone();
+        let progress_tracker = tracker.clone();
+        let on_progress = Arc::new(move |progress| {
+            progress_tracker.set_indexing(progress);
+        });
+        let indexing_vault_path = vault_path.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            build_cache_with_sqlite_and_progress(
+                &indexing_vault_path,
+                indexing_sqlite,
+                indexing_embedder.as_ref(),
+                Some(on_progress),
+            )
+        })
+        .await;
+
+        match result {
+            Ok(Ok(_)) => {
+                tracker.set_ready();
+                if let Some(git_config) = git_sync_config {
+                    // Start sync only after the first consistent index is committed.
+                    let handle = git::spawn_sync_task(
+                        git_config,
+                        indexing_state.vault_write_lock.clone(),
+                        git::SyncOps {
+                            commit: Box::new(git::commit_local),
+                            fetch: Box::new(git::fetch_remote),
+                            integrate: Box::new(git::integrate_fetched),
+                            push: Box::new(git::push_branch),
+                        },
+                    );
+                    let _ = indexing_state.git_sync.set(handle);
+                    info!("Git sync enabled");
+                }
+                spawn_vault_watcher(indexing_state, vault_path, cache_db_path);
+            }
+            Ok(Err(e)) => {
+                tracker.set_failed();
+                error!(
+                    "Failed to index vault at {} into SQLite cache {}: {e}",
+                    vault_path.display(),
+                    cache_db_path.display()
+                );
+            }
+            Err(e) => {
+                tracker.set_failed();
+                error!("Vault indexing task failed: {e}");
+            }
+        }
+    });
 
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         error!("Server error: {e}");
@@ -397,10 +475,11 @@ mod tests {
             web_auth_enabled: web_bearer_token.is_some(),
             demo_mode,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            git_sync: None,
+            git_sync: Arc::new(OnceLock::new()),
             mcp_config: Arc::new(crate::mcp::McpConfig::disabled()),
             archive_prefix: Arc::from("90-archive/"),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            startup: StartupTracker::ready(),
         };
 
         (build_router(state.clone(), web_bearer_token), tmp, state)
@@ -429,6 +508,135 @@ mod tests {
             .await
             .expect("body");
         assert_eq!(&body[..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn indexing_startup_keeps_shell_live_but_blocks_vault_surfaces() {
+        let (_ready_app, _tmp, state) = app_for_tests_with_state();
+        state
+            .startup
+            .set_indexing(crate::startup::IndexingProgressSnapshot {
+                notes_completed: 12,
+                notes_total: 40,
+                chunks_completed: 18,
+                chunks_total: 70,
+                tokens_completed: 4_000,
+                tokens_total: 20_000,
+                elapsed_seconds: 20,
+            });
+        let app = build_router(state, None);
+
+        for path in ["/health", "/api/startup-status"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+        }
+
+        let readiness = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(readiness.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        for path in ["/api/tree", "/mcp"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE, "{path}");
+            let body = to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("body");
+            let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+            assert_eq!(payload["code"], "vault_indexing");
+        }
+    }
+
+    #[tokio::test]
+    async fn startup_status_exposes_human_progress_and_eta() {
+        let (_app, _tmp, state) = app_for_tests_with_state();
+        state
+            .startup
+            .set_indexing(crate::startup::IndexingProgressSnapshot {
+                notes_completed: 12,
+                notes_total: 40,
+                chunks_completed: 18,
+                chunks_total: 70,
+                tokens_completed: 4_000,
+                tokens_total: 20_000,
+                elapsed_seconds: 20,
+            });
+        let response = build_router(state, None)
+            .oneshot(
+                Request::builder()
+                    .uri("/api/startup-status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["cache-control"], "no-store");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let payload: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(payload["state"], "indexing");
+        assert_eq!(payload["notes_completed"], 12);
+        assert_eq!(payload["notes_total"], 40);
+        assert_eq!(payload["percent"], 20);
+        assert_eq!(payload["eta_seconds"], 80);
+    }
+
+    #[tokio::test]
+    async fn ready_endpoint_changes_only_after_startup_completes() {
+        let (_app, _tmp, state) = app_for_tests_with_state();
+        state.startup.set_scanning();
+        let app = build_router(state.clone(), None);
+        let before = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(before.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        state.startup.set_ready();
+        let after = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(after.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -510,10 +718,11 @@ mod tests {
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            git_sync: None,
+            git_sync: Arc::new(OnceLock::new()),
             mcp_config: Arc::new(crate::mcp::McpConfig::disabled()),
             archive_prefix: Arc::from("90-archive/"),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            startup: StartupTracker::ready(),
         };
         let app = build_router(state, None);
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,137 @@
+use std::sync::{Arc, RwLock};
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct IndexingProgressSnapshot {
+    pub notes_completed: usize,
+    pub notes_total: usize,
+    pub chunks_completed: usize,
+    pub chunks_total: usize,
+    pub tokens_completed: usize,
+    pub tokens_total: usize,
+    pub elapsed_seconds: u64,
+}
+
+impl IndexingProgressSnapshot {
+    fn percent(self) -> u8 {
+        if self.tokens_total == 0 {
+            return 0;
+        }
+        ((self.tokens_completed.saturating_mul(100) / self.tokens_total).min(100)) as u8
+    }
+
+    fn eta_seconds(self) -> Option<u64> {
+        if self.tokens_completed == 0 || self.tokens_completed >= self.tokens_total {
+            return None;
+        }
+        let remaining = self.tokens_total - self.tokens_completed;
+        Some(self.elapsed_seconds.saturating_mul(remaining as u64) / self.tokens_completed as u64)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum StartupPhase {
+    Scanning,
+    Indexing(IndexingProgressSnapshot),
+    Ready,
+    Failed,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartupTracker(Arc<RwLock<StartupPhase>>);
+
+impl StartupTracker {
+    pub fn scanning() -> Self {
+        Self(Arc::new(RwLock::new(StartupPhase::Scanning)))
+    }
+
+    pub fn ready() -> Self {
+        Self(Arc::new(RwLock::new(StartupPhase::Ready)))
+    }
+
+    pub fn set_scanning(&self) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Scanning;
+    }
+
+    pub fn set_indexing(&self, progress: IndexingProgressSnapshot) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Indexing(progress);
+    }
+
+    pub fn set_ready(&self) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Ready;
+    }
+
+    pub fn set_failed(&self) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Failed;
+    }
+
+    pub fn is_ready(&self) -> bool {
+        matches!(
+            *self.0.read().expect("startup tracker poisoned"),
+            StartupPhase::Ready
+        )
+    }
+
+    pub fn status(&self) -> StartupStatusResponse {
+        match *self.0.read().expect("startup tracker poisoned") {
+            StartupPhase::Scanning => StartupStatusResponse::simple("scanning", None),
+            StartupPhase::Indexing(progress) => StartupStatusResponse {
+                state: "indexing",
+                notes_completed: Some(progress.notes_completed),
+                notes_total: Some(progress.notes_total),
+                chunks_completed: Some(progress.chunks_completed),
+                chunks_total: Some(progress.chunks_total),
+                tokens_completed: Some(progress.tokens_completed),
+                tokens_total: Some(progress.tokens_total),
+                percent: Some(progress.percent()),
+                eta_seconds: progress.eta_seconds(),
+                message: None,
+            },
+            StartupPhase::Ready => StartupStatusResponse::simple("ready", None),
+            StartupPhase::Failed => {
+                StartupStatusResponse::simple("failed", Some("Indexing could not be completed."))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct StartupStatusResponse {
+    pub state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes_completed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes_total: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_completed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_total: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens_completed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens_total: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub percent: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<&'static str>,
+}
+
+impl StartupStatusResponse {
+    fn simple(state: &'static str, message: Option<&'static str>) -> Self {
+        Self {
+            state,
+            notes_completed: None,
+            notes_total: None,
+            chunks_completed: None,
+            chunks_total: None,
+            tokens_completed: None,
+            tokens_total: None,
+            percent: None,
+            eta_seconds: None,
+            message,
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- add human-readable indexing heartbeats with completed/remaining notes, chunk counts, token-weighted progress, and measured ETA
- add detailed inference diagnostics and a microbenchmark for indexing investigations
- embed chunks individually so short chunks are not padded to the longest sibling input
- start the HTTP server before vault indexing, keep health/startup status available, and return 503 for vault and MCP surfaces until the first index commits
- add a responsive startup screen that polls measured progress and automatically mounts the vault when ready
- delay the vault watcher and Git synchronization until the initial index is consistent
- bump the application version to 2.2.1

## Why

Initial indexing ran synchronously before the listener was bound, so users saw a reverse-proxy 502 for the entire indexing period. Existing progress estimates also treated notes as equal units even though embedding time follows token volume, which produced misleading ETAs. Measurements additionally showed avoidable batch-longest padding when differently sized chunks were embedded together.

This change makes Hatchdoor reachable during indexing, keeps note data locked until it is safe to serve, and reports progress from the actual embedding workload.

## User impact

During an initial or required rebuild, users now see a Hatchdoor-native progress screen with percentage, ETA, note count, and chunk count. Health checks remain available, readiness is explicit, and no note/search/tree data is requested or exposed before indexing completes.

## Validation

- Rust test suite: 274 library tests, 7 eval tests, and 3 CLI tests passed
- targeted startup lifecycle and exact progress-observer tests passed
- frontend startup gate tests: 4/4 passed
- frontend type-check, lint, formatting, and production build passed
- broader frontend suite: 167/168 passed in the parallel run; the single unrelated link-render timing failure passed 9/9 immediately in isolation
- Playwright against a disposable copy of the configured vault confirmed:
  - `/health` returns 200 during indexing
  - `/ready` and protected vault APIs return 503
  - the browser requests only `/api/startup-status`, not note/tree/search data
  - progress updates live and remains readable at 1440×900 and 390×844
  - no application console errors or warnings

The configured production cache was not deleted or rebuilt during UI verification.