### PR TITLE
Establish managed Git vault lifecycle foundation

### DIFF
--- a/docs/architecture/managed-git-vault-foundation.md
+++ b/docs/architecture/managed-git-vault-foundation.md
@@ -1,0 +1,363 @@
+# Managed Git Vault Foundation — High-Level Architecture
+
+- Status: Draft for discussion
+- Scope: First increment of the vault lifecycle roadmap
+- Related roadmap: [`docs/roadmap/vault-lifecycle.md`](../roadmap/vault-lifecycle.md)
+- Related proposal: [Managed Git Vault Lifecycle, PR #18](https://github.com/BattermanZ/Hatchdoor/pull/18)
+- Agent handoff: [`docs/plans/managed-git-vault-agent-handoff.md`](../plans/managed-git-vault-agent-handoff.md)
+- Compatibility: Preserve the existing local-directory workflow
+
+## Purpose
+
+This document describes the runtime foundation for one environment-configured
+local or managed Git vault. Hatchdoor should acquire, synchronize, index, and
+expose the vault without making the application itself unavailable when the
+vault or Git remote has a problem.
+
+This is smaller than the complete Phase 1 roadmap outcome. Configuration and
+secrets remain deployment-owned; managing them through the UI and supporting
+multiple vaults come later.
+
+## Product Promise
+
+An operator can configure one Git repository, start Hatchdoor, and immediately
+reach an application that shows the vault being cloned or reopened,
+synchronized, and indexed.
+
+If the first clone, authentication, branch, or indexing step fails, the process
+keeps serving an actionable status and can retry. If a valid persistent checkout
+already exists, a temporary remote failure leaves the last consistent vault
+snapshot usable and keeps local bidirectional edits durable for later push.
+
+## Scope
+
+The first increment includes:
+
+- one vault per Hatchdoor process;
+- unchanged local-directory mode;
+- a persistent managed Git checkout;
+- pull-only and bidirectional Git modes;
+- public and token-authenticated HTTPS repositories;
+- optional branch and vault subdirectory;
+- startup acquisition, periodic pulling, writeback, retry, and crash recovery;
+- coordinated working-tree and index updates;
+- one lifecycle and capability model shared by web and MCP; and
+- minimal lifecycle status, retry/sync controls, and UI feedback.
+
+It does not include:
+
+- UI-managed configuration or secret storage;
+- multiple vaults or runtime source switching;
+- SSH, Git LFS, submodules, sparse, or shallow clones;
+- an in-browser merge editor or Git history; or
+- multiple Hatchdoor replicas sharing one checkout.
+
+## Principles
+
+1. Markdown remains authoritative; SQLite remains a disposable read model.
+2. Application liveness is independent of vault readiness.
+3. Existing local deployments keep their current behavior.
+4. Git network operations never hold the vault mutation lock.
+5. No operation silently discards, resets, or force-pushes local work.
+6. Web and MCP observe and enforce the same runtime capabilities.
+7. Managed checkout state lives on persistent storage.
+8. Credentials never enter URLs, repository configuration, logs, status, or
+   commits.
+9. The design serves this single-vault increment without prematurely building
+   the multi-vault architecture.
+
+## System Shape
+
+```text
+  deployment configuration
+            |
+            v
+  +----------------------+       commands       +----------------------+
+  | Vault source resolver |---------------------->| Lifecycle manager    |
+  +----------------------+                       +----------------------+
+            |                                               |
+            | resolved source                               | state + capabilities
+            v                                               v
+  +----------------------+                       +----------------------+
+  | Local directory or   |                       | Runtime snapshot     |
+  | managed Git checkout |                       +----------------------+
+  +----------------------+                                  |
+            |                                               |
+            v                                               v
+  +----------------------+    atomic index publish  +-------------------+
+  | Markdown vault       |-------------------------->| SQLite read model |
+  +----------------------+                           +-------------------+
+            ^                                               |
+            |                                               v
+       web/MCP writes                                web API, MCP, SPA
+```
+
+The source and lifecycle layers resolve either source into an ordinary
+filesystem vault. Search, rendering, downloads, attachments, and note operations
+continue to use that filesystem boundary.
+
+## Runtime Model
+
+The names below are descriptive rather than a prescribed Rust API.
+
+### Vault source
+
+```text
+VaultSource
+  Local { vault_root, legacy_git_sync }
+  ManagedGit {
+    repository_url,
+    checkout_root,
+    branch,
+    vault_subdirectory,
+    mode,
+    credentials,
+    poll_interval
+  }
+```
+
+`Local` preserves `VAULT_PATH`. In managed mode the persistent checkout is the
+source; `VAULT_PATH` is not a second source of truth.
+
+### Runtime snapshot
+
+```text
+VaultRuntimeSnapshot
+  phase
+  source and mode
+  repository_root: optional path
+  vault_root: optional validated path
+  capabilities
+  acquisition/index/sync progress
+  sanitized repository status
+  last error and retryability
+```
+
+Paths are optional because Hatchdoor must exist before a vault has been cloned
+or validated. The snapshot replaces separate, potentially contradictory startup
+and Git-sync status concepts.
+
+### Capabilities
+
+```text
+VaultCapabilities
+  browse
+  search
+  mutate
+  pull
+  push
+  retry
+```
+
+Capabilities are derived from source mode and lifecycle phase, then combined
+with existing web, demo, and MCP security policy. Pull-only and conflict states
+always disable mutation. Route and tool guards enforce the result; the frontend
+uses the same snapshot for presentation.
+
+## Lifecycle
+
+Application liveness and vault readiness are distinct:
+
+- `/health` means Hatchdoor can serve its application.
+- `/ready` means a usable vault index has been published.
+- lifecycle status explains initialization, degraded operation, or failure.
+
+```text
+unconfigured
+    |
+    v
+validating -> acquiring -> synchronizing -> indexing -> ready
+     |            |              |             |
+     +------------+--------------+-------------+-> unavailable -> retry
+
+ready -> syncing -> ready
+  |         |
+  |         +-> degraded -> retry
+  |
+  +-> conflict -> read-only recovery -> syncing
+```
+
+`Unavailable` means there is no usable published vault snapshot. `Degraded`
+means Hatchdoor can continue serving an existing snapshot while a remote or
+optional operation fails.
+
+## Startup Behavior
+
+### Local source
+
+The server starts, resolves `VAULT_PATH`, applies the existing starter-vault
+policy, builds the index in the background, and then starts the watcher and
+optional legacy Git sync. No current deployment should need to change.
+
+### First managed Git startup
+
+1. Start the HTTP application in `validating` state.
+2. Validate source configuration and acquire the checkout ownership lock.
+3. Clone into an application-owned temporary sibling directory.
+4. Validate origin, branch, repository shape, and vault boundary.
+5. Atomically install the checkout on persistent storage.
+6. Apply the explicit managed empty/bootstrap policy.
+7. Build and publish the index.
+8. Enter ready state and start polling/writeback.
+
+Failure moves the vault to `unavailable`; it does not stop the HTTP server.
+
+### Subsequent managed startup
+
+Hatchdoor locks and validates the existing checkout, detects dirty files and
+unpushed commits, fetches when possible, and publishes the resulting index. If
+the remote is unavailable, a previously validated checkout can start as
+`degraded` and recover in the background.
+
+## Repository Lifecycle Manager
+
+The current write-triggered Git task evolves into one actor receiving:
+
+- startup preparation or recovery;
+- periodic pull ticks;
+- debounced Hatchdoor write records;
+- manual retry/sync commands;
+- retry timers; and
+- graceful shutdown.
+
+For each synchronization cycle:
+
+```text
+fetch without vault lock
+          |
+          v
+acquire vault lock
+  preserve eligible dirty vault changes
+  re-read local and remote refs
+  fast-forward or merge
+  revalidate vault boundary
+  rebuild/publish index if content changed
+  broadcast one vault revision
+release vault lock
+          |
+          v
+push without vault lock when required
+```
+
+The graph must be re-read after acquiring the lock because a web or MCP write
+may finish while fetch is running. A push rejected because another writer moved
+the remote enters a small bounded fetch/reconcile/push loop, then falls back to
+backoff while retaining local commits.
+
+The main graph actions are:
+
+| State | Action |
+| --- | --- |
+| Equal | No working-tree change |
+| Remote ahead only | Fast-forward and reindex |
+| Local ahead only | Push in bidirectional mode |
+| Both ahead, clean | Merge, reindex, and push in bidirectional mode |
+| Both ahead, conflict | Preserve local head and enter conflict state |
+
+Unexpected local history in pull-only mode is preserved and reported, never
+reset implicitly.
+
+## Working Tree and Index Consistency
+
+Checkout, merge, reset, note mutation, and indexing must not race. Watcher
+refreshes therefore coordinate through the same vault mutation lock as web, MCP,
+and Git working-tree changes.
+
+Readers continue using the previous SQLite snapshot while a replacement is
+built. The new snapshot and vault revision become visible only after a successful
+transaction. A failed later rebuild retains the previous snapshot and marks the
+vault degraded.
+
+Manager-generated filesystem events are coalesced so one working-tree transition
+produces one index publication and one revision event.
+
+## Vault Subdirectory Boundary
+
+Repository root and vault root remain distinct. The configured subdirectory is
+relative, canonicalized, and contained within the repository root.
+
+Containment is revalidated after every checkout, merge, reset, or recovery. This
+prevents a remote commit from replacing the vault directory with an escaping
+symlink.
+
+In subdirectory mode Hatchdoor stages only the validated vault subtree. Dirty
+files elsewhere in the repository are never committed, reset, or deleted by
+Hatchdoor; if they prevent safe integration, the lifecycle reports an actionable
+condition.
+
+## Empty Repositories and Recovery
+
+Local mode retains automatic starter-vault seeding. Managed mode does not seed
+merely because a repository has no Markdown.
+
+An empty or unborn remote may be bootstrapped only in bidirectional mode with an
+explicit option. Pull-only mode rejects bootstrap and never creates a commit it
+cannot push. Source preparation therefore owns seeding; generic index
+construction does not.
+
+Startup recovery classifies repository operation state, dirty vault files,
+outside-vault dirt, and unpushed commits separately. It must preserve dirty vault
+content before any hard reset or operation cleanup. Bidirectional dirty work is
+committed and retried; pull-only dirt becomes an actionable degraded condition.
+
+## Conflict Policy
+
+On a conflict Hatchdoor:
+
+1. records the conflicting paths and both heads;
+2. restores the last clean local head without discarding it;
+3. creates a unique conflict-preservation branch;
+4. attempts to publish that branch according to the chosen product policy;
+5. enters conflict state and disables web/MCP mutation; and
+6. continues serving the last consistent local snapshot read-only.
+
+Hatchdoor never force-pushes or chooses a conflicting version. Once the remote
+configured branch contains the preserved work, polling or manual sync can return
+the vault to ready state.
+
+## Configuration, API, and UI
+
+Configuration remains deployment-owned and restart-bound. It defines source,
+URL, branch, mode, optional subdirectory, persistent checkout location, polling,
+bootstrap, and optional HTTPS credentials. Public repositories require no token;
+private credentials are passed only through `git2` callbacks.
+
+The first operational surface includes:
+
+- lifecycle status and progress;
+- sanitized branch, ahead/behind, dirty, conflict, and operation timestamps;
+- redacted actionable errors;
+- manual retry/sync;
+- shared write capabilities; and
+- a minimal initialization view and ready/degraded/conflict indicator.
+
+It does not include configuration forms or secret entry.
+
+## Deployment and Compatibility
+
+The managed checkout and generated cache use separate persistent locations, for
+example:
+
+```text
+/data/repositories/vault   managed non-bare checkout
+/data/cache                generated SQLite cache
+```
+
+The runtime remains rootless and distroless and uses the existing `git2`
+dependency. A process-lifetime filesystem lock enforces one process per managed
+checkout.
+
+When the source setting is absent or local, current `VAULT_PATH`, starter
+seeding, watcher, writes, and optional legacy Git sync remain unchanged. Existing
+host-managed checkouts are not automatically adopted.
+
+## Decisions to Resolve
+
+1. Is a nonempty managed repository without Markdown a valid empty vault or an
+   unavailable source?
+2. What polling interval should be the default, and can polling be disabled?
+3. What fixed immediate retry limit applies to push races?
+4. Should conflict-preservation branches be published automatically?
+5. Does `/ready` stay successful whenever a previously published snapshot is
+   usable, including degraded and conflict states?
+6. What minimum sanitized repository identity should status expose?

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -186,19 +186,22 @@ checks.
 `REGISTRY_SCHEMA_VERSION`, canonical `VaultId` generation and parsing,
 `VaultRegistryStore`, immutable `VaultRegistrySnapshot` values, explicit
 `VaultRegistryState::Ready` versus `Recovery`, structured recovery/error
-types, and the versioned `/data/state/vaults.json` format. An absent file is a
-complete revision-0 zero-Vault state and is not created by reads. Commits are
-serialized by normalized registry path across all store handles in the process,
-compare the expected persisted revision, increment it once, and atomically
-replace the file with owner-only permissions. Corrupt, unsupported, or
-future-schema files expose no Vault records and are never overwritten
-automatically. `VaultRecord` is deliberately an empty persisted identity slot in
-#85; #86 owns its accepted definition fields, validation, redaction, and
-lifecycle operations without changing the registry identity contract.
+types, redacted `VaultDefinition` projections, tagged `VaultSource` values for
+local, existing-Git, and managed-Git Vaults, `VaultGitMode`, credential write
+inputs/updates, validated `add`/`edit`/`enable`/`disable`/`disconnect`
+operations, and the versioned `/data/state/vaults.json` format. An absent file
+is a complete revision-0 zero-Vault state and is not created by reads. Commits
+are serialized by normalized registry path across all store handles in the
+process, compare the expected persisted revision, increment it once, and
+atomically replace the file with owner-only permissions. Corrupt, unsupported,
+future-schema, or structurally invalid definition files expose no Vault records
+and are never overwritten automatically.
 
-**Consumers:** the Vault-definition and legacy-import packets will consume
-this boundary in #86 and #87. No runtime, HTTP, MCP, frontend, cache, search, or
-Git consumer is integrated by #85.
+**Consumers:** the legacy-import packet will consume this boundary in #87;
+later runtime and management adapters consume its safe projections and
+lifecycle operations under their own work packets. No runtime, HTTP, MCP,
+frontend, cache, search, migration, or Git-lifecycle consumer is integrated by
+#86.
 
 **Coordination paths:** `src/lib.rs` exports the boundary. Future construction
 in runtime composition, `/data/state` deployment persistence, and management
@@ -206,6 +209,12 @@ adapters require their own declared work packets.
 
 **Invariants:** the registry is the sole Hatchdoor-owned Vault-definition
 authority; immutable IDs are UUID v4 map keys; revision conflicts save nothing;
+names are unique case-insensitively; canonical Vault paths never overlap and
+disabled definitions continue reserving them; identity-bearing changes require
+a disabled definition plus explicit same-Vault confirmation; readable
+non-writable directories remain valid; disconnect deletes no files or Git
+state; HTTPS credentials persist only in the private registry record and never
+appear in projections, debug output, errors, status, or repository URLs;
 recovery retains the original bytes; Vault contents remain authoritative
 Markdown and SQLite remains disposable (ADR-01); the store adds no service,
 framework, or speculative trait (ADR-02/13); filesystem behavior assumes no

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -176,6 +176,44 @@ schemas fail with recovery guidance and are never overwritten.
 **Validation:** `cargo test runtime_config`, followed by the full backend
 checks.
 
+### Vault collection registry
+
+**Kind:** infrastructure/persistent domain state.
+
+**Owned paths:** `src/vault_registry.rs`.
+
+**Public contract:** `DEFAULT_VAULT_REGISTRY_PATH`,
+`REGISTRY_SCHEMA_VERSION`, canonical `VaultId` generation and parsing,
+`VaultRegistryStore`, immutable `VaultRegistrySnapshot` values, explicit
+`VaultRegistryState::Ready` versus `Recovery`, structured recovery/error
+types, and the versioned `/data/state/vaults.json` format. An absent file is a
+complete revision-0 zero-Vault state and is not created by reads. Commits are
+serialized by normalized registry path across all store handles in the process,
+compare the expected persisted revision, increment it once, and atomically
+replace the file with owner-only permissions. Corrupt, unsupported, or
+future-schema files expose no Vault records and are never overwritten
+automatically. `VaultRecord` is deliberately an empty persisted identity slot in
+#85; #86 owns its accepted definition fields, validation, redaction, and
+lifecycle operations without changing the registry identity contract.
+
+**Consumers:** the Vault-definition and legacy-import packets will consume
+this boundary in #86 and #87. No runtime, HTTP, MCP, frontend, cache, search, or
+Git consumer is integrated by #85.
+
+**Coordination paths:** `src/lib.rs` exports the boundary. Future construction
+in runtime composition, `/data/state` deployment persistence, and management
+adapters require their own declared work packets.
+
+**Invariants:** the registry is the sole Hatchdoor-owned Vault-definition
+authority; immutable IDs are UUID v4 map keys; revision conflicts save nothing;
+recovery retains the original bytes; Vault contents remain authoritative
+Markdown and SQLite remains disposable (ADR-01); the store adds no service,
+framework, or speculative trait (ADR-02/13); filesystem behavior assumes no
+runtime shell and remains usable by the rootless image (ADR-12).
+
+**Validation:** `cargo test vault_registry`,
+`node scripts/check-module-map.mjs`, followed by the full backend checks.
+
 ### Web authentication
 
 **Kind:** infrastructure/security.

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -84,6 +84,7 @@ that production inventory are still checked for stale paths and duplicates.
 - `src/app_state.rs`
 - `src/config.rs`
 - `src/startup.rs`
+- `src/vault_runtime.rs`
 - `src/model_setup.rs`
 - `src/vault_watcher.rs`
 
@@ -106,6 +107,10 @@ that production inventory are still checked for stale paths and duplicates.
 - `AppConfig` is the environment-derived deployment contract and interprets the
   live values from the startup `RuntimeConfig` snapshot.
 - `StartupTracker` exposes startup/model/indexing readiness.
+- `VaultRuntime` and its serialized snapshot expose the current configured
+  source, mode, lifecycle phase, and derived capabilities. This is the rebased
+  single-configured-Vault foundation, not the accepted collection registry or
+  final per-Vault runtime topology.
 - `ModelSetup` owns local model selection, terms acceptance, download integrity,
   and persistent setup records.
 - `spawn_vault_watcher` connects filesystem events to cache refresh.
@@ -128,7 +133,8 @@ specific field, route, startup phase, or integration being changed. Adding an
 
 **Validation:** `cargo test server`, `cargo test app_state`,
 `cargo test config`, `cargo test startup`, `cargo test model_setup`,
-`cargo test vault_watcher`, followed by the full backend checks.
+`cargo test vault_runtime`, `cargo test vault_watcher`, followed by the full
+backend checks.
 
 ### Live configuration foundation
 

--- a/docs/plans/managed-git-vault-agent-handoff.md
+++ b/docs/plans/managed-git-vault-agent-handoff.md
@@ -50,6 +50,63 @@ Before proposing implementation, inspect at least:
 Also inspect the current branch, working-tree status, recent commits, and any
 repository instructions before editing. Preserve unrelated user changes.
 
+## Verified Development VM Snapshot
+
+The following was checked on 2026-07-22. Treat it as a host snapshot rather than
+a permanent project guarantee, and recheck it if the environment changes.
+
+Available tooling:
+
+- Git 2.47.3;
+- Rust 1.97.1 with Cargo, rustfmt, and Clippy;
+- Node 24.16.0 and npm 12.0.1 under
+  `/home/alemhnan/.nvm/versions/node/v24.16.0/bin`;
+- GCC/G++, make, Perl, pkg-config, linker tools, SSH, curl, and Python;
+- Docker 26.1.5 with Docker Compose 2.26.1 and a reachable daemon; and
+- an existing Cargo registry cache.
+
+Preparation still required before verification:
+
+- The repository pins Rust 1.96.0, which is not currently installed. Install
+  that exact toolchain or explicitly agree to verify with the installed 1.97.1;
+  do not silently ignore the pin.
+- Node and npm are not on the non-interactive shell `PATH`. Prefix commands with
+  `/home/alemhnan/.nvm/versions/node/v24.16.0/bin` in `PATH` or load the matching
+  NVM environment before running frontend checks.
+- `frontend/node_modules` is absent, so `npm ci` is required.
+- GitHub CLI (`gh`) is absent. This does not block local work or ordinary Git
+  push, but GitHub Actions log and review-thread workflows need `gh` or the
+  available GitHub connector.
+- The current `origin` points to `BattermanZ/Hatchdoor`; the contributor fork
+  remote and push authentication must be configured and verified separately
+  before publishing.
+
+Host capacity at the same check:
+
+- 1.5 GiB physical RAM, with about 988 MiB available at measurement time;
+- 2.0 GiB swap, almost entirely free;
+- 2 logical CPUs; and
+- about 28 GiB free on the workspace filesystem.
+
+This is sufficient for development and verification, but memory is tight for
+parallel Rust, frontend, and container builds. Run the toolchains sequentially,
+use `CARGO_BUILD_JOBS=1` for local Cargo compilation, and avoid running a full
+container build alongside other compilation. Expect a release/container build
+to use swap and complete slowly. If it is killed for memory despite constrained
+parallelism, perform final container verification on a larger runner rather than
+weakening the checks.
+
+The production Hatchdoor instance reported to use about 1 GiB RAM is managed by
+Komodo on another host, not this development VM. At the 2026-07-22 check, the
+local Docker context had no running containers, no Hatchdoor or Komodo process
+was present, and total host memory use was about 557 MiB. The live deployment
+therefore does not consume this VM's build headroom.
+
+If Hatchdoor is later deployed on this same 1.5 GiB VM at roughly 1 GiB resident
+memory, do not compile alongside it: Rust or container compilation could force
+heavy swapping, disrupt the service, or trigger an out-of-memory kill. Stop or
+move the build, or use a larger runner in that situation.
+
 ## Required Debrief
 
 After reading and inspection, provide a concise debrief before writing code. It

--- a/docs/plans/managed-git-vault-agent-handoff.md
+++ b/docs/plans/managed-git-vault-agent-handoff.md
@@ -1,0 +1,153 @@
+# Managed Git Vault Foundation — Agent Handoff
+
+Use this document to start a fresh implementation chat. It provides the entry
+point, required context, and expected debrief before code changes begin.
+
+## Objective
+
+Implement the managed Git vault foundation described in this repository, one
+reviewable pull-request slice at a time.
+
+The intended end result is one environment-configured local or managed Git vault
+whose acquisition, synchronization, indexing, capabilities, and failures are
+observable while the Hatchdoor application remains available.
+
+Existing local `VAULT_PATH` deployments must remain backward compatible.
+
+## Required Reading
+
+Read these documents in order:
+
+1. [`docs/architecture/managed-git-vault-foundation.md`](../architecture/managed-git-vault-foundation.md)
+2. [`docs/plans/managed-git-vault-foundation.md`](managed-git-vault-foundation.md)
+3. [`docs/roadmap/vault-lifecycle.md`](../roadmap/vault-lifecycle.md)
+4. [`docs/adr/README.md`](../adr/README.md), especially ADR-01, ADR-03, ADR-07,
+   ADR-10, ADR-12, and ADR-13
+5. [Managed Git Vault Lifecycle, PR #18](https://github.com/BattermanZ/Hatchdoor/pull/18),
+   including its review discussion
+
+Treat the architecture and plan as draft working documents. Do not silently
+resolve an open product decision or change an accepted ADR.
+
+## Current-Code Orientation
+
+Before proposing implementation, inspect at least:
+
+- `src/server.rs` — composition, startup, health, readiness, and task startup;
+- `src/app_state.rs` — vault path, cache publication, locks, and revisions;
+- `src/startup.rs` — current startup state model;
+- `src/config.rs` — application environment configuration;
+- `src/git/config.rs` — legacy Git-sync configuration;
+- `src/git/sync.rs` — commit, fetch, integrate, push, and recovery behavior;
+- `src/git/task.rs` — debouncing, retry, and lock boundaries;
+- `src/git/status.rs` — current Git status model;
+- `src/vault_watcher.rs` — filesystem refresh behavior;
+- `src/handlers/write_api.rs` — browser capability and mutation guards;
+- `src/mcp/config.rs` and `src/mcp/tools/` — MCP capability and mutation guards;
+  and
+- `src/vault/seed.rs` and cache construction — current starter-vault policy.
+
+Also inspect the current branch, working-tree status, recent commits, and any
+repository instructions before editing. Preserve unrelated user changes.
+
+## Required Debrief
+
+After reading and inspection, provide a concise debrief before writing code. It
+must include:
+
+1. The current behavior and the specific gap being addressed.
+2. The first proposed pull-request slice and why it is independently useful.
+3. The files and runtime seams likely to change.
+4. The compatibility and data-loss risks.
+5. The characterization and new tests needed.
+6. Any open product decision that blocks or materially changes the slice.
+7. What is explicitly deferred.
+
+Wait for confirmation after this debrief if the user has asked to discuss or
+approve scope before implementation. Otherwise, proceed only when the requested
+slice is unambiguous and no open product decision changes its behavior.
+
+## Recommended First Slice
+
+Begin with the runtime foundation, not cloning:
+
+- explicit local versus managed source configuration types;
+- a lifecycle snapshot that can represent no ready vault;
+- shared runtime capabilities for web and MCP;
+- application startup that does not require a ready vault path or index; and
+- characterization tests proving local mode remains unchanged.
+
+This slice should establish the seam needed by later acquisition and lifecycle
+work without implementing Git clone, polling, conflict branches, or UI-managed
+configuration yet.
+
+If this is too large for one review, split it into:
+
+1. source/lifecycle/capability types with local-mode adapters; then
+2. always-available startup and structured unavailable/initializing responses.
+
+## Open Decisions
+
+Do not assume answers to these without user agreement:
+
+1. Whether a nonempty managed repository without Markdown is a valid empty
+   vault or an unavailable source.
+2. The default polling interval and whether polling can be disabled.
+3. The immediate retry limit for non-fast-forward push races.
+4. Whether conflict-preservation branches are pushed automatically.
+5. Readiness semantics for degraded and conflict states.
+6. The sanitized repository identity exposed through status.
+
+Most of these do not block the recommended first slice. If a chosen slice
+depends on one, surface it in the debrief rather than selecting a default.
+
+## Non-Negotiable Constraints
+
+- Markdown remains the source of truth; SQLite remains disposable.
+- Local mode is the default and preserves current behavior.
+- Git network operations must not hold the vault mutation lock.
+- No dirty work or local commit may be silently reset, discarded, or
+  force-pushed.
+- Web and MCP must enforce the same lifecycle-derived mutation capability.
+- Pull-only and conflict states disable every mutation surface.
+- Repository and vault roots remain distinct in subdirectory mode.
+- Vault containment must be revalidated after every working-tree transition.
+- Subdirectory mode must never stage unrelated repository files.
+- Credentials must not appear in URLs, repository configuration, logs, status,
+  errors, or commits.
+- The runtime remains rootless, distroless, and independent of a Git executable.
+- Do not introduce speculative multi-vault abstractions into this increment.
+
+## Verification Expectations
+
+For every slice:
+
+- add characterization tests before changing an existing behavior;
+- add regression tests for concurrency, containment, or recovery invariants
+  touched by the slice;
+- use temporary local repositories for Git behavior where possible;
+- run formatting, linting, backend tests, and relevant frontend checks;
+- verify `git diff --check`; and
+- clearly separate local verification from container or end-to-end verification.
+
+Do not mark a plan item complete merely because its types or interfaces exist;
+its documented behavior and verification must be present.
+
+## Copyable Fresh-Chat Prompt
+
+```text
+Work on the Hatchdoor managed Git vault foundation.
+
+Start by reading:
+- docs/plans/managed-git-vault-agent-handoff.md
+- docs/architecture/managed-git-vault-foundation.md
+- docs/plans/managed-git-vault-foundation.md
+
+Then inspect the linked roadmap, ADRs, PR #18, and the current implementation
+seams named in the handoff. Do not edit code yet.
+
+Give me the required concise debrief for the recommended first slice: current
+behavior, proposed boundary, affected seams, risks, tests, blockers, and deferred
+work. After we agree on that debrief, implement only the approved slice and
+verify backward compatibility with local mode.
+```

--- a/docs/plans/managed-git-vault-foundation.md
+++ b/docs/plans/managed-git-vault-foundation.md
@@ -1,0 +1,263 @@
+# Managed Git Vault Foundation — Implementation Plan
+
+- Status: Draft for discussion
+- Architecture: [`docs/architecture/managed-git-vault-foundation.md`](../architecture/managed-git-vault-foundation.md)
+- Product roadmap: [`docs/roadmap/vault-lifecycle.md`](../roadmap/vault-lifecycle.md)
+- Design proposal: [Managed Git Vault Lifecycle, PR #18](https://github.com/BattermanZ/Hatchdoor/pull/18)
+- Fresh-chat entry point: [`docs/plans/managed-git-vault-agent-handoff.md`](managed-git-vault-agent-handoff.md)
+- Target: One environment-configured local or managed Git vault with an
+  observable background lifecycle
+
+## Completion Definition
+
+Existing local deployments behave unchanged. A managed Git deployment can
+acquire, reuse, synchronize, index, expose, and safely recover one persistent
+vault while the application remains reachable during vault failures.
+
+The items are ordered implementation milestones, not completed work.
+
+## 0. Resolve the Open Product Decisions
+
+- [ ] Decide how to treat a nonempty managed repository without Markdown.
+- [ ] Select the polling default and whether polling can be disabled.
+- [ ] Select the immediate retry limit for non-fast-forward push races.
+- [ ] Decide whether conflict-preservation branches are pushed automatically.
+- [ ] Define readiness behavior for degraded and conflict states.
+- [ ] Define the sanitized repository identity exposed to clients.
+- [ ] Propose an ADR amendment if the accepted direction changes ADR-10.
+
+Exit: Observable behavior is decided and any required ADR proposal is ready.
+
+## 1. Establish the Runtime Foundation
+
+- [ ] Add explicit local and managed Git source configuration while keeping local
+  as the default.
+- [ ] Represent pull-only and bidirectional managed modes.
+- [ ] Separate configured source, repository root, and validated vault root.
+- [ ] Introduce one lifecycle snapshot for phase, progress, capabilities,
+  repository/index status, and redacted errors.
+- [ ] Allow `AppState` to exist before a vault path or index is ready.
+- [ ] Derive and enforce one mutation capability across browser and MCP.
+- [ ] Keep existing demo, web-auth, and MCP-auth posture checks intact.
+
+Verification:
+
+- [ ] Local mode resolves and behaves as before.
+- [ ] Pull-only rejects every browser and MCP mutation.
+- [ ] Invalid combinations fail clearly without leaking secrets.
+
+Exit: The HTTP application can run without a ready vault, and all surfaces share
+one capability decision.
+
+## 2. Make Vault Startup a Background Lifecycle
+
+- [ ] Start the HTTP listener before acquisition and indexing.
+- [ ] Keep the SPA, `/health`, `/ready`, and lifecycle status reachable throughout
+  initialization and failure.
+- [ ] Return stable structured errors from vault-dependent surfaces until a
+  snapshot is ready.
+- [ ] Preserve an existing published SQLite snapshot during later sync/reindex.
+- [ ] Add an idempotent manual retry command.
+- [ ] Continue to fail fast for unsafe application security configuration.
+
+Verification:
+
+- [ ] The UI remains reachable during a blocked or failed first acquisition.
+- [ ] Readiness changes only after the first index publication.
+- [ ] A transient failure or changed token file can be retried without restart;
+  changed environment settings take effect after restart.
+
+Exit: Operational vault failure is runtime state, not process failure.
+
+## 3. Separate Source Preparation From Indexing
+
+- [ ] Move starter-vault seeding out of generic cache construction.
+- [ ] Preserve the current local empty-vault behavior.
+- [ ] Apply the selected no-Markdown policy to managed repositories.
+- [ ] Reject bootstrap in pull-only mode.
+- [ ] Support explicit bidirectional bootstrap of an empty/unborn remote.
+
+Verification:
+
+- [ ] Local seeding tests remain unchanged.
+- [ ] A managed repository is never seeded implicitly.
+- [ ] Pull-only creates no bootstrap commit.
+- [ ] Explicit bidirectional bootstrap creates and pushes starter notes once.
+
+Exit: Each source prepares content according to its own mutation policy before
+generic indexing begins.
+
+## 4. Acquire and Reuse a Managed Checkout
+
+- [ ] Validate HTTPS URLs and reject embedded credentials.
+- [ ] Support public repositories without credentials and private repositories
+  through `git2` callbacks using a token or token file.
+- [ ] Acquire a process-lifetime checkout ownership lock.
+- [ ] Clone into an owned temporary sibling, validate it, and atomically install
+  it on persistent storage.
+- [ ] Reopen and validate a matching checkout on restart.
+- [ ] Refuse to overwrite or adopt unknown destinations.
+- [ ] Validate branch, origin, repository shape, and vault boundary.
+
+Verification:
+
+- [ ] Fresh public and authenticated fixture clones succeed.
+- [ ] Interrupted clone does not occupy the final destination.
+- [ ] Restart reuses the checkout.
+- [ ] Wrong origin/branch/subdirectory and concurrent ownership fail safely.
+- [ ] Credentials do not appear in logs, status, errors, or `.git/config`.
+
+Exit: Managed configuration reliably produces a validated persistent vault
+without a Git executable.
+
+## 5. Enforce the Vault Boundary
+
+- [ ] Reject absolute, traversing, and escaping subdirectory configuration.
+- [ ] Revalidate canonical containment after every checkout, merge, reset, and
+  recovery operation.
+- [ ] Stage only the validated vault subtree in subdirectory mode.
+- [ ] Leave unrelated repository dirt untouched and report it if it blocks safe
+  integration.
+- [ ] Keep every note, asset, attachment, and download operation inside the
+  validated vault root.
+
+Verification:
+
+- [ ] Startup and post-checkout symlink escapes are rejected.
+- [ ] A Hatchdoor write never commits an outside-subtree file.
+- [ ] Outside-subtree dirt is never reset or deleted implicitly.
+
+Exit: Remote or local repository content cannot redirect Hatchdoor outside its
+vault or make it publish unrelated files.
+
+## 6. Build the Repository Lifecycle Actor
+
+- [ ] Evolve the write-triggered task into one actor handling startup, polling,
+  write batches, manual commands, retry timers, and shutdown.
+- [ ] Fetch and push without the vault mutation lock.
+- [ ] Under the lock, preserve dirty vault work and re-read the commit graph.
+- [ ] Implement no-op, fast-forward, ahead, clean-divergence, and conflict paths.
+- [ ] Revalidate the vault boundary after working-tree changes.
+- [ ] Poll for inbound changes independently of Hatchdoor writes.
+- [ ] Add bounded immediate reconciliation for non-fast-forward push races,
+  followed by backoff with local commits retained.
+
+Verification:
+
+- [ ] Network phases never hold the vault lock.
+- [ ] A write completed during fetch is preserved and included in the post-lock
+  graph decision.
+- [ ] Remote-ahead uses fast-forward without a merge commit.
+- [ ] Clean divergence preserves both histories.
+- [ ] Push races reconcile or stop at the bound without losing local commits.
+- [ ] Polling ingests a change made from another clone.
+
+Exit: One actor safely maintains a shared-branch checkout with independent
+remote writers.
+
+## 7. Publish a Consistent Index
+
+- [ ] Define one lock order for working-tree mutation and index refresh.
+- [ ] Make watcher refreshes coordinate through the vault mutation lock.
+- [ ] Explicitly rebuild after manager-originated working-tree changes.
+- [ ] Coalesce manager-generated watcher events.
+- [ ] Publish SQLite changes transactionally and broadcast one revision.
+- [ ] Retain the prior snapshot when a later rebuild fails.
+
+Verification:
+
+- [ ] Checkout/indexing cannot race browser, MCP, or watcher work.
+- [ ] Readers see the previous or replacement snapshot, never a mixed tree.
+- [ ] One remote transition produces one publication and revision event.
+- [ ] A failed rebuild leaves the prior snapshot usable in degraded state.
+
+Exit: Every published SQLite snapshot corresponds to one validated working-tree
+state.
+
+## 8. Add Recovery and Conflict Safety
+
+- [ ] Classify repository operation state, dirty vault files, outside-vault dirt,
+  and ahead commits separately at startup.
+- [ ] Preserve dirty vault content before any hard reset or cleanup.
+- [ ] Commit and retry recovered dirt in bidirectional mode.
+- [ ] Preserve and report unexpected dirt in pull-only mode.
+- [ ] On conflict, retain the local head on a unique preservation branch.
+- [ ] Publish the branch according to the selected policy and report whether it
+  exists remotely or only locally.
+- [ ] Disable browser/MCP mutation in conflict state while continuing read-only
+  browsing and search.
+- [ ] Recover automatically after the configured remote branch contains the
+  preserved work.
+
+Verification:
+
+- [ ] A process killed during debounce recovers and pushes the dirty edit.
+- [ ] Interrupted Git operation recovery does not discard unrelated vault dirt.
+- [ ] Remote outage with an existing checkout starts degraded and later heals.
+- [ ] A conflict never force-pushes and blocks all mutation surfaces.
+- [ ] Failed preservation-branch publication remains durable locally.
+
+Exit: Crashes, outages, and conflicts cannot silently lose vault work.
+
+## 9. Add the Operational Surface
+
+- [ ] Expose lifecycle phase, progress, mode, branch, ahead/behind, dirty state,
+  operation timestamps, conflicts, and redacted errors.
+- [ ] Add authenticated retry/sync behavior.
+- [ ] Extend web capabilities and MCP Git status from the same snapshot.
+- [ ] Show first acquisition/indexing progress in the existing startup surface.
+- [ ] Add a compact ready/syncing/degraded/conflict indicator and details view.
+- [ ] Clearly explain pull-only and conflict read-only states.
+- [ ] Do not add configuration forms or secret entry.
+
+Verification:
+
+- [ ] UI states map mechanically to lifecycle fixtures.
+- [ ] Web and MCP report consistent mode, readiness, and capabilities.
+- [ ] Status and errors contain no secrets or internal filesystem paths.
+
+Exit: An operator can understand and retry lifecycle work without container
+access or log inspection.
+
+## 10. Finish Shutdown, Deployment, and Compatibility
+
+- [ ] On graceful shutdown, stop mutations, drain writes, commit locally, and
+  attempt final remote reconciliation within a bounded timeout.
+- [ ] Document separate persistent repository and cache storage.
+- [ ] Verify rootless/distroless clone and reuse permissions.
+- [ ] Keep local mode and legacy `HATCHDOOR_GIT_SYNC_ENABLED` compatible.
+- [ ] Document public pull-only and private bidirectional deployments, outages,
+  conflicts, and host-managed checkout migration.
+- [ ] Add container-level end-to-end scenarios for the completion definition.
+
+Release scenarios:
+
+- [ ] Existing local deployment upgrades without changes.
+- [ ] Fresh public pull-only and private bidirectional sources become ready.
+- [ ] Container recreation reuses the checkout and retained local state.
+- [ ] First-clone failure leaves the application reachable and actionable.
+- [ ] Remote changes, network outage/recovery, push races, conflicts, dirty crash
+  recovery, and subdirectory escapes behave as documented.
+
+Exit: The complete behavior is covered by automated tests or documented
+container verification and is ready for release review.
+
+## Suggested Pull Request Slices
+
+1. Runtime source, lifecycle, and capability model.
+2. Always-available startup and source-specific seeding.
+3. Managed checkout acquisition, reuse, and vault boundary.
+4. Polling, reconciliation, and coordinated index publication.
+5. Crash/conflict recovery and graceful shutdown.
+6. Operational API, minimal UI, deployment docs, and end-to-end tests.
+
+Each slice should preserve local behavior and add characterization tests before
+changing an existing seam.
+
+## Deferred Work
+
+- UI-managed vault configuration and Git secrets.
+- Configuration precedence between environment and product state.
+- Runtime add/edit/remove/switch behavior.
+- Multi-vault identity, navigation, search, indexes, and MCP scoping.
+- Provider-specific conflict workflows and additional Git transports.

--- a/docs/roadmap/vault-lifecycle.md
+++ b/docs/roadmap/vault-lifecycle.md
@@ -133,6 +133,13 @@ Git is a transport and collaboration mechanism around the Markdown vault. A
 Git failure should affect synchronization, not the availability of the entire
 Hatchdoor application.
 
+The proposed first increment is detailed in the
+[managed Git vault foundation architecture](../architecture/managed-git-vault-foundation.md)
+and its [implementation plan](../plans/managed-git-vault-foundation.md). These
+are draft working documents for turning this roadmap outcome into reviewable
+delivery slices; they do not expand the product-managed configuration scope of
+Phase 1.
+
 ### 1.4 Configurable Embedding Provider
 
 > **Status: exploratory, low priority, not accepted.** External inference

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -14,12 +14,19 @@ use crate::cache::SqliteCache;
 use crate::embed::Embedder;
 use crate::startup::{IndexingProgressSnapshot, StartupTracker};
 use crate::vault::{VaultIndex, VaultScanConfig, seed_empty_vault};
+use crate::vault_runtime::VaultSource;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub vault_path: PathBuf,
     pub cache_db_path: PathBuf,
-    pub cache: Arc<RwLock<VaultCache>>,
+    /// Disposable SQLite handle used while a configured local vault is still
+    /// being indexed. It is published through `ready_vault` only after a
+    /// successful build.
+    pub startup_sqlite: Arc<SqliteCache>,
+    /// Published only after a vault path has been validated and its first index
+    /// has committed. The application can serve liveness and lifecycle routes
+    /// while this is `None`.
+    pub ready_vault: Arc<RwLock<Option<ReadyVault>>>,
     pub vault_revision: Arc<AtomicU64>,
     pub vault_events: broadcast::Sender<u64>,
     /// Fires when a reindex changes the vault's layer marker set, so the MCP
@@ -298,8 +305,42 @@ impl AppState {
             handle.record(record);
         }
     }
+
+    pub async fn ready_vault(&self) -> Result<ReadyVault, (StatusCode, Json<ErrorResponse>)> {
+        self.ready_vault
+            .read()
+            .await
+            .clone()
+            .ok_or_else(vault_unavailable)
+    }
+
+    pub async fn publish_ready_vault(&self, vault_path: PathBuf, cache: VaultCache) {
+        *self.ready_vault.write().await = Some(ReadyVault { vault_path, cache });
+    }
+
+    pub async fn vault_path(&self) -> Option<PathBuf> {
+        self.ready_vault
+            .read()
+            .await
+            .as_ref()
+            .map(|ready| ready.vault_path.clone())
+    }
+
+    pub fn configured_local_vault_path(&self) -> Option<PathBuf> {
+        match self.startup.runtime().source() {
+            VaultSource::Local { vault_path } => Some(vault_path.clone()),
+            VaultSource::ManagedGit(_) => None,
+        }
+    }
 }
 
+#[derive(Clone)]
+pub struct ReadyVault {
+    pub vault_path: PathBuf,
+    pub cache: VaultCache,
+}
+
+#[derive(Clone)]
 pub struct VaultCache {
     pub sqlite: Arc<SqliteCache>,
 }
@@ -356,8 +397,16 @@ pub fn build_cache_with_sqlite_and_progress(
 pub async fn sqlite_cache(
     state: &AppState,
 ) -> Result<Arc<SqliteCache>, (StatusCode, Json<ErrorResponse>)> {
-    let guard = state.cache.read().await;
-    Ok(guard.sqlite.clone())
+    Ok(state.ready_vault().await?.cache.sqlite)
+}
+
+pub fn vault_unavailable() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorResponse {
+            error: "Vault is not ready".to_string(),
+        }),
+    )
 }
 
 /// Build a generic `500` response, logging the real detail rather than leaking
@@ -438,8 +487,19 @@ async fn run_reindex(
     state: &AppState,
     on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
 ) -> Result<(), String> {
-    let sqlite = state.cache.read().await.sqlite.clone();
-    let vault_path = state.vault_path.clone();
+    let ready_vault = state.ready_vault.read().await.clone();
+    let was_ready = ready_vault.is_some();
+    let (sqlite, vault_path) = match ready_vault {
+        Some(ready) => (ready.cache.sqlite, ready.vault_path),
+        None => (
+            state.startup_sqlite.clone(),
+            state
+                .configured_local_vault_path()
+                .ok_or_else(|| "Vault is not ready".to_string())?,
+        ),
+    };
+    let current_sqlite = sqlite.clone();
+    let logged_vault_path = vault_path.clone();
     let embedder = state.embedder.clone();
     let runtime_snapshot = state.runtime_snapshot();
     let scan_config = state.live_scan_config()?;
@@ -477,13 +537,20 @@ async fn run_reindex(
     .await
     .map_err(|error| format!("background reindex task panicked: {error}"))??;
 
-    debug!(vault_path = %state.vault_path.display(), "SQLite vault cache refreshed");
+    if !was_ready {
+        state
+            .publish_ready_vault(
+                logged_vault_path.clone(),
+                VaultCache {
+                    sqlite: current_sqlite.clone(),
+                },
+            )
+            .await;
+    }
 
-    let current_marker_hash = state
-        .cache
-        .read()
-        .await
-        .sqlite
+    debug!(vault_path = %logged_vault_path.display(), "SQLite vault cache refreshed");
+
+    let current_marker_hash = current_sqlite
         .get_metadata("marker_set_hash")
         .ok()
         .flatten();
@@ -644,9 +711,9 @@ mod tests {
         let (vault_events, _) = broadcast::channel(64);
         let (mcp_tools_changed, _) = broadcast::channel(16);
         AppState {
-            vault_path,
             cache_db_path: state_root.join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault { vault_path, cache }))),
             vault_revision: Arc::new(AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -676,8 +743,9 @@ mod tests {
         std::fs::create_dir_all(&vault_path).expect("create vault");
         std::fs::write(vault_path.join("Home.md"), "home").expect("write note");
 
-        let mut state = state_with_vault(vault_path);
-        state.vault_path = dir.path().join("missing-vault");
+        let state = state_with_vault(vault_path);
+        state.ready_vault.write().await.as_mut().unwrap().vault_path =
+            dir.path().join("missing-vault");
 
         let result = refresh_coalescing(&state).await;
         assert!(result.is_err());
@@ -690,8 +758,9 @@ mod tests {
         std::fs::create_dir_all(&vault_path).expect("create vault");
         std::fs::write(vault_path.join("Home.md"), "home").expect("write note");
 
-        let mut state = state_with_vault(vault_path);
-        state.vault_path = dir.path().join("missing-vault");
+        let state = state_with_vault(vault_path);
+        state.ready_vault.write().await.as_mut().unwrap().vault_path =
+            dir.path().join("missing-vault");
 
         let result = sqlite_cache(&state).await;
         assert!(result.is_ok());
@@ -742,11 +811,9 @@ mod tests {
         refresh_now(&state).await.expect("refresh");
 
         assert!(
-            state
-                .cache
-                .read()
+            sqlite_cache(&state)
                 .await
-                .sqlite
+                .expect("ready cache")
                 .read_note_by_slug("ignored")
                 .expect("read")
                 .is_none(),
@@ -784,9 +851,10 @@ mod tests {
         let vault_path = dir.path().join("vault");
         std::fs::create_dir_all(&vault_path).expect("create vault");
         std::fs::write(vault_path.join("Home.md"), "home").expect("write note");
-        let mut state = state_with_vault(vault_path);
+        let state = state_with_vault(vault_path);
         state.startup.set_failed();
-        state.vault_path = dir.path().join("missing-vault");
+        state.ready_vault.write().await.as_mut().unwrap().vault_path =
+            dir.path().join("missing-vault");
 
         let result = refresh_now(&state).await;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,11 @@ use std::path::PathBuf;
 
 use tracing_subscriber::EnvFilter;
 
+use crate::vault_runtime::{ManagedGitMode, ManagedGitSource, VaultSource};
+
 #[derive(Debug, Clone)]
 pub struct AppConfig {
-    pub vault_path: PathBuf,
+    pub vault_source: VaultSource,
     pub cache_db_path: PathBuf,
     pub host: String,
     pub port: u16,
@@ -33,6 +35,11 @@ pub struct AppConfig {
 impl AppConfig {
     pub fn from_env() -> Result<Self, String> {
         let vault_path = env::var("VAULT_PATH").unwrap_or_else(|_| "./vault".to_string());
+        let vault_source = parse_vault_source(
+            env::var("HATCHDOOR_VAULT_SOURCE").ok().as_deref(),
+            PathBuf::from(vault_path),
+            |key| env::var(key).ok(),
+        )?;
         let cache_db_path = env::var("HATCHDOOR_CACHE_DB")
             .unwrap_or_else(|_| "./data/cache/hatchdoor-cache.sqlite3".to_string());
         let host = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -47,7 +54,7 @@ impl AppConfig {
         let port = parse_port(&port_raw)?;
 
         Ok(Self {
-            vault_path: PathBuf::from(vault_path),
+            vault_source,
             cache_db_path: PathBuf::from(cache_db_path),
             host,
             port,
@@ -81,6 +88,73 @@ impl AppConfig {
             .parse::<SocketAddr>()
             .map_err(|e| format!("invalid bind address: {e}"))
     }
+}
+
+fn parse_vault_source(
+    source: Option<&str>,
+    local_vault_path: PathBuf,
+    env_value: impl Fn(&str) -> Option<String>,
+) -> Result<VaultSource, String> {
+    match source
+        .unwrap_or("local")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "" | "local" => Ok(VaultSource::Local {
+            vault_path: local_vault_path,
+        }),
+        "git" | "managed-git" => {
+            let repository_url = non_empty_value(
+                env_value("HATCHDOOR_VAULT_GIT_URL"),
+                "HATCHDOOR_VAULT_GIT_URL",
+            )?;
+            let checkout_path = PathBuf::from(non_empty_value(
+                env_value("HATCHDOOR_VAULT_GIT_CHECKOUT_PATH"),
+                "HATCHDOOR_VAULT_GIT_CHECKOUT_PATH",
+            )?);
+            let mode = match non_empty_value(
+                env_value("HATCHDOOR_VAULT_GIT_MODE"),
+                "HATCHDOOR_VAULT_GIT_MODE",
+            )?
+            .to_ascii_lowercase()
+            .as_str()
+            {
+                "pull-only" => ManagedGitMode::PullOnly,
+                "bidirectional" => ManagedGitMode::Bidirectional,
+                other => {
+                    return Err(format!(
+                        "invalid HATCHDOOR_VAULT_GIT_MODE '{other}': expected pull-only or bidirectional"
+                    ));
+                }
+            };
+            let branch = optional_trimmed(env_value("HATCHDOOR_VAULT_GIT_BRANCH"));
+            let vault_subdirectory =
+                optional_trimmed(env_value("HATCHDOOR_VAULT_GIT_SUBDIR")).map(PathBuf::from);
+
+            Ok(VaultSource::ManagedGit(ManagedGitSource {
+                repository_url,
+                checkout_path,
+                branch,
+                vault_subdirectory,
+                mode,
+            }))
+        }
+        other => Err(format!(
+            "invalid HATCHDOOR_VAULT_SOURCE '{other}': expected local or git"
+        )),
+    }
+}
+
+fn optional_trimmed(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn non_empty_value(value: Option<String>, key: &str) -> Result<String, String> {
+    optional_trimmed(value)
+        .ok_or_else(|| format!("HATCHDOOR_VAULT_SOURCE=git requires {key} to be set"))
 }
 
 pub fn parse_port(input: &str) -> Result<u16, String> {
@@ -143,7 +217,9 @@ mod tests {
     #[test]
     fn socket_addr_builds_expected_address() {
         let cfg = AppConfig {
-            vault_path: PathBuf::from("./vault"),
+            vault_source: VaultSource::Local {
+                vault_path: PathBuf::from("./vault"),
+            },
             cache_db_path: PathBuf::from("./data/cache/hatchdoor-cache.sqlite3"),
             host: "0.0.0.0".to_string(),
             port: 42824,
@@ -156,5 +232,54 @@ mod tests {
 
         let addr = cfg.socket_addr().expect("valid addr");
         assert_eq!(addr.to_string(), "0.0.0.0:42824");
+    }
+
+    #[test]
+    fn vault_source_defaults_to_legacy_local_path() {
+        let source = parse_vault_source(None, PathBuf::from("/legacy/vault"), |_| None)
+            .expect("local source");
+        assert_eq!(
+            source,
+            VaultSource::Local {
+                vault_path: PathBuf::from("/legacy/vault")
+            }
+        );
+    }
+
+    #[test]
+    fn managed_source_requires_explicit_mode_and_paths() {
+        let value = |key: &str| match key {
+            "HATCHDOOR_VAULT_GIT_URL" => Some("https://example.test/vault.git".to_string()),
+            "HATCHDOOR_VAULT_GIT_CHECKOUT_PATH" => Some("/data/vault".to_string()),
+            "HATCHDOOR_VAULT_GIT_MODE" => Some("pull-only".to_string()),
+            "HATCHDOOR_VAULT_GIT_BRANCH" => Some("main".to_string()),
+            "HATCHDOOR_VAULT_GIT_SUBDIR" => Some("notes".to_string()),
+            _ => None,
+        };
+        let source = parse_vault_source(Some("git"), PathBuf::from("ignored"), value)
+            .expect("managed source");
+
+        assert_eq!(
+            source,
+            VaultSource::ManagedGit(ManagedGitSource {
+                repository_url: "https://example.test/vault.git".to_string(),
+                checkout_path: PathBuf::from("/data/vault"),
+                branch: Some("main".to_string()),
+                vault_subdirectory: Some(PathBuf::from("notes")),
+                mode: ManagedGitMode::PullOnly,
+            })
+        );
+    }
+
+    #[test]
+    fn managed_source_rejects_implicit_mode() {
+        let value = |key: &str| match key {
+            "HATCHDOOR_VAULT_GIT_URL" => Some("https://example.test/vault.git".to_string()),
+            "HATCHDOOR_VAULT_GIT_CHECKOUT_PATH" => Some("/data/vault".to_string()),
+            _ => None,
+        };
+        let error = parse_vault_source(Some("git"), PathBuf::from("ignored"), value)
+            .expect_err("missing mode rejected");
+        assert!(error.contains("HATCHDOOR_VAULT_GIT_MODE"));
     }
 }

--- a/src/git/sync.rs
+++ b/src/git/sync.rs
@@ -598,6 +598,13 @@ mod tests {
             .unwrap();
         drop(remote);
         drop(repo);
+        // A bare repository created by libgit2 can retain an unborn `master`
+        // HEAD even after `main` is pushed. Point HEAD at the fixture branch so
+        // follow-up clones reliably check out the commit on every host.
+        Repository::open_bare(&remote_dir)
+            .unwrap()
+            .set_head("refs/heads/main")
+            .unwrap();
         (tmp, work_dir, remote_dir)
     }
 

--- a/src/handlers/api.rs
+++ b/src/handlers/api.rs
@@ -22,11 +22,8 @@ use crate::app_state::{AppState, refresh_coalescing, run_blocking, sqlite_cache}
 const MAX_RESOLVE_BATCH: usize = 200;
 
 pub async fn health_handler(State(state): State<AppState>) -> impl IntoResponse {
-    let cache = state.cache.read().await.sqlite.clone();
-    match run_blocking(move || cache.health_check()).await {
-        Ok(()) => (StatusCode::OK, "ok").into_response(),
-        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "unavailable").into_response(),
-    }
+    let _ = state;
+    (StatusCode::OK, "ok").into_response()
 }
 
 pub async fn tree_handler(State(state): State<AppState>) -> impl IntoResponse {

--- a/src/handlers/assets.rs
+++ b/src/handlers/assets.rs
@@ -6,13 +6,16 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::IntoResponse;
 
 use crate::api_types::ErrorResponse;
-use crate::app_state::{AppState, run_blocking};
+use crate::app_state::{AppState, run_blocking, vault_unavailable};
 
 pub async fn vault_asset_handler(
     Path(path): Path<String>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    let asset_path = match resolve_asset_path(&state.vault_path, &path) {
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
+    let asset_path = match resolve_asset_path(&vault_path, &path) {
         Ok(path) => path,
         Err(kind) => {
             return asset_error_response(kind, &path);

--- a/src/handlers/diagnostics.rs
+++ b/src/handlers/diagnostics.rs
@@ -225,7 +225,9 @@ pub async fn diagnostics_handler(
         Ok(cache) => cache,
         Err(err) => return err.into_response(),
     };
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return crate::app_state::vault_unavailable().into_response();
+    };
     let scan_config = match state.live_scan_config() {
         Ok(scan_config) => scan_config,
         Err(error) => return internal_error(error).into_response(),

--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 use zip::write::SimpleFileOptions;
 
 use crate::api_types::ErrorResponse;
-use crate::app_state::{AppState, sqlite_cache};
+use crate::app_state::{AppState, sqlite_cache, vault_unavailable};
 use crate::vault::Note;
 
 pub async fn note_download_handler(
@@ -25,7 +25,9 @@ pub async fn note_download_handler(
     // Reading the note and bundling its assets is filesystem + zip work; keep it
     // off the async runtime.
     let lookup_slug = slug.clone();
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let demo_mode = state.demo_mode;
     let export = match crate::app_state::run_blocking(move || {
         let Some(note) = cache.read_note_by_slug(&lookup_slug)? else {

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -179,20 +179,21 @@ pub async fn get_index_status_handler(State(state): State<AppState>) -> Response
 /// durable desired configuration, while this reports the task that is applying
 /// it right now.
 pub async fn get_git_status_handler(State(state): State<AppState>) -> Response {
+    let vault_path = state.vault_path().await;
     let status = match state.git_sync.try_read() {
         Ok(sync) => match sync.as_ref() {
             Some(handle) => handle.status().read().await.clone(),
             None => crate::git::GitSyncStatus::disabled(),
         },
         Err(_) => {
-            let mode = crate::git::GitConfig::from_snapshot(
-                state.vault_path.clone(),
-                &state.runtime_snapshot(),
-            )
-            .ok()
-            .flatten()
-            .map(|config| config.mode.as_str().to_string())
-            .unwrap_or_else(|| "off".to_string());
+            let mode = vault_path
+                .and_then(|vault_path| {
+                    crate::git::GitConfig::from_snapshot(vault_path, &state.runtime_snapshot())
+                        .ok()
+                        .flatten()
+                })
+                .map(|config| config.mode.as_str().to_string())
+                .unwrap_or_else(|| "off".to_string());
             crate::git::GitSyncStatus {
                 enabled: mode != "off",
                 state: "stopping".to_string(),
@@ -313,15 +314,19 @@ async fn patch_settings_with_git_lifecycle(
     state: &AppState,
     request: PatchSettingsRequest,
 ) -> Response {
-    let old_git_config = match crate::git::GitConfig::from_snapshot(
-        state.vault_path.clone(),
-        &state.runtime_snapshot(),
-    ) {
-        Ok(config) => config,
-        Err(error) => {
-            return validation_response(vec![FieldError::on("HATCHDOOR_GIT_SYNC_ENABLED", error)]);
-        }
+    let Some(vault_path) = state.vault_path().await else {
+        return crate::app_state::vault_unavailable().into_response();
     };
+    let old_git_config =
+        match crate::git::GitConfig::from_snapshot(vault_path.clone(), &state.runtime_snapshot()) {
+            Ok(config) => config,
+            Err(error) => {
+                return validation_response(vec![FieldError::on(
+                    "HATCHDOOR_GIT_SYNC_ENABLED",
+                    error,
+                )]);
+            }
+        };
 
     let mut active = state.git_sync.write().await;
     if let Some(handle) = active.as_ref()
@@ -336,7 +341,7 @@ async fn patch_settings_with_git_lifecycle(
     active.take();
 
     let git_paths = GitPaths {
-        vault_path: state.vault_path.clone(),
+        vault_path,
         cache_db_path: state.cache_db_path.clone(),
         settings_file_path: state.runtime_config.settings_path().to_path_buf(),
     };

--- a/src/handlers/write_api.rs
+++ b/src/handlers/write_api.rs
@@ -6,7 +6,7 @@ use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
 use crate::api_types::ErrorResponse;
-use crate::app_state::{AppState, internal_error, refresh_now};
+use crate::app_state::{AppState, internal_error, refresh_now, vault_unavailable};
 use crate::git::WriteRecord;
 use crate::vault::{
     AttachmentInfo, AttachmentOutcome, VaultIndex, WriteError, WriteOutcome, archive_note,
@@ -108,9 +108,13 @@ pub async fn write_capabilities_handler(State(state): State<AppState>) -> impl I
             .into_response();
     }
 
-    let vault_writable = vault_path_is_writable(&state.vault_path);
+    let lifecycle_allows_mutation = state.startup.snapshot().capabilities.mutate;
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
+    let vault_writable = vault_path_is_writable(&vault_path);
     let mut warnings = Vec::new();
-    if vault_writable && !state.web_auth_enabled {
+    if lifecycle_allows_mutation && vault_writable && !state.web_auth_enabled {
         warnings.push(
             "Frontend writes are enabled without requiring Hatchdoor web authentication; this is unauthenticated and should not be exposed to untrusted networks.".to_string(),
         );
@@ -119,10 +123,15 @@ pub async fn write_capabilities_handler(State(state): State<AppState>) -> impl I
         warnings
             .push("Vault path is not writable; browser write features are disabled.".to_string());
     }
+    if !lifecycle_allows_mutation {
+        warnings.push(
+            "The vault lifecycle is read-only; browser write features are disabled.".to_string(),
+        );
+    }
     (
         StatusCode::OK,
         Json(WriteCapabilitiesResponse {
-            enabled: vault_writable,
+            enabled: lifecycle_allows_mutation && vault_writable,
             settings_enabled: true,
             warnings,
         }),
@@ -137,11 +146,23 @@ fn vault_path_is_writable(path: &std::path::Path) -> bool {
 }
 
 pub(crate) fn reject_demo_mode_write(state: &AppState) -> Option<Response> {
-    state.demo_mode.then(|| {
+    if state.demo_mode {
+        return Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: "Hatchdoor demo mode is read-only; write operations are disabled."
+                        .to_string(),
+                }),
+            )
+                .into_response(),
+        );
+    }
+    (!state.startup.snapshot().capabilities.mutate).then(|| {
         (
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
-                error: "Hatchdoor demo mode is read-only; write operations are disabled."
+                error: "The vault lifecycle is read-only; write operations are disabled."
                     .to_string(),
             }),
         )
@@ -253,7 +274,9 @@ pub async fn upload_attachment_handler(
     };
 
     let _guard = state.vault_write_lock.clone().lock_owned().await;
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let snapshot = state.runtime_snapshot();
     let max_attachment_bytes = match AppState::runtime_mcp_config(&snapshot) {
         Ok(config) => config.max_attachment_bytes,
@@ -301,7 +324,9 @@ pub async fn create_note_handler(
     }
 
     let _guard = state.vault_write_lock.clone().lock_owned().await;
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let outcome = match run_write_op(move || {
         create_note(&vault_path, &relative_path, &payload.content, false)
     })
@@ -394,7 +419,9 @@ pub async fn rename_note_handler(
     if let Some(response) = reject_noise_write(&state, &target_relative_path) {
         return response;
     }
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let outcome = match run_write_op(move || {
         move_or_rename_note(
             &vault_path,
@@ -452,7 +479,9 @@ pub async fn move_note_handler(
     if let Some(response) = reject_noise_write(&state, &target_relative_path) {
         return response;
     }
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let expected_content_hash = payload.expected_content_hash;
     let outcome = match run_write_op(move || {
         move_or_rename_note(
@@ -506,7 +535,9 @@ pub async fn move_rename_note_handler(
     if let Some(response) = reject_noise_write(&state, &target_relative_path) {
         return response;
     }
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let outcome = match run_write_op(move || {
         move_or_rename_note(
             &vault_path,
@@ -566,7 +597,9 @@ pub async fn archive_note_handler(
     if let Some(response) = reject_noise_write(&state, &target_relative_path) {
         return response;
     }
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let outcome = match run_write_op(move || {
         archive_note(
             &vault_path,
@@ -610,7 +643,9 @@ pub async fn delete_note_handler(
         Ok(entry) => entry,
         Err(err) => return err.into_response(),
     };
-    let vault_path = state.vault_path.clone();
+    let Some(vault_path) = state.vault_path().await else {
+        return vault_unavailable().into_response();
+    };
     let outcome = match run_write_op(move || {
         delete_note(&vault_path, &index, &entry, &payload.expected_content_hash)
     })
@@ -643,7 +678,8 @@ where
 }
 
 async fn current_index(state: &AppState) -> Result<VaultIndex, (StatusCode, Json<ErrorResponse>)> {
-    let vault_path = state.vault_path.clone();
+    let vault_path = state.vault_path().await.ok_or_else(vault_unavailable)?;
+    let vault_display = vault_path.display().to_string();
     let scan_config = state.live_scan_config().map_err(internal_error)?;
     match tokio::task::spawn_blocking(move || {
         VaultIndex::build_with_config(&vault_path, &scan_config)
@@ -653,7 +689,7 @@ async fn current_index(state: &AppState) -> Result<VaultIndex, (StatusCode, Json
         Ok(Ok(index)) => Ok(index),
         Ok(Err(error)) => Err(internal_error(format!(
             "failed to index vault at '{}': {error}",
-            state.vault_path.display()
+            vault_display
         ))),
         Err(join_error) => Err(internal_error(format!(
             "vault index build panicked: {join_error}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@ pub mod search;
 pub mod server;
 pub mod startup;
 pub mod vault;
+pub mod vault_runtime;
 pub mod vault_watcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,6 @@ pub mod search;
 pub mod server;
 pub mod startup;
 pub mod vault;
+pub mod vault_registry;
 pub mod vault_runtime;
 pub mod vault_watcher;

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -108,7 +108,11 @@ async fn handle_mcp_post(
         "tools/list" => {
             let layers = layer_catalog_for(&state).await;
             let mut tools = setup_tools_list();
-            tools.extend(tools_list(config, &layers));
+            tools.extend(tools_list(
+                config,
+                &layers,
+                state.startup.snapshot().capabilities.mutate,
+            ));
             Ok(json!({ "tools": tools }))
         }
         "tools/call" => handle_tools_call(state, request.params, config).await,
@@ -199,7 +203,7 @@ mod tests {
     use tempfile::TempDir;
     use tokio::sync::RwLock;
 
-    use crate::app_state::{build_cache, test_embedder};
+    use crate::app_state::{ReadyVault, build_cache, test_embedder};
 
     fn enabled_config() -> McpConfig {
         McpConfig {
@@ -242,9 +246,12 @@ mod tests {
         let (vault_events, _) = tokio::sync::broadcast::channel(64);
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -295,9 +302,12 @@ mod tests {
         let (vault_events, _) = tokio::sync::broadcast::channel(64);
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -758,7 +768,14 @@ mod tests {
         )
         .await;
         assert_eq!(create["error"]["code"], -32602);
-        assert!(!state.vault_path.join("wiki/.hatchdoor-layer").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("wiki/.hatchdoor-layer")
+                .exists()
+        );
 
         let import = call_tool(
             state,
@@ -809,7 +826,14 @@ mod tests {
                 .contains("noise-exclusion"),
             "the refusal must explain the noise match"
         );
-        assert!(!state.vault_path.join("notes/scratch.tmp").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("notes/scratch.tmp")
+                .exists()
+        );
 
         let import = call_tool(
             state,
@@ -1299,6 +1323,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pull_only_lifecycle_hides_and_rejects_mcp_mutation_tools() {
+        let (mut state, _tmp) = test_state();
+        state.startup =
+            crate::startup::StartupTracker::new(crate::vault_runtime::VaultRuntime::ready(
+                crate::vault_runtime::VaultSource::ManagedGit(
+                    crate::vault_runtime::ManagedGitSource {
+                        repository_url: "https://example.test/vault.git".to_string(),
+                        checkout_path: "/data/repositories/vault".into(),
+                        branch: None,
+                        vault_subdirectory: None,
+                        mode: crate::vault_runtime::ManagedGitMode::PullOnly,
+                    },
+                ),
+            ));
+
+        let listed = post_json_with_auth(
+            state.clone(),
+            json!({"jsonrpc":"2.0","id":51,"method":"tools/list"}),
+            write_config(),
+        )
+        .await;
+        let body = response_json(listed).await;
+        let names: Vec<&str> = body["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("tool name"))
+            .collect();
+        assert!(!names.contains(&"create_note"));
+
+        let called = post_json_with_auth(
+            state,
+            json!({
+                "jsonrpc":"2.0",
+                "id":52,
+                "method":"tools/call",
+                "params": {
+                    "name":"create_note",
+                    "arguments":{"relative_path":"Blocked.md","content":"no"}
+                }
+            }),
+            write_config(),
+        )
+        .await;
+        let body = response_json(called).await;
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("error message")
+                .contains("vault lifecycle")
+        );
+    }
+
+    #[tokio::test]
     async fn attachment_import_config_lists_base64_and_http_methods() {
         let (state, _tmp) = test_state();
         let mut config = write_config();
@@ -1383,8 +1461,9 @@ mod tests {
         let attachment = &body["result"]["structuredContent"]["attachment"];
         assert_eq!(attachment["relative_path"], "Assets/diagram.png");
         assert_eq!(attachment["size_bytes"], 9);
+        let vault_path = state.vault_path().await.expect("ready vault");
         assert_eq!(
-            std::fs::read(state.vault_path.join("Assets/diagram.png")).expect("read attachment"),
+            std::fs::read(vault_path.join("Assets/diagram.png")).expect("read attachment"),
             b"png-bytes"
         );
     }
@@ -1404,7 +1483,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
         assert_eq!(body["error"]["code"], -32602);
-        assert!(!state.vault_path.join("Assets/diagram.png").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("Assets/diagram.png")
+                .exists()
+        );
     }
 
     #[tokio::test]
@@ -1425,7 +1511,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
         assert_eq!(body["error"]["code"], -32602);
-        assert!(!state.vault_path.join("Assets/diagram.png").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("Assets/diagram.png")
+                .exists()
+        );
     }
 
     #[tokio::test]
@@ -1444,8 +1537,9 @@ mod tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::OK);
+        let vault_path = state.vault_path().await.expect("ready vault");
         assert_eq!(
-            std::fs::read(state.vault_path.join("Assets/w.png")).expect("read attachment"),
+            std::fs::read(vault_path.join("Assets/w.png")).expect("read attachment"),
             b"png-bytes"
         );
     }
@@ -1471,7 +1565,14 @@ mod tests {
 
         let body = response_json(response).await;
         assert_eq!(body["error"]["code"], -32602);
-        assert!(!state.vault_path.join("Assets/diagram.png").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("Assets/diagram.png")
+                .exists()
+        );
     }
 
     #[tokio::test]
@@ -1489,7 +1590,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
         assert_eq!(body["error"]["code"], -32602);
-        assert!(!state.vault_path.join("Assets/evil.exe").exists());
+        assert!(
+            !state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("Assets/evil.exe")
+                .exists()
+        );
     }
 
     #[tokio::test]
@@ -1516,8 +1624,9 @@ mod tests {
         .await;
         let conflict_body = response_json(conflict).await;
         assert_eq!(conflict_body["error"]["code"], -32602);
+        let vault_path = state.vault_path().await.expect("ready vault");
         assert_eq!(
-            std::fs::read(state.vault_path.join("Assets/diagram.png")).expect("read"),
+            std::fs::read(vault_path.join("Assets/diagram.png")).expect("read"),
             b"first"
         );
 
@@ -1531,7 +1640,14 @@ mod tests {
         .await;
         assert_eq!(overwrite.status(), StatusCode::OK);
         assert_eq!(
-            std::fs::read(state.vault_path.join("Assets/diagram.png")).expect("read"),
+            std::fs::read(
+                state
+                    .vault_path()
+                    .await
+                    .expect("ready vault")
+                    .join("Assets/diagram.png"),
+            )
+            .expect("read"),
             b"second"
         );
     }
@@ -1560,9 +1676,16 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
         assert_eq!(body["result"]["structuredContent"]["ok"], true);
-        assert!(state.vault_path.join("Projects/New.md").exists());
+        assert!(
+            state
+                .vault_path()
+                .await
+                .expect("ready vault")
+                .join("Projects/New.md")
+                .exists()
+        );
 
-        let cache = state.cache.read().await;
+        let cache = state.ready_vault().await.expect("ready vault").cache;
         let note = cache
             .sqlite
             .read_note_by_slug("new")
@@ -1600,11 +1723,18 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["result"]["structuredContent"]["ok"], true);
         assert_eq!(
-            std::fs::read_to_string(state.vault_path.join("Home.md")).expect("read"),
+            std::fs::read_to_string(
+                state
+                    .vault_path()
+                    .await
+                    .expect("ready vault")
+                    .join("Home.md"),
+            )
+            .expect("read"),
             "# Home\nALPHA token\n[[Plan]]\n"
         );
 
-        let cache = state.cache.read().await;
+        let cache = state.ready_vault().await.expect("ready vault").cache;
         let note = cache
             .sqlite
             .read_note_by_slug("home")
@@ -1646,10 +1776,11 @@ mod tests {
         assert_eq!(content["ok"], true);
         assert_eq!(content["slug"], "renamed-home");
         assert_eq!(content["relative_path"], "Renamed Home");
-        assert!(state.vault_path.join("Renamed Home.md").exists());
-        assert!(!state.vault_path.join("Home.md").exists());
+        let vault_path = state.vault_path().await.expect("ready vault");
+        assert!(vault_path.join("Renamed Home.md").exists());
+        assert!(!vault_path.join("Home.md").exists());
 
-        let cache = state.cache.read().await;
+        let cache = state.ready_vault().await.expect("ready vault").cache;
         let note = cache
             .sqlite
             .read_note_by_slug("renamed-home")
@@ -1688,7 +1819,14 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["result"]["structuredContent"]["ok"], true);
         assert_eq!(
-            std::fs::read_to_string(state.vault_path.join("Home.md")).expect("read"),
+            std::fs::read_to_string(
+                state
+                    .vault_path()
+                    .await
+                    .expect("ready vault")
+                    .join("Home.md"),
+            )
+            .expect("read"),
             "# Home\nrewritten\n"
         );
     }
@@ -1763,9 +1901,10 @@ mod tests {
     #[tokio::test]
     async fn query_notes_lists_notes_by_metadata_without_a_search_query() {
         let (state, _tmp) = test_state();
-        std::fs::create_dir_all(state.vault_path.join("Devices")).expect("devices dir");
+        let vault_path = state.vault_path().await.expect("ready vault");
+        std::fs::create_dir_all(vault_path.join("Devices")).expect("devices dir");
         std::fs::write(
-            state.vault_path.join("Devices/Router.md"),
+            vault_path.join("Devices/Router.md"),
             "---\ntags: [type/device, action/review]\nstatus: active\nreview-date: 2026-08-01\nprivate: hidden\n---\n# Router",
         )
         .expect("write router");

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use crate::app_state::AppState;
+use crate::vault::allowed_attachment_extensions;
 
 use super::config::McpConfig;
 use super::protocol::{JsonRpcFailure, tool_error, tool_success};
@@ -19,6 +20,7 @@ pub async fn handle_tools_call(
     params: Option<Value>,
     config: &McpConfig,
 ) -> Result<Value, JsonRpcFailure> {
+    let lifecycle_write_enabled = state.startup.snapshot().capabilities.mutate;
     let params =
         params.ok_or_else(|| JsonRpcFailure::invalid_params("Missing tool call params"))?;
     let name = params
@@ -83,11 +85,19 @@ pub async fn handle_tools_call(
         "refresh_index" => read::refresh_index_tool(state, arguments).await,
         "get_git_sync_status" => read::get_git_sync_status_tool(state).await,
         "layer_diagnostics" => read::layer_diagnostics_tool(state, arguments).await,
-        "get_attachment_import_config" => read::get_attachment_import_config_tool(config),
+        "get_attachment_import_config" if config.write_enabled && lifecycle_write_enabled => {
+            read::get_attachment_import_config_tool(config)
+        }
+        "get_attachment_import_config" => Ok(tool_success(json!({
+            "enabled": false,
+            "allowed_extensions": allowed_attachment_extensions(),
+            "methods": [],
+            "usage": "Attachment upload is unavailable for the current vault lifecycle capabilities."
+        }))),
         "create_note" | "update_note" | "append_to_note" | "edit_note" | "replace_section"
         | "rename_note" | "move_note" | "move_rename_note" | "archive_note" | "delete_note"
         | "import_attachment" | "move_attachment" | "rename_attachment" | "delete_attachment"
-            if config.write_enabled =>
+            if config.write_enabled && lifecycle_write_enabled =>
         {
             // Hold the vault write lock for the whole tool call so a concurrent
             // git-sync merge/reset cannot race a filesystem write.
@@ -112,7 +122,7 @@ pub async fn handle_tools_call(
                 _ => unreachable!(),
             }
         }
-        "list_note_attachments" if config.write_enabled => {
+        "list_note_attachments" if config.write_enabled && lifecycle_write_enabled => {
             write::list_note_attachments_tool(state, arguments).await
         }
         "create_note"
@@ -129,9 +139,14 @@ pub async fn handle_tools_call(
         | "move_attachment"
         | "rename_attachment"
         | "delete_attachment"
-        | "list_note_attachments" => Err(JsonRpcFailure::invalid_params(
-            "MCP write tools are disabled by HATCHDOOR_MCP_WRITE_ENABLED",
-        )),
+        | "list_note_attachments" => {
+            let message = if !config.write_enabled {
+                "MCP write tools are disabled by HATCHDOOR_MCP_WRITE_ENABLED"
+            } else {
+                "MCP write tools are disabled by the vault lifecycle"
+            };
+            Err(JsonRpcFailure::invalid_params(message))
+        }
         other => Err(JsonRpcFailure::invalid_params(format!(
             "Unknown MCP tool: {other}"
         ))),
@@ -165,9 +180,13 @@ fn model_setup_status_payload(state: &AppState) -> Value {
     })
 }
 
-pub fn tools_list(config: &McpConfig, layers: &[crate::search::LayerInfo]) -> Vec<Value> {
+pub fn tools_list(
+    config: &McpConfig,
+    layers: &[crate::search::LayerInfo],
+    lifecycle_write_enabled: bool,
+) -> Vec<Value> {
     let mut tools = read::read_tools_list(layers);
-    if config.write_enabled {
+    if config.write_enabled && lifecycle_write_enabled {
         tools.extend(write::write_tools_list());
     }
     tools

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -247,7 +247,10 @@ pub(super) async fn layer_diagnostics_tool(
     let cache = sqlite_cache(&state)
         .await
         .map_err(|(_status, body)| JsonRpcFailure::internal(body.0.error))?;
-    let vault_path = state.vault_path.clone();
+    let vault_path = state
+        .vault_path()
+        .await
+        .ok_or_else(|| JsonRpcFailure::internal("Vault is not ready"))?;
     let scan_config = state.live_scan_config().map_err(JsonRpcFailure::internal)?;
     let diagnostics = tokio::task::spawn_blocking(move || {
         crate::handlers::diagnostics::build_layer_diagnostics(

--- a/src/mcp/tools/write.rs
+++ b/src/mcp/tools/write.rs
@@ -35,8 +35,13 @@ pub(super) async fn create_note_tool(
         &relative_path,
     )?;
     let overwrite = args.overwrite.unwrap_or(false);
-    let outcome = create_note(&state.vault_path, &relative_path, &args.content, overwrite)
-        .map_err(write_error_to_jsonrpc)?;
+    let outcome = create_note(
+        &vault_path(&state).await?,
+        &relative_path,
+        &args.content,
+        overwrite,
+    )
+    .map_err(write_error_to_jsonrpc)?;
     finalize_note_write(&state, "create", outcome, args.commit_summary).await
 }
 
@@ -144,7 +149,7 @@ pub(super) async fn rename_note_tool(
         &target,
     )?;
     let outcome = move_or_rename_note(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &entry,
         &target,
@@ -182,7 +187,7 @@ pub(super) async fn move_note_tool(
         &target,
     )?;
     let outcome = move_or_rename_note(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &entry,
         &target,
@@ -211,7 +216,7 @@ pub(super) async fn move_rename_note_tool(
     let index = current_index(&state).await?;
     let entry = note_entry(&index, &args.slug)?;
     let outcome = move_or_rename_note(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &entry,
         &target_relative_path,
@@ -243,7 +248,7 @@ pub(super) async fn archive_note_tool(
     let target = format!("{archive_folder}/{file_name}");
     refuse_noise_write(&scan_config.exclude, &target)?;
     let outcome = archive_note(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &entry,
         &archive_prefix,
@@ -263,7 +268,7 @@ pub(super) async fn delete_note_tool(
     let index = current_index(&state).await?;
     let entry = note_entry(&index, &args.slug)?;
     let outcome = delete_note(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &entry,
         &args.expected_content_hash,
@@ -324,7 +329,7 @@ pub(super) async fn import_attachment_tool(
         })?;
 
     let outcome = import_attachment_bytes(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &target_relative_path,
         &bytes,
         config.max_base64_bytes,
@@ -358,7 +363,7 @@ pub(super) async fn move_attachment_tool(
     )?;
     let index = current_index(&state).await?;
     let outcome = move_attachment(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &source_relative_path,
         &target_relative_path,
@@ -392,7 +397,7 @@ pub(super) async fn rename_attachment_tool(
     )?;
     let index = current_index(&state).await?;
     let outcome = rename_attachment(
-        &state.vault_path,
+        &vault_path(&state).await?,
         &index,
         &source_relative_path,
         &new_filename,
@@ -414,7 +419,7 @@ pub(super) async fn delete_attachment_tool(
     let source_relative_path =
         non_empty_argument("source_relative_path", args.source_relative_path)?;
     let index = current_index(&state).await?;
-    let outcome = delete_attachment(&state.vault_path, &index, &source_relative_path)
+    let outcome = delete_attachment(&vault_path(&state).await?, &index, &source_relative_path)
         .map_err(write_error_to_jsonrpc)?;
     refresh_after_write(&state).await?;
     record_attachment_write(&state, "delete_attachment", &outcome, args.commit_summary).await;
@@ -431,7 +436,7 @@ pub(super) async fn list_note_attachments_tool(
     })?;
     let index = current_index(&state).await?;
     let entry = note_entry(&index, &args.slug)?;
-    let attachments = list_note_attachments(&state.vault_path, &index.layers, &entry)
+    let attachments = list_note_attachments(&vault_path(&state).await?, &index.layers, &entry)
         .map_err(write_error_to_jsonrpc)?;
     Ok(tool_success(json!({ "attachments": attachments })))
 }
@@ -440,7 +445,8 @@ pub(super) async fn list_note_attachments_tool(
 /// index to rewrite backlinks/assets, but the O(vault) walk must not block a
 /// tokio worker.
 async fn current_index(state: &AppState) -> Result<VaultIndex, JsonRpcFailure> {
-    let vault_path = state.vault_path.clone();
+    let vault_path = vault_path(state).await?;
+    let vault_display = vault_path.display().to_string();
     let scan_config = state.live_scan_config().map_err(JsonRpcFailure::internal)?;
     match tokio::task::spawn_blocking(move || {
         VaultIndex::build_with_config(&vault_path, &scan_config)
@@ -450,12 +456,19 @@ async fn current_index(state: &AppState) -> Result<VaultIndex, JsonRpcFailure> {
         Ok(Ok(index)) => Ok(index),
         Ok(Err(error)) => Err(JsonRpcFailure::internal(format!(
             "failed to index vault at '{}': {error}",
-            state.vault_path.display()
+            vault_display
         ))),
         Err(join_error) => Err(JsonRpcFailure::internal(format!(
             "vault index build panicked: {join_error}"
         ))),
     }
+}
+
+async fn vault_path(state: &AppState) -> Result<std::path::PathBuf, JsonRpcFailure> {
+    state
+        .vault_path()
+        .await
+        .ok_or_else(|| JsonRpcFailure::internal("Vault is not ready"))
 }
 
 fn note_entry(index: &VaultIndex, slug: &str) -> Result<crate::vault::NoteEntry, JsonRpcFailure> {
@@ -482,8 +495,8 @@ async fn finalize_note_write(
     commit_summary: Option<String>,
 ) -> Result<Value, JsonRpcFailure> {
     refresh_after_write(state).await?;
+    let index = current_index(state).await?;
     if outcome.slug.is_none() && outcome.relative_path.is_some() && outcome.content_hash.is_some() {
-        let index = current_index(state).await?;
         let relative_path = outcome
             .relative_path
             .as_deref()
@@ -501,15 +514,7 @@ async fn finalize_note_write(
     // sees which surface a create/move/rename/archive landed on. Read from the
     // just-refreshed cache; a delete leaves no note, so the layer is None.
     let layer = match &outcome.slug {
-        Some(slug) => state
-            .cache
-            .read()
-            .await
-            .sqlite
-            .read_note_by_slug(slug)
-            .ok()
-            .flatten()
-            .and_then(|note| note.layer),
+        Some(slug) => index.find_by_slug(slug).and_then(|note| note.layer.clone()),
         None => None,
     };
     Ok(write_success(outcome, warning, layer))

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tracing::{error, info, warn};
 
-use crate::app_state::{AppState, VaultCache, build_cache_with_sqlite_and_progress};
+use crate::app_state::{AppState, build_cache_with_sqlite_and_progress};
 use crate::auth::{WebOrLiveMcpToken, WebToken, require_web_or_live_mcp_token, require_web_token};
 use crate::cache::SqliteCache;
 use crate::config::AppConfig;
@@ -39,6 +39,7 @@ use crate::mcp::{McpConfig, mcp_get_handler, mcp_post_handler};
 use crate::model_setup::{ModelSetup, SelectedModel};
 use crate::runtime_config::{RuntimeConfig, live_settings_defaults, settings_file_path};
 use crate::startup::StartupTracker;
+use crate::vault_runtime::{VaultRuntime, VaultSource};
 use crate::vault_watcher::spawn_vault_watcher;
 
 /// Hosts that only accept connections from the local machine. Binding to any
@@ -73,7 +74,7 @@ pub fn check_web_auth_posture(
 pub fn check_demo_mode_posture(
     demo_mode: bool,
     mcp_enabled: bool,
-    git_sync_enabled: bool,
+    git_writes_enabled: bool,
 ) -> Result<(), String> {
     if !demo_mode {
         return Ok(());
@@ -84,9 +85,9 @@ pub fn check_demo_mode_posture(
                 .to_string(),
         );
     }
-    if git_sync_enabled {
+    if git_writes_enabled {
         return Err(
-            "HATCHDOOR_DEMO_MODE=true is incompatible with HATCHDOOR_GIT_SYNC_ENABLED=true; disable git sync for public demos."
+            "HATCHDOOR_DEMO_MODE=true is incompatible with Git writeback; disable HATCHDOOR_GIT_SYNC_ENABLED and managed bidirectional mode for public demos."
                 .to_string(),
         );
     }
@@ -257,6 +258,7 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
         .route("/health", get(health_handler))
         .route("/ready", get(readiness_handler))
         .route("/api/startup-status", get(startup_status_handler))
+        .route("/api/vault-status", get(vault_status_handler))
         .merge(model_setup)
         .merge(settings)
         .merge(mcp)
@@ -305,6 +307,14 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
 
 async fn startup_status_handler(State(state): State<AppState>) -> Response {
     let mut response = Json(state.startup.status()).into_response();
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+
+async fn vault_status_handler(State(state): State<AppState>) -> Response {
+    let mut response = Json(state.startup.snapshot()).into_response();
     response
         .headers_mut()
         .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
@@ -436,9 +446,19 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                 tracker.set_scanning();
                 let progress_tracker = tracker.clone();
                 let on_progress = Arc::new(move |progress| progress_tracker.set_indexing(progress));
+                let Some(vault_path) = state.configured_local_vault_path() else {
+                    state.model_setup_started.store(false, Ordering::Release);
+                    state.startup.runtime().set_unavailable(
+                        "managed_vault_not_acquired",
+                        "Managed Git vault acquisition is not implemented in this foundation slice.",
+                    );
+                    return;
+                };
+                let indexing_vault_path = vault_path.clone();
+                let indexing_sqlite = state.startup_sqlite.clone();
+                let indexing_embedder = state.embedder.clone();
                 let index_state = state.clone();
                 let index_result = tokio::task::spawn_blocking(move || {
-                    let sqlite = index_state.cache.blocking_read().sqlite.clone();
                     let runtime_snapshot = index_state.runtime_config.snapshot();
                     let embed_layers = runtime_snapshot
                         .setting("HATCHDOOR_EMBED_LAYERS")
@@ -446,9 +466,9 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                         .unwrap_or(true);
                     let scan_config = index_state.live_scan_config()?;
                     build_cache_with_sqlite_and_progress(
-                        &index_state.vault_path,
-                        sqlite,
-                        index_state.embedder.as_ref(),
+                        &indexing_vault_path,
+                        indexing_sqlite,
+                        indexing_embedder.as_ref(),
                         Some(on_progress),
                         &scan_config,
                         embed_layers,
@@ -456,14 +476,15 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                 })
                 .await;
                 match index_result {
-                    Ok(Ok(_)) => {
+                    Ok(Ok(cache)) => {
+                        state.publish_ready_vault(vault_path.clone(), cache).await;
                         tracker.set_ready();
                         info!(
                             model = model_name,
                             "Model setup and vault indexing complete"
                         );
                         let git_config = GitConfig::from_snapshot(
-                            state.vault_path.clone(),
+                            vault_path.clone(),
                             &state.runtime_snapshot(),
                         )
                         .unwrap_or_else(|error| {
@@ -489,7 +510,7 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                         }
                         spawn_vault_watcher(
                             state.clone(),
-                            state.vault_path.clone(),
+                            vault_path.clone(),
                             state.cache_db_path.clone(),
                         );
                     }
@@ -497,11 +518,7 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                         state.model_setup_started.store(false, Ordering::Release);
                         tracker.set_failed();
                         error!("Failed to index vault after model setup: {error}");
-                        spawn_vault_watcher(
-                            state.clone(),
-                            state.vault_path.clone(),
-                            state.cache_db_path.clone(),
-                        );
+                        spawn_vault_watcher(state.clone(), vault_path, state.cache_db_path.clone());
                     }
                     Err(error) => {
                         state.model_setup_started.store(false, Ordering::Release);
@@ -532,11 +549,23 @@ async fn require_vault_ready(
     if state.startup.is_ready() {
         return next.run(request).await;
     }
+    let snapshot = state.startup.snapshot();
+    let (error, code) = match snapshot.phase {
+        crate::vault_runtime::VaultPhase::Unavailable => (
+            "The configured vault is unavailable",
+            snapshot
+                .error
+                .as_ref()
+                .map(|error| error.code.as_str())
+                .unwrap_or("vault_unavailable"),
+        ),
+        _ => ("Vault is still being indexed", "vault_indexing"),
+    };
     (
         StatusCode::SERVICE_UNAVAILABLE,
         Json(serde_json::json!({
-            "error": "Vault is still being indexed",
-            "code": "vault_indexing"
+            "error": error,
+            "code": code
         })),
     )
         .into_response()
@@ -631,16 +660,40 @@ pub async fn run_server() {
         std::process::exit(1);
     }
 
-    let git_sync_config = GitConfig::from_snapshot(config.vault_path.clone(), &startup_snapshot)
-        .unwrap_or_else(|e| {
-            error!("Git sync configuration error: {e}");
-            std::process::exit(1);
-        });
+    let git_sync_config = match &config.vault_source {
+        VaultSource::Local { vault_path } => {
+            GitConfig::from_snapshot(vault_path.clone(), &startup_snapshot)
+        }
+        VaultSource::ManagedGit(_) => {
+            let legacy_mode_enabled = startup_snapshot
+                .setting("HATCHDOOR_GIT_SYNC_ENABLED")
+                .is_some_and(|setting| {
+                    !matches!(
+                        setting.value.trim().to_ascii_lowercase().as_str(),
+                        "" | "off" | "false" | "0" | "no"
+                    )
+                });
+            if legacy_mode_enabled {
+                Err("HATCHDOOR_GIT_SYNC_ENABLED cannot be combined with HATCHDOOR_VAULT_SOURCE=git; managed source mode owns Git synchronization".to_string())
+            } else {
+                Ok(None)
+            }
+        }
+    }
+    .unwrap_or_else(|e| {
+        error!("Git sync configuration error: {e}");
+        std::process::exit(1);
+    });
 
+    let managed_writeback = matches!(
+        &config.vault_source,
+        VaultSource::ManagedGit(source)
+            if source.mode == crate::vault_runtime::ManagedGitMode::Bidirectional
+    );
     if let Err(message) = check_demo_mode_posture(
         config.demo_mode,
         mcp_config.enabled,
-        git_sync_config.is_some(),
+        git_sync_config.is_some() || managed_writeback,
     ) {
         error!("{message}");
         std::process::exit(1);
@@ -691,17 +744,19 @@ pub async fn run_server() {
 
     let (vault_events, _) = tokio::sync::broadcast::channel(64);
     let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
-    let startup = if selected_model == SelectedModel::TermsRequired {
-        StartupTracker::terms_required()
-    } else {
-        StartupTracker::scanning()
-    };
+    let runtime = VaultRuntime::new(config.vault_source.clone());
+    let startup = StartupTracker::new(runtime);
+    if matches!(config.vault_source, VaultSource::Local { .. }) {
+        if selected_model == SelectedModel::TermsRequired {
+            startup.set_terms_required();
+        } else {
+            startup.set_scanning();
+        }
+    }
     let state = AppState {
-        vault_path: config.vault_path.clone(),
         cache_db_path: config.cache_db_path.clone(),
-        cache: Arc::new(RwLock::new(VaultCache {
-            sqlite: sqlite.clone(),
-        })),
+        startup_sqlite: sqlite.clone(),
+        ready_vault: Arc::new(RwLock::new(None)),
         vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         vault_events,
         mcp_tools_changed,
@@ -735,7 +790,7 @@ pub async fn run_server() {
     info!(
         host = %config.host,
         port = config.port,
-        vault_path = %config.vault_path.display(),
+        vault_source = ?config.vault_source.kind(),
         cache_db_path = %config.cache_db_path.display(),
         "Hatchdoor starting"
     );
@@ -747,8 +802,17 @@ pub async fn run_server() {
             std::process::exit(1);
         });
 
-    if selected_model != SelectedModel::TermsRequired {
-        spawn_model_startup(state.clone(), selected_model);
+    match config.vault_source {
+        VaultSource::Local { .. } if selected_model != SelectedModel::TermsRequired => {
+            spawn_model_startup(state.clone(), selected_model);
+        }
+        VaultSource::ManagedGit(_) => {
+            state.startup.runtime().set_unavailable(
+                "managed_vault_not_acquired",
+                "Managed Git vault acquisition is not implemented in this foundation slice.",
+            );
+        }
+        VaultSource::Local { .. } => {}
     }
 
     axum::serve(listener, app).await.unwrap_or_else(|e| {
@@ -760,6 +824,7 @@ pub async fn run_server() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_state::ReadyVault;
 
     #[test]
     fn web_auth_posture_refuses_public_bind_without_token() {
@@ -862,9 +927,12 @@ mod tests {
         let (vault_events, _) = tokio::sync::broadcast::channel(64);
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -925,9 +993,12 @@ mod tests {
                 .expect("save MCP token");
         }
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -1435,6 +1506,151 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unavailable_managed_vault_keeps_liveness_status_and_spa_available() {
+        let (_app, _tmp, mut state) = app_for_tests_with_state();
+        *state.ready_vault.write().await = None;
+        state.startup = StartupTracker::new(VaultRuntime::new(VaultSource::ManagedGit(
+            crate::vault_runtime::ManagedGitSource {
+                repository_url: "https://example.test/vault.git".to_string(),
+                checkout_path: "/data/repositories/vault".into(),
+                branch: Some("main".to_string()),
+                vault_subdirectory: None,
+                mode: crate::vault_runtime::ManagedGitMode::PullOnly,
+            },
+        )));
+        state.startup.runtime().set_unavailable(
+            "managed_vault_not_acquired",
+            "Managed vault has not been acquired.",
+        );
+        let app = build_router(state, None);
+
+        for path in ["/health", "/api/startup-status", "/api/vault-status"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+        }
+
+        let spa = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let spa_status = spa.status();
+        let spa_body = to_bytes(spa.into_body(), usize::MAX)
+            .await
+            .expect("SPA body");
+        assert!(
+            spa_status == StatusCode::OK
+                || (spa_status == StatusCode::SERVICE_UNAVAILABLE
+                    && std::str::from_utf8(&spa_body)
+                        .expect("SPA html")
+                        .contains("Frontend not built")),
+            "SPA route must reach the SPA handler rather than vault readiness middleware"
+        );
+
+        let status = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vault-status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let payload: serde_json::Value = serde_json::from_slice(
+            &to_bytes(status.into_body(), usize::MAX)
+                .await
+                .expect("status body"),
+        )
+        .expect("status json");
+        assert_eq!(payload["phase"], "unavailable");
+        assert_eq!(payload["source"], "managed-git");
+        assert_eq!(payload["mode"], "pull-only");
+        assert_eq!(payload["capabilities"]["mutate"], false);
+        assert!(!payload.to_string().contains("/data/repositories/vault"));
+
+        let vault_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/tree")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(vault_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let payload: serde_json::Value = serde_json::from_slice(
+            &to_bytes(vault_response.into_body(), usize::MAX)
+                .await
+                .expect("vault response body"),
+        )
+        .expect("vault response json");
+        assert_eq!(payload["code"], "managed_vault_not_acquired");
+    }
+
+    #[tokio::test]
+    async fn pull_only_lifecycle_disables_browser_mutation() {
+        let (_app, _tmp, mut state) = app_for_tests_with_state();
+        state.startup = StartupTracker::new(VaultRuntime::ready(VaultSource::ManagedGit(
+            crate::vault_runtime::ManagedGitSource {
+                repository_url: "https://example.test/vault.git".to_string(),
+                checkout_path: "/data/repositories/vault".into(),
+                branch: None,
+                vault_subdirectory: None,
+                mode: crate::vault_runtime::ManagedGitMode::PullOnly,
+            },
+        )));
+        let app = build_router(state, None);
+
+        let capabilities = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/write-capabilities")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let payload: serde_json::Value = serde_json::from_slice(
+            &to_bytes(capabilities.into_body(), usize::MAX)
+                .await
+                .expect("capabilities body"),
+        )
+        .expect("capabilities json");
+        assert_eq!(payload["enabled"], false);
+
+        let mutation = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/note")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"relative_path":"Blocked.md","content":"no"}"#,
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(mutation.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
     async fn indexing_startup_keeps_shell_live_but_blocks_vault_surfaces() {
         let (_ready_app, _tmp, state) = app_for_tests_with_state();
         state
@@ -1635,9 +1851,12 @@ mod tests {
         let (vault_events, _) = tokio::sync::broadcast::channel(64);
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -2281,7 +2500,7 @@ mod tests {
     #[tokio::test]
     async fn router_reports_write_capabilities_disabled_for_read_only_vault() {
         let (app, tmp, state) = app_for_tests_with_state();
-        let vault_path = state.vault_path.clone();
+        let vault_path = state.vault_path().await.expect("ready vault path");
         let original_permissions = std::fs::metadata(&vault_path)
             .expect("vault metadata")
             .permissions();
@@ -2602,7 +2821,8 @@ mod tests {
         // rebuild must use HATCHDOOR_EXCLUDE too, or an excluded note becomes
         // writable even though it is absent from every read surface.
         let (_unused_app, _tmp, state) = app_for_tests_with_state();
-        std::fs::write(state.vault_path.join("Ignored.md"), "# Ignored\n").expect("write note");
+        let vault_path = state.vault_path().await.expect("ready vault");
+        std::fs::write(vault_path.join("Ignored.md"), "# Ignored\n").expect("write note");
         state
             .runtime_config
             .save([("HATCHDOOR_EXCLUDE".to_string(), "Ignored.md".to_string())])
@@ -2680,7 +2900,11 @@ mod tests {
     #[tokio::test]
     async fn demo_mode_rejects_write_api_before_touching_vault() {
         let (app, tmp, state) = app_for_tests_with_web_auth_and_demo_mode(None, true);
-        let blocked_path = state.vault_path.join("Demo Write.md");
+        let blocked_path = state
+            .vault_path()
+            .await
+            .expect("ready vault path")
+            .join("Demo Write.md");
 
         let response = app
             .oneshot(
@@ -2757,9 +2981,12 @@ mod tests {
         let (vault_events, _) = tokio::sync::broadcast::channel(64);
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
-            vault_path: vault_root,
             cache_db_path: tmp.path().join("cache.sqlite3"),
-            cache: Arc::new(RwLock::new(cache)),
+            startup_sqlite: cache.sqlite.clone(),
+            ready_vault: Arc::new(RwLock::new(Some(ReadyVault {
+                vault_path: vault_root,
+                cache,
+            }))),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
@@ -2868,7 +3095,15 @@ mod tests {
         // but never shared-cacheable: authenticated deployments put
         // ?access_token= in asset URLs.
         let (app, tmp, state) = app_for_tests_with_web_auth(None);
-        std::fs::write(state.vault_path.join("diagram.png"), b"png-bytes").expect("write asset");
+        std::fs::write(
+            state
+                .vault_path()
+                .await
+                .expect("ready vault path")
+                .join("diagram.png"),
+            b"png-bytes",
+        )
+        .expect("write asset");
 
         let response = app
             .oneshot(

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,6 +1,6 @@
-use std::sync::{Arc, RwLock};
-
 use serde::Serialize;
+
+use crate::vault_runtime::{VaultPhase, VaultRuntime, VaultRuntimeSnapshot, VaultSource};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct IndexingProgressSnapshot {
@@ -31,43 +31,41 @@ impl IndexingProgressSnapshot {
 }
 
 #[derive(Clone, Debug)]
-enum StartupPhase {
-    TermsRequired,
-    Downloading {
-        model: &'static str,
-        downloaded_bytes: Option<u64>,
-        total_bytes: Option<u64>,
-    },
-    Scanning,
-    Indexing(IndexingProgressSnapshot),
-    Ready,
-    Failed {
-        message: String,
-    },
-}
-
-#[derive(Clone, Debug)]
-pub struct StartupTracker(Arc<RwLock<StartupPhase>>);
+pub struct StartupTracker(VaultRuntime);
 
 impl StartupTracker {
+    pub fn new(runtime: VaultRuntime) -> Self {
+        Self(runtime)
+    }
+
     pub fn terms_required() -> Self {
-        Self(Arc::new(RwLock::new(StartupPhase::TermsRequired)))
+        let runtime = VaultRuntime::new(VaultSource::Local {
+            vault_path: "./vault".into(),
+        });
+        runtime.set_terms_required();
+        Self(runtime)
     }
 
     pub fn scanning() -> Self {
-        Self(Arc::new(RwLock::new(StartupPhase::Scanning)))
+        let runtime = VaultRuntime::new(VaultSource::Local {
+            vault_path: "./vault".into(),
+        });
+        runtime.set_scanning();
+        Self(runtime)
     }
 
     pub fn ready() -> Self {
-        Self(Arc::new(RwLock::new(StartupPhase::Ready)))
+        Self(VaultRuntime::ready(VaultSource::Local {
+            vault_path: "./vault".into(),
+        }))
     }
 
     pub fn set_scanning(&self) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Scanning;
+        self.0.set_scanning();
     }
 
     pub fn set_terms_required(&self) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::TermsRequired;
+        self.0.set_terms_required();
     }
 
     pub fn set_downloading(
@@ -76,85 +74,84 @@ impl StartupTracker {
         downloaded_bytes: Option<u64>,
         total_bytes: Option<u64>,
     ) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Downloading {
-            model,
-            downloaded_bytes,
-            total_bytes,
-        };
+        self.0.set_downloading(model, downloaded_bytes, total_bytes);
     }
 
     pub fn set_indexing(&self, progress: IndexingProgressSnapshot) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Indexing(progress);
+        self.0.set_indexing(progress);
     }
 
     pub fn set_ready(&self) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Ready;
+        self.0.set_ready();
     }
 
     pub fn set_failed(&self) {
-        self.set_failed_with_message("Indexing could not be completed.");
+        self.0
+            .set_unavailable("vault_index_failed", "Indexing could not be completed.");
     }
 
     pub fn set_model_setup_failed(&self) {
-        self.set_failed_with_message(
+        self.0.set_unavailable(
+            "model_setup_failed",
             "The search model could not be downloaded or loaded. Check the Hatchdoor logs, then retry setup.",
         );
     }
 
-    fn set_failed_with_message(&self, message: impl Into<String>) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Failed {
-            message: message.into(),
-        };
+    pub fn is_ready(&self) -> bool {
+        self.0.is_ready()
     }
 
-    pub fn is_ready(&self) -> bool {
-        matches!(
-            *self.0.read().expect("startup tracker poisoned"),
-            StartupPhase::Ready
-        )
+    pub fn snapshot(&self) -> VaultRuntimeSnapshot {
+        self.0.snapshot()
+    }
+
+    pub fn runtime(&self) -> &VaultRuntime {
+        &self.0
     }
 
     pub fn status(&self) -> StartupStatusResponse {
-        match *self.0.read().expect("startup tracker poisoned") {
-            StartupPhase::TermsRequired => StartupStatusResponse::simple("terms_required", None),
-            StartupPhase::Downloading {
-                model,
-                downloaded_bytes,
-                total_bytes,
-            } => StartupStatusResponse {
+        let snapshot = self.0.snapshot();
+        match snapshot.phase {
+            VaultPhase::TermsRequired => StartupStatusResponse::simple("terms_required", None),
+            VaultPhase::Downloading => StartupStatusResponse {
                 state: "downloading",
-                model: Some(model),
-                downloaded_bytes,
-                total_bytes,
+                model: snapshot.model,
+                downloaded_bytes: snapshot.downloaded_bytes,
+                total_bytes: snapshot.total_bytes,
                 notes_completed: None,
                 notes_total: None,
                 chunks_completed: None,
                 chunks_total: None,
                 tokens_completed: None,
                 tokens_total: None,
-                percent: download_percent(downloaded_bytes, total_bytes),
+                percent: download_percent(snapshot.downloaded_bytes, snapshot.total_bytes),
                 eta_seconds: None,
                 message: None,
             },
-            StartupPhase::Scanning => StartupStatusResponse::simple("scanning", None),
-            StartupPhase::Indexing(progress) => StartupStatusResponse {
-                state: "indexing",
-                model: None,
-                downloaded_bytes: None,
-                total_bytes: None,
-                notes_completed: Some(progress.notes_completed),
-                notes_total: Some(progress.notes_total),
-                chunks_completed: Some(progress.chunks_completed),
-                chunks_total: Some(progress.chunks_total),
-                tokens_completed: Some(progress.tokens_completed),
-                tokens_total: Some(progress.tokens_total),
-                percent: Some(progress.percent()),
-                eta_seconds: progress.eta_seconds(),
-                message: None,
-            },
-            StartupPhase::Ready => StartupStatusResponse::simple("ready", None),
-            StartupPhase::Failed { ref message } => {
-                StartupStatusResponse::simple("failed", Some(message.clone()))
+            VaultPhase::Validating | VaultPhase::Scanning => {
+                StartupStatusResponse::simple("scanning", None)
+            }
+            VaultPhase::Indexing => {
+                let progress = snapshot.indexing.unwrap_or_default();
+                StartupStatusResponse {
+                    state: "indexing",
+                    model: None,
+                    downloaded_bytes: None,
+                    total_bytes: None,
+                    notes_completed: Some(progress.notes_completed),
+                    notes_total: Some(progress.notes_total),
+                    chunks_completed: Some(progress.chunks_completed),
+                    chunks_total: Some(progress.chunks_total),
+                    tokens_completed: Some(progress.tokens_completed),
+                    tokens_total: Some(progress.tokens_total),
+                    percent: Some(progress.percent()),
+                    eta_seconds: progress.eta_seconds(),
+                    message: None,
+                }
+            }
+            VaultPhase::Ready => StartupStatusResponse::simple("ready", None),
+            VaultPhase::Unavailable => {
+                StartupStatusResponse::simple("failed", snapshot.error.map(|error| error.message))
             }
         }
     }

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -1,8 +1,9 @@
-//! Authoritative, revisioned persistence for the collection of Vault identities.
+//! Authoritative, revisioned persistence and lifecycle management for Vault definitions.
 //!
-//! Definition fields and lifecycle operations intentionally arrive in issue #86.
-//! This boundary owns only durable identity, revision, atomicity, permissions,
-//! and recovery behavior.
+//! This boundary owns durable identity, tagged source definitions, validation,
+//! credential redaction, optimistic lifecycle operations, atomicity, permissions,
+//! and recovery behavior. Runtime reconciliation, Git lifecycle, migration, and
+//! transport adapters remain outside this module.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -140,16 +141,169 @@ fn decode_hex(value: u8) -> Option<u8> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum VaultSource {
+    Local {
+        path: PathBuf,
+    },
+    ExistingGit {
+        repository_path: PathBuf,
+        repository_url: Option<String>,
+        branch: Option<String>,
+        vault_subdirectory: Option<PathBuf>,
+        mode: VaultGitMode,
+    },
+    ManagedGit {
+        repository_url: String,
+        branch: Option<String>,
+        vault_subdirectory: Option<PathBuf>,
+        mode: VaultGitMode,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VaultGitMode {
+    LocalHistory,
+    PullOnly,
+    TwoWay,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct HttpsCredentials {
+    pub username: String,
+    pub token: String,
+}
+
+impl fmt::Debug for HttpsCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HttpsCredentials")
+            .field("username", &"[REDACTED]")
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-/// The persisted slot for one Vault ID. Issue #86 adds the accepted definition
-/// fields without changing the identity or registry persistence contract.
-pub struct VaultRecord {}
+struct StoredHttpsCredentials {
+    username: String,
+    token: String,
+}
+
+impl fmt::Debug for StoredHttpsCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StoredHttpsCredentials")
+            .field("username", &"[REDACTED]")
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl From<HttpsCredentials> for StoredHttpsCredentials {
+    fn from(credentials: HttpsCredentials) -> Self {
+        Self {
+            username: credentials.username,
+            token: credentials.token,
+        }
+    }
+}
+
+pub struct NewVaultDefinition {
+    pub name: String,
+    pub enabled: bool,
+    pub source: VaultSource,
+    pub exclude_patterns: Vec<String>,
+    pub https_credentials: Option<HttpsCredentials>,
+}
+
+#[derive(Debug)]
+pub enum HttpsCredentialUpdate {
+    Keep,
+    Remove,
+    Replace(HttpsCredentials),
+}
+
+pub struct VaultDefinitionEdit {
+    pub name: String,
+    pub source: VaultSource,
+    pub exclude_patterns: Vec<String>,
+    pub https_credentials: HttpsCredentialUpdate,
+    pub confirm_identity_change: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VaultDefinition {
+    vault_id: VaultId,
+    name: String,
+    enabled: bool,
+    source: VaultSource,
+    exclude_patterns: Vec<String>,
+    credential_configured: bool,
+}
+
+impl VaultDefinition {
+    pub fn vault_id(&self) -> VaultId {
+        self.vault_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn source(&self) -> &VaultSource {
+        &self.source
+    }
+
+    pub fn exclude_patterns(&self) -> &[String] {
+        &self.exclude_patterns
+    }
+
+    pub fn credential_configured(&self) -> bool {
+        self.credential_configured
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VaultRecord {
+    name: String,
+    enabled: bool,
+    source: VaultSource,
+    exclude_patterns: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    https_credentials: Option<StoredHttpsCredentials>,
+}
 
 impl VaultRecord {
+    fn redacted(&self, vault_id: VaultId) -> VaultDefinition {
+        VaultDefinition {
+            vault_id,
+            name: self.name.clone(),
+            enabled: self.enabled,
+            source: self.source.clone(),
+            exclude_patterns: self.exclude_patterns.clone(),
+            credential_configured: self.https_credentials.is_some(),
+        }
+    }
+
     #[cfg(test)]
-    fn empty() -> Self {
-        Self {}
+    fn empty(vault_id: VaultId) -> Self {
+        Self {
+            name: format!("Test Vault {vault_id}"),
+            enabled: true,
+            source: VaultSource::Local {
+                path: PathBuf::from("/tmp/test-vault").join(vault_id.to_string()),
+            },
+            exclude_patterns: Vec::new(),
+            https_credentials: None,
+        }
     }
 }
 
@@ -180,7 +334,58 @@ impl VaultRegistrySnapshot {
     pub fn vault_ids(&self) -> impl ExactSizeIterator<Item = VaultId> + '_ {
         self.vaults.keys().copied()
     }
+
+    pub fn definitions(&self) -> impl Iterator<Item = VaultDefinition> + '_ {
+        self.vaults
+            .iter()
+            .map(|(vault_id, record)| record.redacted(*vault_id))
+    }
+
+    pub fn definition(&self, vault_id: VaultId) -> Option<VaultDefinition> {
+        self.vaults
+            .get(&vault_id)
+            .map(|record| record.redacted(vault_id))
+    }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VaultDefinitionError {
+    InvalidName,
+    InvalidExclusionPattern,
+    DuplicateName,
+    PathOverlap,
+    VaultNotFound,
+    IdentityChangeRequiresDisabled,
+    IdentityChangeRequiresConfirmation,
+    InvalidSource(String),
+}
+
+impl fmt::Display for VaultDefinitionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName => formatter.write_str("Vault name must be non-empty"),
+            Self::InvalidExclusionPattern => {
+                formatter.write_str("Vault exclusion patterns must not contain control characters")
+            }
+            Self::DuplicateName => {
+                formatter.write_str("Vault name is already used by another definition")
+            }
+            Self::PathOverlap => formatter.write_str(
+                "Vault path overlaps another connected Vault, including disabled definitions",
+            ),
+            Self::VaultNotFound => formatter.write_str("Vault definition was not found"),
+            Self::IdentityChangeRequiresDisabled => formatter.write_str(
+                "Vault source, repository, branch, subdirectory, or location may change only while disabled",
+            ),
+            Self::IdentityChangeRequiresConfirmation => formatter.write_str(
+                "Vault identity-bearing changes require explicit confirmation that it is the same logical Vault",
+            ),
+            Self::InvalidSource(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for VaultDefinitionError {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VaultRegistryRecoveryKind {
@@ -217,6 +422,7 @@ pub enum VaultRegistryError {
     RecoveryRequired,
     RevisionExhausted,
     LockPoisoned,
+    InvalidDefinition(VaultDefinitionError),
     Storage(String),
 }
 
@@ -232,6 +438,7 @@ impl fmt::Display for VaultRegistryError {
             }
             Self::RevisionExhausted => formatter.write_str("Vault registry revision is exhausted"),
             Self::LockPoisoned => formatter.write_str("Vault registry write lock was poisoned"),
+            Self::InvalidDefinition(error) => error.fmt(formatter),
             Self::Storage(message) => formatter.write_str(message),
         }
     }
@@ -270,6 +477,199 @@ impl VaultRegistryStore {
         self.load_unlocked()
     }
 
+    pub fn add(
+        &self,
+        expected_revision: u64,
+        definition: NewVaultDefinition,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        let VaultRegistryState::Ready(current) = self.load()? else {
+            return Err(VaultRegistryError::RecoveryRequired);
+        };
+        let name = normalize_vault_name(definition.name)?;
+        if current
+            .vaults
+            .values()
+            .any(|record| vault_name_key(&record.name) == vault_name_key(&name))
+        {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::DuplicateName,
+            ));
+        }
+        let source = normalize_source(definition.source)?;
+        let vault_id = loop {
+            let candidate = VaultId::generate().map_err(|error| {
+                VaultRegistryError::Storage(format!("could not generate Vault ID: {error}"))
+            })?;
+            if !current.vaults.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+        let vault_path = canonical_or_normalized(&self.source_vault_path(vault_id, &source));
+        if current.vaults.iter().any(|(existing_id, record)| {
+            let existing =
+                canonical_or_normalized(&self.source_vault_path(*existing_id, &record.source));
+            paths_overlap(&vault_path, &existing)
+        }) {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::PathOverlap,
+            ));
+        }
+        let exclude_patterns = normalize_exclude_patterns(definition.exclude_patterns)?;
+        let mut vaults = current.vaults;
+        let https_credentials = normalize_credentials(&source, definition.https_credentials)?;
+        vaults.insert(
+            vault_id,
+            VaultRecord {
+                name,
+                enabled: definition.enabled,
+                source,
+                exclude_patterns,
+                https_credentials,
+            },
+        );
+        self.commit(expected_revision, vaults)
+    }
+
+    pub fn edit(
+        &self,
+        expected_revision: u64,
+        vault_id: VaultId,
+        edit: VaultDefinitionEdit,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        let VaultRegistryState::Ready(current) = self.load()? else {
+            return Err(VaultRegistryError::RecoveryRequired);
+        };
+        ensure_revision(&current, expected_revision)?;
+        let Some(existing) = current.vaults.get(&vault_id).cloned() else {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::VaultNotFound,
+            ));
+        };
+        let name = normalize_vault_name(edit.name)?;
+        if current.vaults.iter().any(|(other_id, record)| {
+            *other_id != vault_id && vault_name_key(&record.name) == vault_name_key(&name)
+        }) {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::DuplicateName,
+            ));
+        }
+        let source = normalize_source(edit.source)?;
+        let identity_changed = !same_source_identity(&existing.source, &source);
+        if identity_changed && existing.enabled {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::IdentityChangeRequiresDisabled,
+            ));
+        }
+        if identity_changed && !edit.confirm_identity_change {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::IdentityChangeRequiresConfirmation,
+            ));
+        }
+        let vault_path = canonical_or_normalized(&self.source_vault_path(vault_id, &source));
+        if current.vaults.iter().any(|(other_id, record)| {
+            if *other_id == vault_id {
+                return false;
+            }
+            let existing_path =
+                canonical_or_normalized(&self.source_vault_path(*other_id, &record.source));
+            paths_overlap(&vault_path, &existing_path)
+        }) {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::PathOverlap,
+            ));
+        }
+        let https_credentials = match edit.https_credentials {
+            HttpsCredentialUpdate::Keep
+                if source_is_remote_backed(&source) && !identity_changed =>
+            {
+                existing.https_credentials
+            }
+            HttpsCredentialUpdate::Keep | HttpsCredentialUpdate::Remove => None,
+            HttpsCredentialUpdate::Replace(credentials) => {
+                normalize_credentials(&source, Some(credentials))?
+            }
+        };
+        let mut vaults = current.vaults;
+        vaults.insert(
+            vault_id,
+            VaultRecord {
+                name,
+                enabled: existing.enabled,
+                source,
+                exclude_patterns: normalize_exclude_patterns(edit.exclude_patterns)?,
+                https_credentials,
+            },
+        );
+        self.commit(expected_revision, vaults)
+    }
+
+    pub fn enable(
+        &self,
+        expected_revision: u64,
+        vault_id: VaultId,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        self.set_enabled(expected_revision, vault_id, true)
+    }
+
+    pub fn disable(
+        &self,
+        expected_revision: u64,
+        vault_id: VaultId,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        self.set_enabled(expected_revision, vault_id, false)
+    }
+
+    pub fn disconnect(
+        &self,
+        expected_revision: u64,
+        vault_id: VaultId,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        let VaultRegistryState::Ready(current) = self.load()? else {
+            return Err(VaultRegistryError::RecoveryRequired);
+        };
+        ensure_revision(&current, expected_revision)?;
+        let mut vaults = current.vaults;
+        if vaults.remove(&vault_id).is_none() {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::VaultNotFound,
+            ));
+        }
+        self.commit(expected_revision, vaults)
+    }
+
+    fn set_enabled(
+        &self,
+        expected_revision: u64,
+        vault_id: VaultId,
+        enabled: bool,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        let VaultRegistryState::Ready(current) = self.load()? else {
+            return Err(VaultRegistryError::RecoveryRequired);
+        };
+        ensure_revision(&current, expected_revision)?;
+        let mut vaults = current.vaults;
+        let Some(existing) = vaults.get(&vault_id) else {
+            return Err(VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::VaultNotFound,
+            ));
+        };
+        if existing.enabled == enabled {
+            return Ok(VaultRegistrySnapshot {
+                schema_version: REGISTRY_SCHEMA_VERSION,
+                revision: expected_revision,
+                vaults,
+            });
+        }
+        if enabled {
+            normalize_source(existing.source.clone())?;
+        }
+        let record = vaults
+            .get_mut(&vault_id)
+            .expect("record checked before enable transition");
+        record.enabled = enabled;
+        self.commit(expected_revision, vaults)
+    }
+
     fn load_unlocked(&self) -> Result<VaultRegistryState, VaultRegistryError> {
         if !self.path.exists() {
             return Ok(VaultRegistryState::Ready(VaultRegistrySnapshot::empty()));
@@ -283,10 +683,8 @@ impl VaultRegistryStore {
         })?;
         let value: serde_json::Value = match serde_json::from_slice(&encoded) {
             Ok(value) => value,
-            Err(error) => {
-                return Ok(VaultRegistryState::Recovery(
-                    self.corrupt(error.to_string()),
-                ));
+            Err(_) => {
+                return Ok(VaultRegistryState::Recovery(self.corrupt("invalid JSON")));
             }
         };
         let Some(schema_version) = value.get("schema_version").and_then(|value| value.as_u64())
@@ -323,12 +721,15 @@ impl VaultRegistryStore {
         }
         let stored: StoredVaultRegistry = match serde_json::from_value(value) {
             Ok(stored) => stored,
-            Err(error) => {
+            Err(_) => {
                 return Ok(VaultRegistryState::Recovery(
-                    self.corrupt(error.to_string()),
+                    self.corrupt("invalid registry shape"),
                 ));
             }
         };
+        if let Err(detail) = self.validate_stored_definitions(&stored.vaults) {
+            return Ok(VaultRegistryState::Recovery(self.corrupt(detail)));
+        }
         Ok(VaultRegistryState::Ready(VaultRegistrySnapshot {
             schema_version: stored.schema_version,
             revision: stored.revision,
@@ -336,7 +737,7 @@ impl VaultRegistryStore {
         }))
     }
 
-    pub fn commit(
+    fn commit(
         &self,
         expected_revision: u64,
         vaults: impl IntoIterator<Item = (VaultId, VaultRecord)>,
@@ -365,6 +766,46 @@ impl VaultRegistryStore {
         };
         self.persist(&next)?;
         Ok(next)
+    }
+
+    fn validate_stored_definitions(
+        &self,
+        vaults: &BTreeMap<VaultId, VaultRecord>,
+    ) -> Result<(), &'static str> {
+        validate_stored_names(vaults)?;
+        for record in vaults.values() {
+            if record.exclude_patterns.iter().any(|pattern| {
+                pattern.is_empty()
+                    || pattern.trim() != pattern
+                    || pattern.chars().any(char::is_control)
+            }) {
+                return Err("Vault definition contains invalid exclusion patterns");
+            }
+            if !stored_source_is_valid(&record.source) {
+                return Err("Vault definition contains an invalid or credential-bearing source");
+            }
+            if let Some(credentials) = &record.https_credentials
+                && (!source_is_remote_backed(&record.source)
+                    || credentials.username.is_empty()
+                    || credentials.token.is_empty()
+                    || credentials.username.trim() != credentials.username
+                    || credentials.token.trim() != credentials.token)
+            {
+                return Err("Vault definition contains invalid HTTPS credentials");
+            }
+        }
+        let definitions = vaults.iter().collect::<Vec<_>>();
+        for (index, (vault_id, record)) in definitions.iter().enumerate() {
+            let path = canonical_or_normalized(&self.source_vault_path(**vault_id, &record.source));
+            for (other_id, other) in definitions.iter().skip(index + 1) {
+                let other_path =
+                    canonical_or_normalized(&self.source_vault_path(**other_id, &other.source));
+                if paths_overlap(&path, &other_path) {
+                    return Err("Vault definitions contain overlapping canonical paths");
+                }
+            }
+        }
+        Ok(())
     }
 
     fn persist(&self, snapshot: &VaultRegistrySnapshot) -> Result<(), VaultRegistryError> {
@@ -413,6 +854,34 @@ impl VaultRegistryStore {
         &self.path
     }
 
+    fn source_vault_path(&self, vault_id: VaultId, source: &VaultSource) -> PathBuf {
+        match source {
+            VaultSource::Local { path } => path.clone(),
+            VaultSource::ExistingGit {
+                repository_path,
+                vault_subdirectory,
+                ..
+            } => vault_subdirectory.as_ref().map_or_else(
+                || repository_path.clone(),
+                |subdirectory| repository_path.join(subdirectory),
+            ),
+            VaultSource::ManagedGit {
+                vault_subdirectory, ..
+            } => {
+                let state_directory = self.path.parent().unwrap_or_else(|| Path::new("."));
+                let repository = state_directory
+                    .join("vaults")
+                    .join(vault_id.to_string())
+                    .join("repository");
+                vault_subdirectory
+                    .as_ref()
+                    .map_or(repository.clone(), |subdirectory| {
+                        repository.join(subdirectory)
+                    })
+            }
+        }
+    }
+
     fn corrupt(&self, detail: impl fmt::Display) -> VaultRegistryRecovery {
         VaultRegistryRecovery {
             kind: VaultRegistryRecoveryKind::Corrupt,
@@ -421,6 +890,467 @@ impl VaultRegistryStore {
                 self.path.display()
             ),
         }
+    }
+}
+
+fn normalize_vault_name(name: String) -> Result<String, VaultRegistryError> {
+    let name = name.trim().to_string();
+    if name.is_empty() || name.chars().any(char::is_control) {
+        return Err(VaultRegistryError::InvalidDefinition(
+            VaultDefinitionError::InvalidName,
+        ));
+    }
+    Ok(name)
+}
+
+fn vault_name_key(name: &str) -> String {
+    name.to_lowercase()
+}
+
+fn ensure_revision(
+    snapshot: &VaultRegistrySnapshot,
+    expected_revision: u64,
+) -> Result<(), VaultRegistryError> {
+    if snapshot.revision != expected_revision {
+        return Err(VaultRegistryError::RevisionConflict {
+            expected: expected_revision,
+            actual: snapshot.revision,
+        });
+    }
+    Ok(())
+}
+
+fn normalize_exclude_patterns(patterns: Vec<String>) -> Result<Vec<String>, VaultRegistryError> {
+    let patterns = patterns
+        .into_iter()
+        .map(|pattern| pattern.trim().to_string())
+        .filter(|pattern| !pattern.is_empty())
+        .collect::<Vec<_>>();
+    if patterns
+        .iter()
+        .any(|pattern| pattern.chars().any(char::is_control))
+    {
+        return Err(VaultRegistryError::InvalidDefinition(
+            VaultDefinitionError::InvalidExclusionPattern,
+        ));
+    }
+    Ok(patterns)
+}
+
+fn normalize_optional_branch(branch: Option<String>) -> Result<Option<String>, VaultRegistryError> {
+    let branch = branch
+        .map(|branch| branch.trim().to_string())
+        .filter(|branch| !branch.is_empty());
+    if branch
+        .as_ref()
+        .is_some_and(|branch| branch.chars().any(char::is_control))
+    {
+        return Err(invalid_source(
+            "Git branch must not contain control characters",
+        ));
+    }
+    Ok(branch)
+}
+
+fn same_source_identity(first: &VaultSource, second: &VaultSource) -> bool {
+    match (first, second) {
+        (VaultSource::Local { path: first }, VaultSource::Local { path: second }) => {
+            first == second
+        }
+        (
+            VaultSource::ExistingGit {
+                repository_path: first_path,
+                repository_url: first_url,
+                branch: first_branch,
+                vault_subdirectory: first_subdirectory,
+                ..
+            },
+            VaultSource::ExistingGit {
+                repository_path: second_path,
+                repository_url: second_url,
+                branch: second_branch,
+                vault_subdirectory: second_subdirectory,
+                ..
+            },
+        ) => {
+            first_path == second_path
+                && first_url == second_url
+                && first_branch == second_branch
+                && first_subdirectory == second_subdirectory
+        }
+        (
+            VaultSource::ManagedGit {
+                repository_url: first_url,
+                branch: first_branch,
+                vault_subdirectory: first_subdirectory,
+                ..
+            },
+            VaultSource::ManagedGit {
+                repository_url: second_url,
+                branch: second_branch,
+                vault_subdirectory: second_subdirectory,
+                ..
+            },
+        ) => {
+            first_url == second_url
+                && first_branch == second_branch
+                && first_subdirectory == second_subdirectory
+        }
+        _ => false,
+    }
+}
+
+fn normalize_source(source: VaultSource) -> Result<VaultSource, VaultRegistryError> {
+    let source = normalize_structural_source(source)?;
+    match source {
+        VaultSource::Local { path } => {
+            let path = path.canonicalize().map_err(|error| {
+                VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(format!(
+                    "local Vault path '{}' is not readable: {error}",
+                    path.display()
+                )))
+            })?;
+            let metadata = fs::metadata(&path).map_err(|error| {
+                VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(format!(
+                    "local Vault path '{}' is not readable: {error}",
+                    path.display()
+                )))
+            })?;
+            if !metadata.is_dir() {
+                return Err(VaultRegistryError::InvalidDefinition(
+                    VaultDefinitionError::InvalidSource(format!(
+                        "local Vault path '{}' is not a directory",
+                        path.display()
+                    )),
+                ));
+            }
+            fs::read_dir(&path).map_err(|error| {
+                VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(format!(
+                    "local Vault path '{}' is not readable: {error}",
+                    path.display()
+                )))
+            })?;
+            Ok(VaultSource::Local { path })
+        }
+        VaultSource::ManagedGit {
+            repository_url,
+            branch,
+            vault_subdirectory,
+            mode,
+        } => Ok(VaultSource::ManagedGit {
+            repository_url,
+            branch,
+            vault_subdirectory,
+            mode,
+        }),
+        VaultSource::ExistingGit {
+            repository_path,
+            repository_url,
+            branch,
+            vault_subdirectory,
+            mode,
+        } => {
+            let repository_path = repository_path.canonicalize().map_err(|error| {
+                invalid_source(&format!(
+                    "existing Git location '{}' is not readable: {error}",
+                    repository_path.display()
+                ))
+            })?;
+            let repository = git2::Repository::open(&repository_path).map_err(|_| {
+                invalid_source("existing Git location must be a readable working checkout")
+            })?;
+            if repository.is_bare() || repository.workdir().is_none() {
+                return Err(invalid_source(
+                    "existing Git location must be a readable working checkout",
+                ));
+            }
+            let workdir = repository
+                .workdir()
+                .expect("non-bare repository checked above")
+                .canonicalize()
+                .map_err(|_| {
+                    invalid_source("existing Git location must be a readable working checkout")
+                })?;
+            if workdir != repository_path {
+                return Err(invalid_source(
+                    "existing Git location must be the working checkout root",
+                ));
+            }
+            let vault_path = vault_subdirectory.as_ref().map_or_else(
+                || repository_path.clone(),
+                |subdirectory| repository_path.join(subdirectory),
+            );
+            let canonical_vault_path = vault_path.canonicalize().map_err(|error| {
+                invalid_source(&format!(
+                    "existing Git Vault path '{}' is not readable: {error}",
+                    vault_path.display()
+                ))
+            })?;
+            if !canonical_vault_path.starts_with(&repository_path) {
+                return Err(invalid_source(
+                    "existing Git Vault subdirectory must stay inside its repository",
+                ));
+            }
+            fs::read_dir(&canonical_vault_path).map_err(|error| {
+                invalid_source(&format!(
+                    "existing Git Vault path '{}' is not readable: {error}",
+                    canonical_vault_path.display()
+                ))
+            })?;
+            let canonical_subdirectory = canonical_vault_path
+                .strip_prefix(&repository_path)
+                .expect("contained Vault path checked above");
+            let vault_subdirectory = if canonical_subdirectory.as_os_str().is_empty() {
+                None
+            } else {
+                Some(canonical_subdirectory.to_path_buf())
+            };
+            Ok(VaultSource::ExistingGit {
+                repository_path,
+                repository_url,
+                branch,
+                vault_subdirectory,
+                mode,
+            })
+        }
+    }
+}
+
+fn normalize_structural_source(source: VaultSource) -> Result<VaultSource, VaultRegistryError> {
+    match source {
+        VaultSource::Local { path } => Ok(VaultSource::Local { path }),
+        VaultSource::ManagedGit {
+            repository_url,
+            branch,
+            vault_subdirectory,
+            mode,
+        } => {
+            if mode == VaultGitMode::LocalHistory {
+                return Err(invalid_source(
+                    "managed Git requires pull_only or two_way mode",
+                ));
+            }
+            Ok(VaultSource::ManagedGit {
+                repository_url: normalize_https_repository_url(repository_url)?,
+                branch: normalize_optional_branch(branch)?,
+                vault_subdirectory: vault_subdirectory
+                    .map(normalize_relative_subdirectory)
+                    .transpose()?,
+                mode,
+            })
+        }
+        VaultSource::ExistingGit {
+            repository_path,
+            repository_url,
+            branch,
+            vault_subdirectory,
+            mode,
+        } => {
+            let repository_url = match (mode, repository_url) {
+                (VaultGitMode::LocalHistory, None) => None,
+                (VaultGitMode::LocalHistory, Some(_)) => {
+                    return Err(invalid_source(
+                        "local_history mode must not configure a remote repository URL",
+                    ));
+                }
+                (_, Some(repository_url)) => Some(normalize_https_repository_url(repository_url)?),
+                (_, None) => {
+                    return Err(invalid_source(
+                        "pull_only and two_way existing Git modes require a repository URL",
+                    ));
+                }
+            };
+            Ok(VaultSource::ExistingGit {
+                repository_path,
+                repository_url,
+                branch: normalize_optional_branch(branch)?,
+                vault_subdirectory: vault_subdirectory
+                    .map(normalize_relative_subdirectory)
+                    .transpose()?,
+                mode,
+            })
+        }
+    }
+}
+
+fn normalize_credentials(
+    source: &VaultSource,
+    credentials: Option<HttpsCredentials>,
+) -> Result<Option<StoredHttpsCredentials>, VaultRegistryError> {
+    let Some(credentials) = credentials else {
+        return Ok(None);
+    };
+    if !source_is_remote_backed(source) {
+        return Err(VaultRegistryError::InvalidDefinition(
+            VaultDefinitionError::InvalidSource(
+                "HTTPS credentials are valid only for a remote-backed Vault".to_string(),
+            ),
+        ));
+    }
+    let username = credentials.username.trim().to_string();
+    let token = credentials.token.trim().to_string();
+    if username.is_empty() || token.is_empty() {
+        return Err(VaultRegistryError::InvalidDefinition(
+            VaultDefinitionError::InvalidSource(
+                "HTTPS credential username and token must both be non-empty".to_string(),
+            ),
+        ));
+    }
+    Ok(Some(StoredHttpsCredentials { username, token }))
+}
+
+fn source_is_remote_backed(source: &VaultSource) -> bool {
+    matches!(
+        source,
+        VaultSource::ManagedGit { .. }
+            | VaultSource::ExistingGit {
+                repository_url: Some(_),
+                ..
+            }
+    )
+}
+
+fn normalize_https_repository_url(repository_url: String) -> Result<String, VaultRegistryError> {
+    let repository_url = repository_url.trim().to_string();
+    if !is_safe_https_repository_url(&repository_url) {
+        return Err(invalid_source(
+            "Git repository URL must be valid credential-free HTTPS with a repository path",
+        ));
+    }
+    Ok(repository_url)
+}
+
+fn is_safe_https_repository_url(repository_url: &str) -> bool {
+    let Some(remainder) = repository_url.strip_prefix("https://") else {
+        return false;
+    };
+    let Some((authority, path)) = remainder.split_once('/') else {
+        return false;
+    };
+    !(authority.is_empty()
+        || authority.contains('@')
+        || path.is_empty()
+        || repository_url.contains(['?', '#', '\\'])
+        || repository_url
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control()))
+        && valid_https_authority(authority)
+        && valid_percent_encoding(repository_url)
+}
+
+fn valid_https_authority(authority: &str) -> bool {
+    if let Some(ipv6) = authority.strip_prefix('[') {
+        let Some((address, suffix)) = ipv6.split_once(']') else {
+            return false;
+        };
+        return address.parse::<std::net::Ipv6Addr>().is_ok() && valid_port_suffix(suffix);
+    }
+
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (authority, None),
+    };
+    !host.is_empty()
+        && !host.contains(':')
+        && host.split('.').all(|label| {
+            !label.is_empty()
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+        && port.is_none_or(valid_port)
+}
+
+fn valid_port_suffix(suffix: &str) -> bool {
+    suffix.is_empty() || suffix.strip_prefix(':').is_some_and(valid_port)
+}
+
+fn valid_port(port: &str) -> bool {
+    !port.is_empty()
+        && port.bytes().all(|byte| byte.is_ascii_digit())
+        && port.parse::<u16>().is_ok()
+}
+
+fn valid_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return false;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    true
+}
+
+fn normalize_relative_subdirectory(path: PathBuf) -> Result<PathBuf, VaultRegistryError> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => normalized.push(value),
+            _ => {
+                return Err(invalid_source(
+                    "Vault subdirectory must be a contained relative path",
+                ));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(invalid_source(
+            "Vault subdirectory must be a contained relative path",
+        ));
+    }
+    Ok(normalized)
+}
+
+fn invalid_source(message: &str) -> VaultRegistryError {
+    VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(message.to_string()))
+}
+
+fn paths_overlap(first: &Path, second: &Path) -> bool {
+    first.starts_with(second) || second.starts_with(first)
+}
+
+fn validate_stored_names(vaults: &BTreeMap<VaultId, VaultRecord>) -> Result<(), &'static str> {
+    let mut names = std::collections::BTreeSet::new();
+    for record in vaults.values() {
+        if record.name.trim().is_empty()
+            || record.name.trim() != record.name
+            || record.name.chars().any(char::is_control)
+        {
+            return Err("Vault definition contains an invalid name");
+        }
+        if !names.insert(vault_name_key(&record.name)) {
+            return Err("Vault definitions contain duplicate case-insensitive names");
+        }
+    }
+    Ok(())
+}
+
+fn stored_source_is_valid(source: &VaultSource) -> bool {
+    if normalize_structural_source(source.clone()).as_ref() != Ok(source) {
+        return false;
+    }
+    match source {
+        VaultSource::Local { path } => {
+            path.is_absolute() && normalized_absolute_path(path) == *path
+        }
+        VaultSource::ExistingGit {
+            repository_path, ..
+        } => {
+            repository_path.is_absolute()
+                && normalized_absolute_path(repository_path) == *repository_path
+        }
+        VaultSource::ManagedGit { .. } => true,
     }
 }
 
@@ -457,6 +1387,11 @@ fn normalized_absolute_path(path: &Path) -> PathBuf {
         }
     }
     normalized
+}
+
+fn canonical_or_normalized(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| normalized_absolute_path(path))
 }
 
 fn temporary_path(path: &Path) -> Result<PathBuf, VaultRegistryError> {
@@ -536,6 +1471,7 @@ fn sync_directory(_path: &Path) -> Result<(), VaultRegistryError> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
@@ -543,8 +1479,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        DEFAULT_VAULT_REGISTRY_PATH, REGISTRY_SCHEMA_VERSION, VaultId, VaultRecord,
-        VaultRegistryError, VaultRegistryRecoveryKind, VaultRegistryState, VaultRegistryStore,
+        DEFAULT_VAULT_REGISTRY_PATH, HttpsCredentialUpdate, HttpsCredentials, NewVaultDefinition,
+        REGISTRY_SCHEMA_VERSION, VaultDefinitionEdit, VaultDefinitionError, VaultGitMode, VaultId,
+        VaultRecord, VaultRegistryError, VaultRegistryRecoveryKind, VaultRegistryState,
+        VaultRegistryStore, VaultSource,
     };
 
     #[test]
@@ -599,6 +1537,863 @@ mod tests {
     }
 
     #[test]
+    fn local_definition_add_round_trips_through_the_public_snapshot() {
+        let directory = tempdir().expect("temporary directory");
+        let vault_path = directory.path().join("notes");
+        std::fs::create_dir(&vault_path).expect("create Vault directory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+
+        let committed = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Personal".to_string(),
+                    enabled: true,
+                    source: VaultSource::Local {
+                        path: vault_path.clone(),
+                    },
+                    exclude_patterns: vec![" private/** ".to_string(), "".to_string()],
+                    https_credentials: None,
+                },
+            )
+            .expect("add local Vault");
+
+        assert_eq!(committed.revision(), 1);
+        let definition = committed
+            .definitions()
+            .next()
+            .expect("committed definition");
+        assert_eq!(definition.name(), "Personal");
+        assert!(definition.enabled());
+        assert_eq!(
+            definition.source(),
+            &VaultSource::Local {
+                path: vault_path.canonicalize().expect("canonical Vault path")
+            }
+        );
+        assert_eq!(definition.exclude_patterns(), &["private/**"]);
+        assert!(!definition.credential_configured());
+
+        let VaultRegistryState::Ready(restarted) = store.load().expect("reload registry") else {
+            panic!("valid registry entered recovery");
+        };
+        assert_eq!(restarted.definitions().next(), Some(definition));
+    }
+
+    #[test]
+    fn vault_names_are_unique_without_regard_to_case() {
+        let directory = tempdir().expect("temporary directory");
+        let first_path = directory.path().join("first");
+        let second_path = directory.path().join("second");
+        std::fs::create_dir(&first_path).expect("create first Vault");
+        std::fs::create_dir(&second_path).expect("create second Vault");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        store
+            .add(0, local_definition("Personal", first_path, true))
+            .expect("add first Vault");
+
+        let error = store
+            .add(1, local_definition("personal", second_path, true))
+            .expect_err("case-insensitive duplicate name accepted");
+
+        assert_eq!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::DuplicateName)
+        );
+        let VaultRegistryState::Ready(snapshot) = store.load().expect("reload registry") else {
+            panic!("valid registry entered recovery");
+        };
+        assert_eq!(snapshot.revision(), 1);
+        assert_eq!(snapshot.definitions().count(), 1);
+    }
+
+    #[test]
+    fn disabled_definitions_continue_reserving_their_canonical_paths() {
+        let directory = tempdir().expect("temporary directory");
+        let parent = directory.path().join("notes");
+        let nested = parent.join("nested");
+        std::fs::create_dir_all(&nested).expect("create nested Vault paths");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        store
+            .add(0, local_definition("Paused", parent, false))
+            .expect("add disabled Vault");
+
+        let error = store
+            .add(1, local_definition("Nested", nested, true))
+            .expect_err("nested path accepted");
+
+        assert_eq!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::PathOverlap)
+        );
+        let VaultRegistryState::Ready(snapshot) = store.load().expect("reload registry") else {
+            panic!("valid registry entered recovery");
+        };
+        assert_eq!(snapshot.revision(), 1);
+    }
+
+    #[test]
+    fn managed_https_credentials_are_persisted_but_redacted_from_reads_and_debug() {
+        let directory = tempdir().expect("temporary directory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let credentials = HttpsCredentials {
+            username: "git-user".to_string(),
+            token: "super-secret-token".to_string(),
+        };
+        assert!(!format!("{credentials:?}").contains("super-secret-token"));
+
+        let committed = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Remote notes".to_string(),
+                    enabled: true,
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://example.test/owner/notes.git".to_string(),
+                        branch: Some("main".to_string()),
+                        vault_subdirectory: Some(PathBuf::from("knowledge/notes")),
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: Some(credentials),
+                },
+            )
+            .expect("add managed Vault");
+
+        let definition = committed.definitions().next().expect("definition");
+        assert!(definition.credential_configured());
+        assert!(!format!("{definition:?}").contains("super-secret-token"));
+        assert_eq!(
+            definition.source(),
+            &VaultSource::ManagedGit {
+                repository_url: "https://example.test/owner/notes.git".to_string(),
+                branch: Some("main".to_string()),
+                vault_subdirectory: Some(PathBuf::from("knowledge/notes")),
+                mode: VaultGitMode::PullOnly,
+            }
+        );
+        let encoded = std::fs::read_to_string(store.path()).expect("persisted registry");
+        assert!(encoded.contains("super-secret-token"));
+        assert!(!format!("{committed:?}").contains("super-secret-token"));
+    }
+
+    #[test]
+    fn existing_git_source_requires_a_readable_checkout_and_canonicalizes_its_location() {
+        let directory = tempdir().expect("temporary directory");
+        let repository_path = directory.path().join("repository");
+        git2::Repository::init(&repository_path).expect("initialize repository");
+        std::fs::create_dir(repository_path.join("notes")).expect("create Vault subdirectory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+
+        let committed = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Existing checkout".to_string(),
+                    enabled: true,
+                    source: VaultSource::ExistingGit {
+                        repository_path: repository_path.clone(),
+                        repository_url: None,
+                        branch: None,
+                        vault_subdirectory: Some(PathBuf::from("notes")),
+                        mode: VaultGitMode::LocalHistory,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect("add existing checkout");
+
+        assert_eq!(
+            committed.definitions().next().expect("definition").source(),
+            &VaultSource::ExistingGit {
+                repository_path: repository_path
+                    .canonicalize()
+                    .expect("canonical repository"),
+                repository_url: None,
+                branch: None,
+                vault_subdirectory: Some(PathBuf::from("notes")),
+                mode: VaultGitMode::LocalHistory,
+            }
+        );
+
+        let not_repository = directory.path().join("ordinary-directory");
+        std::fs::create_dir(&not_repository).expect("create ordinary directory");
+        let error = store
+            .add(
+                1,
+                NewVaultDefinition {
+                    name: "Not Git".to_string(),
+                    enabled: true,
+                    source: VaultSource::ExistingGit {
+                        repository_path: not_repository,
+                        repository_url: None,
+                        branch: None,
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::LocalHistory,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect_err("ordinary directory accepted as existing Git");
+        assert!(matches!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_git_symlink_subdirectory_cannot_bypass_canonical_overlap_validation() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempdir().expect("temporary directory");
+        let repository_path = directory.path().join("repository");
+        git2::Repository::init(&repository_path).expect("initialize repository");
+        let actual = repository_path.join("actual");
+        std::fs::create_dir(&actual).expect("create actual Vault path");
+        symlink("actual", repository_path.join("alias")).expect("create in-repository symlink");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Existing checkout".to_string(),
+                    enabled: false,
+                    source: VaultSource::ExistingGit {
+                        repository_path,
+                        repository_url: None,
+                        branch: None,
+                        vault_subdirectory: Some(PathBuf::from("alias")),
+                        mode: VaultGitMode::LocalHistory,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect("add existing checkout");
+        assert!(matches!(
+            added.definitions().next().expect("definition").source(),
+            VaultSource::ExistingGit {
+                vault_subdirectory: Some(path),
+                ..
+            } if path == std::path::Path::new("actual")
+        ));
+
+        let error = store
+            .add(1, local_definition("Same files", actual, true))
+            .expect_err("symlink alias bypassed path overlap");
+
+        assert_eq!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::PathOverlap)
+        );
+    }
+
+    #[test]
+    fn existing_git_source_rejects_the_repository_metadata_directory_as_its_location() {
+        let directory = tempdir().expect("temporary directory");
+        let repository_path = directory.path().join("repository");
+        git2::Repository::init(&repository_path).expect("initialize repository");
+        let path = directory.path().join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+
+        let error = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Metadata is not a Vault".to_string(),
+                    enabled: true,
+                    source: VaultSource::ExistingGit {
+                        repository_path: repository_path.join(".git"),
+                        repository_url: None,
+                        branch: None,
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::LocalHistory,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect_err("repository metadata accepted as checkout root");
+
+        assert!(matches!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(_))
+        ));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn malformed_https_repository_urls_save_nothing() {
+        for repository_url in [
+            "https://:bad/notes.git",
+            "https://example.test/%zz/notes.git",
+        ] {
+            let directory = tempdir().expect("temporary directory");
+            let path = directory.path().join("vaults.json");
+            let store = VaultRegistryStore::new(&path);
+
+            let error = store
+                .add(
+                    0,
+                    NewVaultDefinition {
+                        name: "Malformed remote".to_string(),
+                        enabled: true,
+                        source: VaultSource::ManagedGit {
+                            repository_url: repository_url.to_string(),
+                            branch: None,
+                            vault_subdirectory: None,
+                            mode: VaultGitMode::PullOnly,
+                        },
+                        exclude_patterns: Vec::new(),
+                        https_credentials: None,
+                    },
+                )
+                .expect_err("malformed HTTPS URL accepted");
+
+            assert!(matches!(
+                error,
+                VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(_))
+            ));
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn identity_changes_require_a_disabled_definition_and_explicit_confirmation() {
+        let directory = tempdir().expect("temporary directory");
+        let original_path = directory.path().join("original");
+        let replacement_path = directory.path().join("replacement");
+        std::fs::create_dir(&original_path).expect("create original Vault");
+        std::fs::create_dir(&replacement_path).expect("create replacement Vault");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(0, local_definition("Notes", original_path, true))
+            .expect("add Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+
+        let enabled_error = store
+            .edit(
+                1,
+                vault_id,
+                local_edit("Notes", replacement_path.clone(), true),
+            )
+            .expect_err("enabled identity change accepted");
+        assert_eq!(
+            enabled_error,
+            VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::IdentityChangeRequiresDisabled
+            )
+        );
+
+        let disabled = store.disable(1, vault_id).expect("disable Vault");
+        assert_eq!(disabled.revision(), 2);
+        assert!(!disabled.definitions().next().expect("definition").enabled());
+
+        let confirmation_error = store
+            .edit(
+                2,
+                vault_id,
+                local_edit("Notes", replacement_path.clone(), false),
+            )
+            .expect_err("unconfirmed identity change accepted");
+        assert_eq!(
+            confirmation_error,
+            VaultRegistryError::InvalidDefinition(
+                VaultDefinitionError::IdentityChangeRequiresConfirmation
+            )
+        );
+
+        let edited = store
+            .edit(
+                2,
+                vault_id,
+                local_edit("Notes", replacement_path.clone(), true),
+            )
+            .expect("confirmed disabled identity change");
+        let definition = edited.definitions().next().expect("definition");
+        assert_eq!(definition.vault_id(), vault_id);
+        assert!(!definition.enabled());
+        assert_eq!(
+            definition.source(),
+            &VaultSource::Local {
+                path: replacement_path
+                    .canonicalize()
+                    .expect("canonical replacement")
+            }
+        );
+    }
+
+    #[test]
+    fn disconnect_removes_only_the_definition_and_preserves_vault_files() {
+        let directory = tempdir().expect("temporary directory");
+        let vault_path = directory.path().join("notes");
+        std::fs::create_dir(&vault_path).expect("create Vault");
+        let note_path = vault_path.join("kept.md");
+        std::fs::write(&note_path, "# Kept\n").expect("write note");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(0, local_definition("Notes", vault_path.clone(), true))
+            .expect("add Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+
+        let disconnected = store.disconnect(1, vault_id).expect("disconnect Vault");
+
+        assert_eq!(disconnected.revision(), 2);
+        assert_eq!(disconnected.definitions().count(), 0);
+        assert_eq!(
+            std::fs::read_to_string(note_path).expect("preserved note"),
+            "# Kept\n"
+        );
+        assert!(vault_path.exists());
+    }
+
+    #[test]
+    fn structurally_invalid_persisted_definitions_enter_recovery_without_overwrite() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = br#"{
+          "schema_version": 1,
+          "revision": 8,
+          "vaults": {
+            "018f47a0-7768-4d0c-8da3-5aa28d1c31c7": {
+              "name": "Personal",
+              "enabled": true,
+              "source": {"type": "local", "path": "/srv/first"},
+              "exclude_patterns": []
+            },
+            "b676d7c4-ca1c-4c92-813f-b47b14a5192d": {
+              "name": "personal",
+              "enabled": false,
+              "source": {"type": "local", "path": "/srv/second"},
+              "exclude_patterns": []
+            }
+          }
+        }"#;
+        std::fs::write(&path, original).expect("write invalid registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("invalid definitions were treated as ready");
+        };
+
+        assert_eq!(recovery.kind(), VaultRegistryRecoveryKind::Corrupt);
+        assert_eq!(std::fs::read(&path).expect("preserved registry"), original);
+        assert_eq!(
+            store
+                .disconnect(
+                    8,
+                    VaultId::from_str("018f47a0-7768-4d0c-8da3-5aa28d1c31c7").expect("known ID")
+                )
+                .expect_err("invalid registry overwritten"),
+            VaultRegistryError::RecoveryRequired
+        );
+    }
+
+    #[test]
+    fn credential_bearing_repository_urls_enter_redacted_recovery() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = br#"{
+          "schema_version": 1,
+          "revision": 4,
+          "vaults": {
+            "018f47a0-7768-4d0c-8da3-5aa28d1c31c7": {
+              "name": "Remote",
+              "enabled": true,
+              "source": {
+                "type": "managed_git",
+                "repository_url": "https://git-user:url-secret@example.test/notes.git",
+                "branch": "main",
+                "vault_subdirectory": null,
+                "mode": "pull_only"
+              },
+              "exclude_patterns": []
+            }
+          }
+        }"#;
+        std::fs::write(&path, original).expect("write unsafe registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("credential-bearing URL was treated as ready");
+        };
+
+        assert_eq!(recovery.kind(), VaultRegistryRecoveryKind::Corrupt);
+        assert!(!recovery.message().contains("url-secret"));
+        assert_eq!(std::fs::read(&path).expect("preserved registry"), original);
+    }
+
+    #[test]
+    fn malformed_persisted_secret_fields_do_not_echo_values_in_recovery() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = br#"{
+          "schema_version": 1,
+          "revision": 4,
+          "vaults": {
+            "018f47a0-7768-4d0c-8da3-5aa28d1c31c7": {
+              "name": "Remote",
+              "enabled": true,
+              "source": {
+                "type": "managed_git",
+                "repository_url": "https://example.test/notes.git",
+                "branch": "main",
+                "vault_subdirectory": null,
+                "mode": "value-that-must-not-leak"
+              },
+              "exclude_patterns": []
+            }
+          }
+        }"#;
+        std::fs::write(&path, original).expect("write malformed registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("malformed definition was treated as ready");
+        };
+
+        assert_eq!(recovery.kind(), VaultRegistryRecoveryKind::Corrupt);
+        assert!(!recovery.message().contains("value-that-must-not-leak"));
+        assert_eq!(std::fs::read(&path).expect("preserved registry"), original);
+    }
+
+    #[test]
+    fn enabled_definitions_allow_name_mode_and_credential_changes() {
+        let directory = tempdir().expect("temporary directory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let source = VaultSource::ManagedGit {
+            repository_url: "https://example.test/notes.git".to_string(),
+            branch: Some("main".to_string()),
+            vault_subdirectory: None,
+            mode: VaultGitMode::PullOnly,
+        };
+        let added = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Remote".to_string(),
+                    enabled: true,
+                    source: source.clone(),
+                    exclude_patterns: Vec::new(),
+                    https_credentials: Some(HttpsCredentials {
+                        username: "old-user".to_string(),
+                        token: "old-token".to_string(),
+                    }),
+                },
+            )
+            .expect("add remote Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+
+        let edited = store
+            .edit(
+                1,
+                vault_id,
+                VaultDefinitionEdit {
+                    name: "Renamed remote".to_string(),
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://example.test/notes.git".to_string(),
+                        branch: Some("main".to_string()),
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::TwoWay,
+                    },
+                    exclude_patterns: vec!["drafts/**".to_string()],
+                    https_credentials: HttpsCredentialUpdate::Replace(HttpsCredentials {
+                        username: "new-user".to_string(),
+                        token: "new-token".to_string(),
+                    }),
+                    confirm_identity_change: false,
+                },
+            )
+            .expect("edit non-identity fields");
+
+        let definition = edited.definitions().next().expect("definition");
+        assert!(definition.enabled());
+        assert_eq!(definition.name(), "Renamed remote");
+        assert!(definition.credential_configured());
+        assert!(matches!(
+            definition.source(),
+            VaultSource::ManagedGit {
+                mode: VaultGitMode::TwoWay,
+                ..
+            }
+        ));
+        let encoded = std::fs::read_to_string(store.path()).expect("registry");
+        assert!(!encoded.contains("old-token"));
+        assert!(encoded.contains("new-token"));
+
+        let removed = store
+            .edit(
+                2,
+                vault_id,
+                VaultDefinitionEdit {
+                    name: "Renamed remote".to_string(),
+                    source: definition.source().clone(),
+                    exclude_patterns: vec!["drafts/**".to_string()],
+                    https_credentials: HttpsCredentialUpdate::Remove,
+                    confirm_identity_change: false,
+                },
+            )
+            .expect("remove credential");
+        assert!(
+            !removed
+                .definitions()
+                .next()
+                .expect("definition")
+                .credential_configured()
+        );
+        assert!(
+            !std::fs::read_to_string(store.path())
+                .expect("registry")
+                .contains("new-token")
+        );
+    }
+
+    #[test]
+    fn invalid_sources_reject_the_transaction_without_leaking_credentials() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+        let error = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Unsafe remote".to_string(),
+                    enabled: true,
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://git-user:embedded-secret@example.test/notes.git"
+                            .to_string(),
+                        branch: None,
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect_err("credential-bearing URL accepted");
+        assert!(!error.to_string().contains("embedded-secret"));
+        assert!(!path.exists());
+
+        let error = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Escaping remote".to_string(),
+                    enabled: true,
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://example.test/notes.git".to_string(),
+                        branch: None,
+                        vault_subdirectory: Some(PathBuf::from("../outside")),
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect_err("escaping subdirectory accepted");
+        assert!(matches!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(_))
+        ));
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn readable_non_writable_local_vaults_remain_valid() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempdir().expect("temporary directory");
+        let vault_path = directory.path().join("read-only-notes");
+        std::fs::create_dir(&vault_path).expect("create Vault");
+        std::fs::set_permissions(&vault_path, std::fs::Permissions::from_mode(0o555))
+            .expect("make Vault non-writable");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+
+        let committed = store
+            .add(0, local_definition("Read only", vault_path, true))
+            .expect("connect readable non-writable Vault");
+
+        assert!(
+            committed
+                .definitions()
+                .next()
+                .expect("definition")
+                .enabled()
+        );
+    }
+
+    #[test]
+    fn enable_preserves_identity_and_increments_the_registry_revision() {
+        let directory = tempdir().expect("temporary directory");
+        let vault_path = directory.path().join("notes");
+        std::fs::create_dir(&vault_path).expect("create Vault");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(0, local_definition("Paused", vault_path, false))
+            .expect("add disabled Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+
+        let enabled = store.enable(1, vault_id).expect("enable Vault");
+
+        let definition = enabled.definitions().next().expect("definition");
+        assert_eq!(enabled.revision(), 2);
+        assert_eq!(definition.vault_id(), vault_id);
+        assert!(definition.enabled());
+    }
+
+    #[test]
+    fn enable_revalidates_a_local_source_before_saving() {
+        let directory = tempdir().expect("temporary directory");
+        let vault_path = directory.path().join("notes");
+        std::fs::create_dir(&vault_path).expect("create Vault");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(0, local_definition("Paused", vault_path.clone(), false))
+            .expect("add disabled Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+        std::fs::remove_dir(&vault_path).expect("make source unavailable");
+
+        let error = store
+            .enable(1, vault_id)
+            .expect_err("unreadable source was enabled");
+
+        assert!(matches!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::InvalidSource(_))
+        ));
+        let VaultRegistryState::Ready(snapshot) = store.load().expect("reload registry") else {
+            panic!("valid registry entered recovery");
+        };
+        assert_eq!(snapshot.revision(), 1);
+        assert!(!snapshot.definition(vault_id).expect("definition").enabled());
+    }
+
+    #[test]
+    fn confirmed_repository_change_does_not_carry_an_old_credential() {
+        let directory = tempdir().expect("temporary directory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Paused remote".to_string(),
+                    enabled: false,
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://old.example.test/notes.git".to_string(),
+                        branch: Some("main".to_string()),
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: Some(HttpsCredentials {
+                        username: "old-user".to_string(),
+                        token: "old-repository-token".to_string(),
+                    }),
+                },
+            )
+            .expect("add managed Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+
+        let edited = store
+            .edit(
+                1,
+                vault_id,
+                VaultDefinitionEdit {
+                    name: "Paused remote".to_string(),
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://new.example.test/notes.git".to_string(),
+                        branch: Some("main".to_string()),
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: HttpsCredentialUpdate::Keep,
+                    confirm_identity_change: true,
+                },
+            )
+            .expect("confirm repository change");
+
+        assert!(
+            !edited
+                .definitions()
+                .next()
+                .expect("definition")
+                .credential_configured()
+        );
+        assert!(
+            !std::fs::read_to_string(store.path())
+                .expect("registry")
+                .contains("old-repository-token")
+        );
+    }
+
+    #[test]
+    fn managed_checkout_paths_participate_in_overlap_validation() {
+        let directory = tempdir().expect("temporary directory");
+        let store = VaultRegistryStore::new(directory.path().join("vaults.json"));
+        let added = store
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Managed".to_string(),
+                    enabled: false,
+                    source: VaultSource::ManagedGit {
+                        repository_url: "https://example.test/notes.git".to_string(),
+                        branch: None,
+                        vault_subdirectory: None,
+                        mode: VaultGitMode::PullOnly,
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                },
+            )
+            .expect("add managed Vault");
+        let vault_id = added.definitions().next().expect("definition").vault_id();
+        let managed_checkout = directory
+            .path()
+            .join("vaults")
+            .join(vault_id.to_string())
+            .join("repository");
+        std::fs::create_dir_all(&managed_checkout).expect("create managed checkout location");
+
+        let error = store
+            .add(
+                1,
+                local_definition("Overlapping local", managed_checkout, true),
+            )
+            .expect_err("managed checkout overlap accepted");
+
+        assert_eq!(
+            error,
+            VaultRegistryError::InvalidDefinition(VaultDefinitionError::PathOverlap)
+        );
+    }
+
+    fn local_definition(name: &str, path: PathBuf, enabled: bool) -> NewVaultDefinition {
+        NewVaultDefinition {
+            name: name.to_string(),
+            enabled,
+            source: VaultSource::Local { path },
+            exclude_patterns: Vec::new(),
+            https_credentials: None,
+        }
+    }
+
+    fn local_edit(name: &str, path: PathBuf, confirm_identity_change: bool) -> VaultDefinitionEdit {
+        VaultDefinitionEdit {
+            name: name.to_string(),
+            source: VaultSource::Local { path },
+            exclude_patterns: Vec::new(),
+            https_credentials: HttpsCredentialUpdate::Keep,
+            confirm_identity_change,
+        }
+    }
+
+    #[test]
     fn committed_registry_round_trips_ids_and_monotonic_revision() {
         let directory = tempdir().expect("temporary directory");
         let path = directory.path().join("state").join("vaults.json");
@@ -606,23 +2401,22 @@ mod tests {
         let id = VaultId::from_str("018f47a0-7768-4d0c-8da3-5aa28d1c31c7").expect("known Vault ID");
 
         let committed = store
-            .commit(0, [(id, VaultRecord::empty())])
+            .commit(0, [(id, VaultRecord::empty(id))])
             .expect("commit registry");
 
         assert_eq!(committed.revision(), 1);
         assert_eq!(committed.vault_ids().collect::<Vec<_>>(), vec![id]);
         let encoded = std::fs::read_to_string(&path).expect("read registry");
+        let encoded: serde_json::Value = serde_json::from_str(&encoded).expect("registry JSON");
+        assert_eq!(encoded["schema_version"], 1);
+        assert_eq!(encoded["revision"], 1);
         assert_eq!(
-            encoded,
-            concat!(
-                "{\n",
-                "  \"schema_version\": 1,\n",
-                "  \"revision\": 1,\n",
-                "  \"vaults\": {\n",
-                "    \"018f47a0-7768-4d0c-8da3-5aa28d1c31c7\": {}\n",
-                "  }\n",
-                "}\n"
-            )
+            encoded["vaults"]["018f47a0-7768-4d0c-8da3-5aa28d1c31c7"]["name"],
+            "Test Vault 018f47a0-7768-4d0c-8da3-5aa28d1c31c7"
+        );
+        assert_eq!(
+            encoded["vaults"]["018f47a0-7768-4d0c-8da3-5aa28d1c31c7"]["source"]["type"],
+            "local"
         );
 
         let VaultRegistryState::Ready(restarted) = store.load().expect("reload registry") else {
@@ -760,7 +2554,7 @@ mod tests {
             let id = VaultId::from_str(value).expect("known Vault ID");
             std::thread::spawn(move || {
                 barrier.wait();
-                store.commit(1, [(id, VaultRecord::empty())])
+                store.commit(1, [(id, VaultRecord::empty(id))])
             })
         });
 
@@ -800,10 +2594,8 @@ mod tests {
         first.commit(0, []).expect("initial commit");
         let records = (0..1024)
             .map(|_| {
-                (
-                    VaultId::generate().expect("generate Vault ID"),
-                    VaultRecord::empty(),
-                )
+                let id = VaultId::generate().expect("generate Vault ID");
+                (id, VaultRecord::empty(id))
             })
             .collect::<Vec<_>>();
         let barrier = Arc::new(Barrier::new(3));
@@ -844,10 +2636,8 @@ mod tests {
         let store = Arc::new(VaultRegistryStore::new(&path));
         let vaults = (0..128)
             .map(|_| {
-                (
-                    VaultId::generate().expect("generate Vault ID"),
-                    VaultRecord::empty(),
-                )
+                let id = VaultId::generate().expect("generate Vault ID");
+                (id, VaultRecord::empty(id))
             })
             .collect::<Vec<_>>();
         store.commit(0, vaults.clone()).expect("initial registry");

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -1,0 +1,898 @@
+//! Authoritative, revisioned persistence for the collection of Vault identities.
+//!
+//! Definition fields and lifecycle operations intentionally arrive in issue #86.
+//! This boundary owns only durable identity, revision, atomicity, permissions,
+//! and recovery behavior.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The on-disk `vaults.json` format version.
+pub const REGISTRY_SCHEMA_VERSION: u32 = 1;
+/// The authoritative Vault collection registry in persistent instance state.
+pub const DEFAULT_VAULT_REGISTRY_PATH: &str = "/data/state/vaults.json";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VaultId([u8; 16]);
+
+impl VaultId {
+    pub fn generate() -> Result<Self, VaultIdError> {
+        let mut bytes = [0_u8; 16];
+        getrandom::fill(&mut bytes).map_err(|error| VaultIdError::Randomness(error.to_string()))?;
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        Ok(Self(bytes))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VaultIdError {
+    InvalidFormat,
+    Randomness(String),
+}
+
+impl fmt::Display for VaultIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFormat => formatter.write_str("Vault ID must be a canonical UUID v4"),
+            Self::Randomness(error) => write!(formatter, "could not generate Vault ID: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for VaultIdError {}
+
+impl fmt::Display for VaultId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes = self.0;
+        write!(
+            formatter,
+            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            bytes[0],
+            bytes[1],
+            bytes[2],
+            bytes[3],
+            bytes[4],
+            bytes[5],
+            bytes[6],
+            bytes[7],
+            bytes[8],
+            bytes[9],
+            bytes[10],
+            bytes[11],
+            bytes[12],
+            bytes[13],
+            bytes[14],
+            bytes[15]
+        )
+    }
+}
+
+impl FromStr for VaultId {
+    type Err = VaultIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() != 36
+            || !value.is_ascii()
+            || [8, 13, 18, 23]
+                .into_iter()
+                .any(|index| value.as_bytes()[index] != b'-')
+        {
+            return Err(VaultIdError::InvalidFormat);
+        }
+
+        let mut bytes = [0_u8; 16];
+        let mut output = 0;
+        let encoded = value.as_bytes();
+        let mut input = 0;
+        while input < encoded.len() {
+            if matches!(input, 8 | 13 | 18 | 23) {
+                input += 1;
+                continue;
+            }
+            let high = decode_hex(encoded[input]).ok_or(VaultIdError::InvalidFormat)?;
+            let low = decode_hex(encoded[input + 1]).ok_or(VaultIdError::InvalidFormat)?;
+            bytes[output] = (high << 4) | low;
+            input += 2;
+            output += 1;
+        }
+
+        if bytes[6] >> 4 != 4 || bytes[8] >> 6 != 2 {
+            return Err(VaultIdError::InvalidFormat);
+        }
+        Ok(Self(bytes))
+    }
+}
+
+impl Serialize for VaultId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for VaultId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(D::Error::custom)
+    }
+}
+
+fn decode_hex(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(deny_unknown_fields)]
+/// The persisted slot for one Vault ID. Issue #86 adds the accepted definition
+/// fields without changing the identity or registry persistence contract.
+pub struct VaultRecord {}
+
+impl VaultRecord {
+    #[cfg(test)]
+    fn empty() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VaultRegistrySnapshot {
+    schema_version: u32,
+    revision: u64,
+    vaults: BTreeMap<VaultId, VaultRecord>,
+}
+
+impl VaultRegistrySnapshot {
+    fn empty() -> Self {
+        Self {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            revision: 0,
+            vaults: BTreeMap::new(),
+        }
+    }
+
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn vault_ids(&self) -> impl ExactSizeIterator<Item = VaultId> + '_ {
+        self.vaults.keys().copied()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VaultRegistryRecoveryKind {
+    Corrupt,
+    UnsupportedSchema { found: u64, supported: u32 },
+    FutureSchema { found: u64, supported: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VaultRegistryRecovery {
+    kind: VaultRegistryRecoveryKind,
+    message: String,
+}
+
+impl VaultRegistryRecovery {
+    pub fn kind(&self) -> VaultRegistryRecoveryKind {
+        self.kind
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VaultRegistryState {
+    Ready(VaultRegistrySnapshot),
+    Recovery(VaultRegistryRecovery),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VaultRegistryError {
+    RevisionConflict { expected: u64, actual: u64 },
+    RecoveryRequired,
+    RevisionExhausted,
+    LockPoisoned,
+    Storage(String),
+}
+
+impl fmt::Display for VaultRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RevisionConflict { expected, actual } => write!(
+                formatter,
+                "Vault registry revision conflict: expected {expected}, current {actual}"
+            ),
+            Self::RecoveryRequired => {
+                formatter.write_str("Vault registry requires recovery and will not be overwritten")
+            }
+            Self::RevisionExhausted => formatter.write_str("Vault registry revision is exhausted"),
+            Self::LockPoisoned => formatter.write_str("Vault registry write lock was poisoned"),
+            Self::Storage(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for VaultRegistryError {}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredVaultRegistry {
+    schema_version: u32,
+    revision: u64,
+    vaults: BTreeMap<VaultId, VaultRecord>,
+}
+
+#[derive(Clone)]
+pub struct VaultRegistryStore {
+    path: PathBuf,
+    write_lock: Arc<Mutex<()>>,
+}
+
+impl VaultRegistryStore {
+    pub fn at_default_path() -> Self {
+        Self::new(DEFAULT_VAULT_REGISTRY_PATH)
+    }
+
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        Self {
+            write_lock: write_lock_for(&path),
+            path,
+        }
+    }
+
+    pub fn load(&self) -> Result<VaultRegistryState, VaultRegistryError> {
+        self.load_unlocked()
+    }
+
+    fn load_unlocked(&self) -> Result<VaultRegistryState, VaultRegistryError> {
+        if !self.path.exists() {
+            return Ok(VaultRegistryState::Ready(VaultRegistrySnapshot::empty()));
+        }
+
+        let encoded = fs::read(&self.path).map_err(|error| {
+            VaultRegistryError::Storage(format!(
+                "could not read Vault registry '{}': {error}",
+                self.path.display()
+            ))
+        })?;
+        let value: serde_json::Value = match serde_json::from_slice(&encoded) {
+            Ok(value) => value,
+            Err(error) => {
+                return Ok(VaultRegistryState::Recovery(
+                    self.corrupt(error.to_string()),
+                ));
+            }
+        };
+        let Some(schema_version) = value.get("schema_version").and_then(|value| value.as_u64())
+        else {
+            return Ok(VaultRegistryState::Recovery(
+                self.corrupt("missing unsigned schema_version"),
+            ));
+        };
+        if schema_version > u64::from(REGISTRY_SCHEMA_VERSION) {
+            return Ok(VaultRegistryState::Recovery(VaultRegistryRecovery {
+                kind: VaultRegistryRecoveryKind::FutureSchema {
+                    found: schema_version,
+                    supported: REGISTRY_SCHEMA_VERSION,
+                },
+                message: format!(
+                    "Vault registry '{}' uses newer schema {schema_version}, but this Hatchdoor supports schema {}. Upgrade Hatchdoor or restore a compatible backup; Hatchdoor will not overwrite it.",
+                    self.path.display(),
+                    REGISTRY_SCHEMA_VERSION
+                ),
+            }));
+        }
+        if schema_version < u64::from(REGISTRY_SCHEMA_VERSION) {
+            return Ok(VaultRegistryState::Recovery(VaultRegistryRecovery {
+                kind: VaultRegistryRecoveryKind::UnsupportedSchema {
+                    found: schema_version,
+                    supported: REGISTRY_SCHEMA_VERSION,
+                },
+                message: format!(
+                    "Vault registry '{}' uses unsupported schema {schema_version}, but this Hatchdoor supports schema {}. Restore a compatible backup; Hatchdoor will not overwrite it.",
+                    self.path.display(),
+                    REGISTRY_SCHEMA_VERSION
+                ),
+            }));
+        }
+        let stored: StoredVaultRegistry = match serde_json::from_value(value) {
+            Ok(stored) => stored,
+            Err(error) => {
+                return Ok(VaultRegistryState::Recovery(
+                    self.corrupt(error.to_string()),
+                ));
+            }
+        };
+        Ok(VaultRegistryState::Ready(VaultRegistrySnapshot {
+            schema_version: stored.schema_version,
+            revision: stored.revision,
+            vaults: stored.vaults,
+        }))
+    }
+
+    pub fn commit(
+        &self,
+        expected_revision: u64,
+        vaults: impl IntoIterator<Item = (VaultId, VaultRecord)>,
+    ) -> Result<VaultRegistrySnapshot, VaultRegistryError> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_| VaultRegistryError::LockPoisoned)?;
+        let VaultRegistryState::Ready(current) = self.load_unlocked()? else {
+            return Err(VaultRegistryError::RecoveryRequired);
+        };
+        if current.revision != expected_revision {
+            return Err(VaultRegistryError::RevisionConflict {
+                expected: expected_revision,
+                actual: current.revision,
+            });
+        }
+        let revision = current
+            .revision
+            .checked_add(1)
+            .ok_or(VaultRegistryError::RevisionExhausted)?;
+        let next = VaultRegistrySnapshot {
+            schema_version: REGISTRY_SCHEMA_VERSION,
+            revision,
+            vaults: vaults.into_iter().collect(),
+        };
+        self.persist(&next)?;
+        Ok(next)
+    }
+
+    fn persist(&self, snapshot: &VaultRegistrySnapshot) -> Result<(), VaultRegistryError> {
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent).map_err(|error| {
+            VaultRegistryError::Storage(format!(
+                "could not create Vault registry directory '{}': {error}",
+                parent.display()
+            ))
+        })?;
+        let encoded = serde_json::to_vec_pretty(&StoredVaultRegistry {
+            schema_version: snapshot.schema_version,
+            revision: snapshot.revision,
+            vaults: snapshot.vaults.clone(),
+        })
+        .map_err(|error| {
+            VaultRegistryError::Storage(format!("could not encode Vault registry: {error}"))
+        })?;
+        let temporary = temporary_path(&self.path)?;
+        let result = (|| {
+            let mut file = create_private_file(&temporary)?;
+            file.write_all(&encoded).map_err(|error| {
+                VaultRegistryError::Storage(format!("could not write Vault registry: {error}"))
+            })?;
+            file.write_all(b"\n").map_err(|error| {
+                VaultRegistryError::Storage(format!("could not finalize Vault registry: {error}"))
+            })?;
+            file.sync_all().map_err(|error| {
+                VaultRegistryError::Storage(format!("could not sync Vault registry: {error}"))
+            })?;
+            fs::rename(&temporary, &self.path).map_err(|error| {
+                VaultRegistryError::Storage(format!(
+                    "could not replace Vault registry '{}': {error}",
+                    self.path.display()
+                ))
+            })?;
+            sync_directory(parent)
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn corrupt(&self, detail: impl fmt::Display) -> VaultRegistryRecovery {
+        VaultRegistryRecovery {
+            kind: VaultRegistryRecoveryKind::Corrupt,
+            message: format!(
+                "Vault registry '{}' is corrupt ({detail}). Restore a known-good backup or move the file aside explicitly; Hatchdoor will not overwrite it.",
+                self.path.display()
+            ),
+        }
+    }
+}
+
+fn write_lock_for(path: &Path) -> Arc<Mutex<()>> {
+    static WRITE_LOCKS: OnceLock<Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+
+    let path = normalized_absolute_path(path);
+    let mut locks = WRITE_LOCKS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    locks
+        .entry(path)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn normalized_absolute_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|directory| directory.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn temporary_path(path: &Path) -> Result<PathBuf, VaultRegistryError> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            VaultRegistryError::Storage(format!(
+                "Vault registry path '{}' has no file name",
+                path.display()
+            ))
+        })?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    for nonce in 0..100_u32 {
+        let candidate = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), nonce));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(VaultRegistryError::Storage(format!(
+        "could not create a unique temporary Vault registry beside '{}'",
+        path.display()
+    )))
+}
+
+#[cfg(unix)]
+fn create_private_file(path: &Path) -> Result<std::fs::File, VaultRegistryError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|error| {
+            VaultRegistryError::Storage(format!(
+                "could not create temporary Vault registry '{}': {error}",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+fn create_private_file(path: &Path) -> Result<std::fs::File, VaultRegistryError> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            VaultRegistryError::Storage(format!(
+                "could not create temporary Vault registry '{}': {error}",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<(), VaultRegistryError> {
+    let directory = std::fs::File::open(path).map_err(|error| {
+        VaultRegistryError::Storage(format!(
+            "could not open Vault registry directory '{}': {error}",
+            path.display()
+        ))
+    })?;
+    directory.sync_all().map_err(|error| {
+        VaultRegistryError::Storage(format!(
+            "could not sync Vault registry directory '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<(), VaultRegistryError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    use tempfile::tempdir;
+
+    use super::{
+        DEFAULT_VAULT_REGISTRY_PATH, REGISTRY_SCHEMA_VERSION, VaultId, VaultRecord,
+        VaultRegistryError, VaultRegistryRecoveryKind, VaultRegistryState, VaultRegistryStore,
+    };
+
+    #[test]
+    fn absent_registry_is_zero_vault_without_creating_a_file() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+
+        let state = store.load().expect("load absent registry");
+        let VaultRegistryState::Ready(snapshot) = state else {
+            panic!("absent registry entered recovery");
+        };
+
+        assert_eq!(snapshot.schema_version(), REGISTRY_SCHEMA_VERSION);
+        assert_eq!(snapshot.revision(), 0);
+        assert_eq!(snapshot.vault_ids().count(), 0);
+        assert!(!path.exists(), "zero-Vault load created the registry");
+    }
+
+    #[test]
+    fn default_store_uses_the_authoritative_instance_state_path() {
+        assert_eq!(
+            VaultRegistryStore::at_default_path().path(),
+            std::path::Path::new(DEFAULT_VAULT_REGISTRY_PATH)
+        );
+        assert_eq!(DEFAULT_VAULT_REGISTRY_PATH, "/data/state/vaults.json");
+    }
+
+    #[test]
+    fn generated_vault_ids_are_canonical_random_uuids() {
+        let id = VaultId::generate().expect("generate Vault ID");
+        let encoded = id.to_string();
+
+        assert_eq!(encoded.len(), 36);
+        assert_eq!(&encoded[8..9], "-");
+        assert_eq!(&encoded[13..14], "-");
+        assert_eq!(&encoded[18..19], "-");
+        assert_eq!(&encoded[23..24], "-");
+        assert_eq!(&encoded[14..15], "4", "UUID version");
+        assert!(matches!(&encoded[19..20], "8" | "9" | "a" | "b"));
+        assert_eq!(VaultId::from_str(&encoded).expect("parse generated ID"), id);
+    }
+
+    #[test]
+    fn vault_ids_reject_noncanonical_or_invalid_values() {
+        let uppercase = "018F47A0-7768-4D0C-8DA3-5AA28D1C31C7";
+        let wrong_version = "018f47a0-7768-7d0c-8da3-5aa28d1c31c7";
+
+        assert!(VaultId::from_str(uppercase).is_err());
+        assert!(VaultId::from_str(wrong_version).is_err());
+        assert!(VaultId::from_str("not-a-uuid").is_err());
+    }
+
+    #[test]
+    fn committed_registry_round_trips_ids_and_monotonic_revision() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("state").join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+        let id = VaultId::from_str("018f47a0-7768-4d0c-8da3-5aa28d1c31c7").expect("known Vault ID");
+
+        let committed = store
+            .commit(0, [(id, VaultRecord::empty())])
+            .expect("commit registry");
+
+        assert_eq!(committed.revision(), 1);
+        assert_eq!(committed.vault_ids().collect::<Vec<_>>(), vec![id]);
+        let encoded = std::fs::read_to_string(&path).expect("read registry");
+        assert_eq!(
+            encoded,
+            concat!(
+                "{\n",
+                "  \"schema_version\": 1,\n",
+                "  \"revision\": 1,\n",
+                "  \"vaults\": {\n",
+                "    \"018f47a0-7768-4d0c-8da3-5aa28d1c31c7\": {}\n",
+                "  }\n",
+                "}\n"
+            )
+        );
+
+        let VaultRegistryState::Ready(restarted) = store.load().expect("reload registry") else {
+            panic!("valid registry entered recovery");
+        };
+        assert_eq!(restarted, committed);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn committed_registry_is_private_to_its_owner() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+
+        store.commit(0, []).expect("commit empty registry");
+
+        let mode = std::fs::metadata(path)
+            .expect("registry metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn stale_revision_is_rejected_without_changing_the_registry() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let store = VaultRegistryStore::new(&path);
+        let initial = store.commit(0, []).expect("initial commit");
+        let before = std::fs::read(&path).expect("registry before conflict");
+
+        let error = store.commit(0, []).expect_err("stale commit accepted");
+
+        assert_eq!(
+            error,
+            VaultRegistryError::RevisionConflict {
+                expected: 0,
+                actual: initial.revision(),
+            }
+        );
+        assert_eq!(
+            std::fs::read(path).expect("registry after conflict"),
+            before
+        );
+    }
+
+    #[test]
+    fn corrupt_registry_enters_recovery_and_is_never_overwritten() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = b"{ definitely not valid json";
+        std::fs::write(&path, original).expect("write corrupt registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("corrupt registry was treated as ready");
+        };
+
+        assert_eq!(recovery.kind(), VaultRegistryRecoveryKind::Corrupt);
+        assert!(recovery.message().contains("corrupt"));
+        assert!(recovery.message().contains("will not overwrite"));
+        assert_eq!(
+            store.commit(0, []).expect_err("corrupt file overwritten"),
+            VaultRegistryError::RecoveryRequired
+        );
+        assert_eq!(std::fs::read(path).expect("retained registry"), original);
+    }
+
+    #[test]
+    fn future_schema_enters_recovery_with_upgrade_guidance() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = br#"{"schema_version":2,"revision":41,"vaults":{}}"#;
+        std::fs::write(&path, original).expect("write future registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("future registry was treated as ready");
+        };
+
+        assert_eq!(
+            recovery.kind(),
+            VaultRegistryRecoveryKind::FutureSchema {
+                found: 2,
+                supported: REGISTRY_SCHEMA_VERSION,
+            }
+        );
+        assert!(recovery.message().contains("Upgrade Hatchdoor"));
+        assert!(recovery.message().contains("will not overwrite"));
+        assert_eq!(std::fs::read(path).expect("retained registry"), original);
+    }
+
+    #[test]
+    fn current_schema_with_unknown_record_fields_is_recoverable_corruption() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let original = br#"{
+            "schema_version": 1,
+            "revision": 3,
+            "vaults": {
+                "018f47a0-7768-4d0c-8da3-5aa28d1c31c7": {"name": "not-yet-supported"}
+            }
+        }"#;
+        std::fs::write(&path, original).expect("write incompatible registry");
+        let store = VaultRegistryStore::new(&path);
+
+        let VaultRegistryState::Recovery(recovery) = store.load().expect("load registry") else {
+            panic!("unsupported record shape was accepted");
+        };
+
+        assert_eq!(recovery.kind(), VaultRegistryRecoveryKind::Corrupt);
+        assert_eq!(std::fs::read(path).expect("retained registry"), original);
+    }
+
+    #[test]
+    fn concurrent_commits_serialize_and_reject_one_stale_writer() {
+        let directory = tempdir().expect("temporary directory");
+        let store = Arc::new(VaultRegistryStore::new(
+            directory.path().join("vaults.json"),
+        ));
+        store.commit(0, []).expect("initial commit");
+        let barrier = Arc::new(Barrier::new(3));
+
+        let writers = [
+            "018f47a0-7768-4d0c-8da3-5aa28d1c31c7",
+            "b676d7c4-ca1c-4c92-813f-b47b14a5192d",
+        ]
+        .map(|value| {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            let id = VaultId::from_str(value).expect("known Vault ID");
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.commit(1, [(id, VaultRecord::empty())])
+            })
+        });
+
+        barrier.wait();
+        let results = writers.map(|writer| writer.join().expect("writer thread"));
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| {
+                    matches!(
+                        result,
+                        Err(VaultRegistryError::RevisionConflict {
+                            expected: 1,
+                            actual: 2
+                        })
+                    )
+                })
+                .count(),
+            1
+        );
+
+        let VaultRegistryState::Ready(snapshot) = store.load().expect("load committed registry")
+        else {
+            panic!("committed registry entered recovery");
+        };
+        assert_eq!(snapshot.revision(), 2);
+        assert_eq!(snapshot.vault_ids().count(), 1);
+    }
+
+    #[test]
+    fn independently_constructed_stores_serialize_writes_to_the_same_path() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let first = Arc::new(VaultRegistryStore::new(&path));
+        let second = Arc::new(VaultRegistryStore::new(&path));
+        first.commit(0, []).expect("initial commit");
+        let records = (0..1024)
+            .map(|_| {
+                (
+                    VaultId::generate().expect("generate Vault ID"),
+                    VaultRecord::empty(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let barrier = Arc::new(Barrier::new(3));
+
+        let writers = [first, second].map(|store| {
+            let barrier = barrier.clone();
+            let records = records.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.commit(1, records)
+            })
+        });
+
+        barrier.wait();
+        let results = writers.map(|writer| writer.join().expect("writer thread"));
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| {
+                    matches!(
+                        result,
+                        Err(VaultRegistryError::RevisionConflict {
+                            expected: 1,
+                            actual: 2
+                        })
+                    )
+                })
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn replacement_never_exposes_partial_json_to_readers() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join("vaults.json");
+        let store = Arc::new(VaultRegistryStore::new(&path));
+        let vaults = (0..128)
+            .map(|_| {
+                (
+                    VaultId::generate().expect("generate Vault ID"),
+                    VaultRecord::empty(),
+                )
+            })
+            .collect::<Vec<_>>();
+        store.commit(0, vaults.clone()).expect("initial registry");
+        let started = Arc::new(Barrier::new(2));
+        let finished = Arc::new(AtomicBool::new(false));
+
+        let writer = {
+            let store = store.clone();
+            let started = started.clone();
+            let finished = finished.clone();
+            std::thread::spawn(move || {
+                started.wait();
+                for expected in 1..=12 {
+                    let records = if expected % 2 == 0 {
+                        vaults.clone()
+                    } else {
+                        Vec::new()
+                    };
+                    store.commit(expected, records).expect("atomic commit");
+                }
+                finished.store(true, Ordering::Release);
+            })
+        };
+
+        started.wait();
+        let mut observations = 0;
+        while !finished.load(Ordering::Acquire) || observations < 64 {
+            let encoded = std::fs::read(&path).expect("read while replacing");
+            let value: serde_json::Value =
+                serde_json::from_slice(&encoded).expect("complete registry JSON");
+            assert_eq!(value["schema_version"], REGISTRY_SCHEMA_VERSION);
+            assert!(value["revision"].as_u64().is_some());
+            assert!(matches!(
+                value["vaults"].as_object().map(|vaults| vaults.len()),
+                Some(0 | 128)
+            ));
+            observations += 1;
+        }
+        writer.join().expect("writer thread");
+
+        let temporary_files = std::fs::read_dir(directory.path())
+            .expect("registry directory")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(temporary_files, 0);
+    }
+}

--- a/src/vault_runtime.rs
+++ b/src/vault_runtime.rs
@@ -1,0 +1,305 @@
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use serde::Serialize;
+
+use crate::startup::IndexingProgressSnapshot;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VaultSource {
+    Local { vault_path: PathBuf },
+    ManagedGit(ManagedGitSource),
+}
+
+impl VaultSource {
+    pub fn kind(&self) -> VaultSourceKind {
+        match self {
+            Self::Local { .. } => VaultSourceKind::Local,
+            Self::ManagedGit(_) => VaultSourceKind::ManagedGit,
+        }
+    }
+
+    pub fn mode(&self) -> VaultSourceMode {
+        match self {
+            Self::Local { .. } => VaultSourceMode::Local,
+            Self::ManagedGit(source) => source.mode.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManagedGitSource {
+    pub repository_url: String,
+    pub checkout_path: PathBuf,
+    pub branch: Option<String>,
+    pub vault_subdirectory: Option<PathBuf>,
+    pub mode: ManagedGitMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ManagedGitMode {
+    PullOnly,
+    Bidirectional,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VaultSourceKind {
+    Local,
+    ManagedGit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VaultSourceMode {
+    Local,
+    PullOnly,
+    Bidirectional,
+}
+
+impl From<ManagedGitMode> for VaultSourceMode {
+    fn from(value: ManagedGitMode) -> Self {
+        match value {
+            ManagedGitMode::PullOnly => Self::PullOnly,
+            ManagedGitMode::Bidirectional => Self::Bidirectional,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VaultPhase {
+    TermsRequired,
+    Downloading,
+    Validating,
+    Scanning,
+    Indexing,
+    Ready,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct VaultCapabilities {
+    pub browse: bool,
+    pub search: bool,
+    pub mutate: bool,
+    pub pull: bool,
+    pub push: bool,
+    pub retry: bool,
+}
+
+impl VaultCapabilities {
+    fn derive(source_mode: VaultSourceMode, phase: VaultPhase) -> Self {
+        let ready = phase == VaultPhase::Ready;
+        Self {
+            browse: ready,
+            search: ready,
+            mutate: ready
+                && matches!(
+                    source_mode,
+                    VaultSourceMode::Local | VaultSourceMode::Bidirectional
+                ),
+            pull: ready
+                && matches!(
+                    source_mode,
+                    VaultSourceMode::PullOnly | VaultSourceMode::Bidirectional
+                ),
+            push: ready && source_mode == VaultSourceMode::Bidirectional,
+            retry: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct VaultRuntimeSnapshot {
+    pub phase: VaultPhase,
+    pub source: VaultSourceKind,
+    pub mode: VaultSourceMode,
+    pub capabilities: VaultCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downloaded_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexing: Option<IndexingProgressSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<VaultRuntimeError>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct VaultRuntimeError {
+    pub code: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+impl VaultRuntimeSnapshot {
+    fn new(source: &VaultSource, phase: VaultPhase) -> Self {
+        let mode = source.mode();
+        Self {
+            phase,
+            source: source.kind(),
+            mode,
+            capabilities: VaultCapabilities::derive(mode, phase),
+            model: None,
+            downloaded_bytes: None,
+            total_bytes: None,
+            indexing: None,
+            error: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VaultRuntime {
+    source: Arc<VaultSource>,
+    snapshot: Arc<RwLock<VaultRuntimeSnapshot>>,
+}
+
+impl VaultRuntime {
+    pub fn new(source: VaultSource) -> Self {
+        let snapshot = VaultRuntimeSnapshot::new(&source, VaultPhase::Validating);
+        Self {
+            source: Arc::new(source),
+            snapshot: Arc::new(RwLock::new(snapshot)),
+        }
+    }
+
+    pub fn ready(source: VaultSource) -> Self {
+        let runtime = Self::new(source);
+        runtime.set_phase(VaultPhase::Ready);
+        runtime
+    }
+
+    pub fn source(&self) -> &VaultSource {
+        &self.source
+    }
+
+    pub fn snapshot(&self) -> VaultRuntimeSnapshot {
+        self.snapshot
+            .read()
+            .expect("vault runtime snapshot poisoned")
+            .clone()
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.snapshot().phase == VaultPhase::Ready
+    }
+
+    pub fn set_scanning(&self) {
+        self.set_phase(VaultPhase::Scanning);
+    }
+
+    pub fn set_terms_required(&self) {
+        self.set_phase(VaultPhase::TermsRequired);
+    }
+
+    pub fn set_downloading(
+        &self,
+        model: &'static str,
+        downloaded_bytes: Option<u64>,
+        total_bytes: Option<u64>,
+    ) {
+        let mut snapshot = self
+            .snapshot
+            .write()
+            .expect("vault runtime snapshot poisoned");
+        snapshot.phase = VaultPhase::Downloading;
+        snapshot.capabilities = VaultCapabilities::derive(snapshot.mode, snapshot.phase);
+        snapshot.model = Some(model);
+        snapshot.downloaded_bytes = downloaded_bytes;
+        snapshot.total_bytes = total_bytes;
+        snapshot.indexing = None;
+        snapshot.error = None;
+    }
+
+    pub fn set_indexing(&self, progress: IndexingProgressSnapshot) {
+        let mut snapshot = self
+            .snapshot
+            .write()
+            .expect("vault runtime snapshot poisoned");
+        snapshot.phase = VaultPhase::Indexing;
+        snapshot.capabilities = VaultCapabilities::derive(snapshot.mode, snapshot.phase);
+        snapshot.model = None;
+        snapshot.downloaded_bytes = None;
+        snapshot.total_bytes = None;
+        snapshot.indexing = Some(progress);
+        snapshot.error = None;
+    }
+
+    pub fn set_ready(&self) {
+        self.set_phase(VaultPhase::Ready);
+    }
+
+    pub fn set_unavailable(&self, code: impl Into<String>, message: impl Into<String>) {
+        let mut snapshot = self
+            .snapshot
+            .write()
+            .expect("vault runtime snapshot poisoned");
+        snapshot.phase = VaultPhase::Unavailable;
+        snapshot.capabilities = VaultCapabilities::derive(snapshot.mode, snapshot.phase);
+        snapshot.model = None;
+        snapshot.downloaded_bytes = None;
+        snapshot.total_bytes = None;
+        snapshot.indexing = None;
+        snapshot.error = Some(VaultRuntimeError {
+            code: code.into(),
+            message: message.into(),
+            retryable: false,
+        });
+    }
+
+    fn set_phase(&self, phase: VaultPhase) {
+        let mut snapshot = self
+            .snapshot
+            .write()
+            .expect("vault runtime snapshot poisoned");
+        snapshot.phase = phase;
+        snapshot.capabilities = VaultCapabilities::derive(snapshot.mode, phase);
+        snapshot.model = None;
+        snapshot.downloaded_bytes = None;
+        snapshot.total_bytes = None;
+        snapshot.indexing = None;
+        snapshot.error = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn managed(mode: ManagedGitMode) -> VaultSource {
+        VaultSource::ManagedGit(ManagedGitSource {
+            repository_url: "https://example.test/vault.git".to_string(),
+            checkout_path: PathBuf::from("/data/vault"),
+            branch: None,
+            vault_subdirectory: None,
+            mode,
+        })
+    }
+
+    #[test]
+    fn pull_only_ready_state_never_allows_mutation_or_push() {
+        let runtime = VaultRuntime::ready(managed(ManagedGitMode::PullOnly));
+        let capabilities = runtime.snapshot().capabilities;
+        assert!(capabilities.browse);
+        assert!(capabilities.search);
+        assert!(capabilities.pull);
+        assert!(!capabilities.mutate);
+        assert!(!capabilities.push);
+    }
+
+    #[test]
+    fn unavailable_state_has_no_ready_vault_capabilities() {
+        let runtime = VaultRuntime::new(managed(ManagedGitMode::Bidirectional));
+        runtime.set_unavailable("not_acquired", "Vault has not been acquired");
+        let snapshot = runtime.snapshot();
+        assert_eq!(snapshot.phase, VaultPhase::Unavailable);
+        assert!(!snapshot.capabilities.browse);
+        assert!(!snapshot.capabilities.search);
+        assert!(!snapshot.capabilities.mutate);
+        assert!(!snapshot.capabilities.retry);
+    }
+}


### PR DESCRIPTION
## Current packet: #86 validated Vault definitions

Implements #86 only on the existing draft integration branch. Tested commit:
`3ed9ecba8f1efa3e7a9c8335ce1d6c50d73d9496`.

### Definition-management contract

- Persists the accepted common name, enabled state, per-Vault exclusions, and a
  tagged `local`, `existing_git`, or `managed_git` source under the immutable
  UUID map key established by #85.
- Provides shared-core `add`, `edit`, `enable`, `disable`, and `disconnect`
  operations with optimistic registry revisions. Case-insensitive duplicate
  names and equal/ancestor/descendant canonical paths are rejected; disabled
  definitions continue reserving their paths.
- Source/repository/branch/subdirectory/location changes require a disabled
  definition and explicit same-logical-Vault confirmation. Name, Git mode,
  exclusions, and credentials may change normally without changing the UUID.
- Existing-Git definitions require a readable working checkout. Readable but
  non-writable local directories are valid. Re-enabling revalidates the source.
- Private HTTPS username/token values persist only inside the `0600` registry.
  Public snapshots expose only `credential_configured`; debug output, errors,
  recovery guidance, and repository URLs remain credential-free. Changing
  repository identity never carries an old credential implicitly.
- Disconnect removes only the registry record and its in-record credential. It
  performs no deletion of notes, checkouts, Git history, or remotes.

No runtime reconciliation, migration, Git acquisition/sync, HTTP, MCP,
frontend, cache, search, or deployment work is included. #67, #102, and #103
are unchanged, and no #87 or later implementation was begun.

### #86 interface-change checklist

Interface change: validated Vault definitions and lifecycle operations
Producer boundary: Vault collection registry (`src/vault_registry.rs`)
Kind: additive and behavior-changing persistent/Rust contract
Old contract: schema-1 registry records were an intentionally empty #85 identity slot, with only the private raw commit seam
New contract: validated tagged definition records, redacted projections, write-only credential inputs/updates, and add/edit/enable/disable/disconnect operations with the invariants above; raw record commit is private
Consumer boundaries: no production consumer is integrated in #86; repository references, module assignments, and the complete fixed-point diff were searched. #87 is the first planned consumer, followed by the routed runtime and management adapters.
Compatibility/migration: zero-Vault schema-1 registries remain valid; no production #85 consumer could create records; legacy environment conversion remains #87; downgrade is unsupported inside the draft integration route
Rollout/rollback: PR #31 remains draft and has no deployment wiring; revert the #86 commit before dependent packets to restore the #85 boundary
Evidence: focused registry tests, full backend suite, strict lint/format/type checks, module-map validation, and independent Standards/Spec review

### #86 validation

Run from the repository root at tested commit
`3ed9ecba8f1efa3e7a9c8335ce1d6c50d73d9496`:

- `cargo test vault_registry` — passed (33)
- `cargo check --all-targets` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo test --all` — passed (516 total: 506 library, 7 evaluation, 3 CLI; 0 doc tests)
- `node scripts/check-module-map.mjs` — passed (168 production files assigned exactly once)
- `git diff --check` — passed
- Standards review — initial documentation and duplicated structural-validation findings fixed; independent re-review clean
- Spec review — initial canonical-path, checkout-root, and malformed-HTTPS findings fixed with regressions; independent re-review clean

Frontend, Compose, and container gates were not run because their paths and
deployment behavior are forbidden and unchanged in #86.

### #86 intermediate failures and routed gaps

- TDD deliberately observed red failures before each new public lifecycle,
  validation, redaction, recovery, and filesystem behavior was implemented.
- The first strict Clippy run found one collapsible nested `if`; it was corrected
  before the recorded clean run.
- Independent review found stale module documentation, duplicated structural
  source rules, a symlink-alias overlap bypass, acceptance of a repository's
  `.git` metadata directory as its checkout location, and under-validation of
  HTTPS authorities/percent escapes. The implementation was hardened and three
  regression tests were added before the tested commit.
- The first post-review full-suite run encountered four existing settings tests
  contaminated by stale PID-named `/tmp/hatchdoor-settings-test-*.json` files.
  Two remained reproducible alone, proving cross-process residue; deleting only
  those disposable test artifacts made the clean rerun pass all 516 tests.
- The non-interactive shell did not expose `node`; the installed Node 24.16.0
  binary ran the module-map checker successfully.
- Incremental compilation remained disabled and Cargo used one build job to
  protect VM disk headroom. Final free space remained 7.0 GB (89% used).

Those implementation incidents require no product ticket. Expected draft gaps
remain owned by the accepted route: legacy import #87; per-Vault runtime and
coordination #88-#90; cache/read/search #91-#93; actual Git acquisition,
synchronization, scheduling, and recovery #94-#97; HTTP discovery and management
#98-#101; frontend #102; MCP #103; and final deployment/docs acceptance #104.

---

## Completed packet: #85 Vault registry

Implements #85 only on the existing draft integration branch. The tested commit is
`162f83c9af126124c2dd0b8b53f9340413fccb7e`. It adds the authoritative,
revisioned Vault collection registry without beginning #86 or integrating any
runtime, HTTP, MCP, frontend, migration, search, cache, or Git lifecycle consumer.
It does not modify #67, #102, or #103.

### Registry contract

- One authoritative `/data/state/vaults.json` with `schema_version: 1`, a
  monotonic collection `revision`, and a map keyed by immutable canonical random
  UUID v4 Vault IDs.
- An absent file loads lazily as a complete revision-0, zero-Vault state and is
  not created by reads.
- Commits are serialized by normalized registry path across all store handles in
  the process, require the expected persisted revision, increment exactly once,
  and atomically replace the file with owner-only `0600` permissions.
- Corrupt, unsupported, and future-schema files expose no Vault records, give
  recovery guidance, preserve the original bytes, and refuse commits.
- `VaultRecord` is intentionally an empty persisted identity slot. #86 owns the
  accepted definition fields, validation, redaction, and lifecycle operations.

### #85 interface-change checklist

Interface change: persistent Vault collection registry
Producer boundary: `src/vault_registry.rs`
Kind: additive persistent domain state
Old contract: no authoritative Vault collection, collection revision, or durable Vault ID store
New contract: the exact schema, revision, ID, lazy-zero, optimistic-concurrency, atomicity, permissions, and recovery behavior above
Consumer boundaries: no production consumer is integrated by #85; repository references, module assignments, and the complete branch diff were searched. #86 and #87 are the first planned consumers, followed by the routed runtime/API packets.
Compatibility/migration: existing startup behavior is unchanged; the absent registry remains a zero-Vault state; legacy environment import belongs to #87
Rollout/rollback: this remains a draft integration PR with no deployment change; revert the #85 commit to remove the boundary before consumers exist
Evidence: focused registry tests, full backend suite, strict lint/format checks, module-map validation, and both Standards and Spec reviews

Architectural invariants checked: this adds no service, framework, trait layer,
code generation, ambient/default Vault, runtime consumer, or compatibility shim.
Markdown remains authoritative and SQLite disposable. Existing HTTP and MCP
mutations remain routed through `src/vault/write/`. Search behavior is unchanged.

### #85 validation

Run from the repository root at tested commit
`162f83c9af126124c2dd0b8b53f9340413fccb7e`:

- `cargo test vault_registry` — passed (13)
- `cargo check --all-targets` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo test --all` — passed (496 total: 486 library, 7 evaluation, 3 CLI; 0 doc tests)
- `node scripts/check-module-map.mjs` — passed (168 production files assigned exactly once)
- `git diff --check` — passed
- Standards review — initially found per-instance rather than path-scoped write serialization; fixed with a process-wide normalized-path lock and an independently constructed-store regression test
- Spec review — reported the same optimistic-concurrency gap; fixed by the same tested change

Frontend gates were not run because `frontend/**` is forbidden and unchanged.
Compose/container checks were not run because #85 changes no deployment wiring.

### #85 known intermediate failures and routed gaps

- The TDD sequence intentionally observed failures for each missing registry seam;
  the final review regression then proved that two independently constructed store
  handles could both save revision N+1. The final path-scoped serialization fix
  makes one succeed and one receive the expected revision conflict.
- A first temporary build target filled the available temporary filesystem while
  compiling. Generated target output was removed; validation reused the repository
  target with incremental compilation disabled and one Cargo build job.
- VM disk pressure reached 92%. Only generated/reinstallable artifacts were
  removed: approximately 3.1 GB of Rust incremental output and 509 MB of prototype
  `frontend/node_modules`; free space recovered to 7.0 GB (89% used) after final
  builds.
- The non-interactive shell did not expose Node. The pinned installed Node 24.16.0
  binary ran the module-map checker successfully.
- A module documentation block was briefly inserted at the wrong location and
  made `cargo fmt --check` fail; it was corrected before the recorded validation.

Those setup incidents do not create product follow-up tickets. Expected functional
gaps remain owned by the accepted route: definition operations by #86; legacy
import by #87; per-Vault runtime by #88-#90; cache/read/search by #91-#93; Git
source lifecycle by #94-#97; HTTP discovery and mutation contracts by #98-#101;
frontend by #102; MCP by #103; and final deployment/docs acceptance by #104.

---

## Completed baseline packet: #84

Implements #84 only: rebase the existing managed-Git vault foundation onto the `development` head recorded at ticket start, preserve the accepted multi-Vault decisions, and leave the result as a draft integration baseline for the routed follow-up tickets.

- Recorded `development` base: `f77855c4c9d2a099a232ae8e36c4758a405e7f91`
- Tested integration commit: `7c9ebb3ceacbe2fb4c5516f7f19b8bf91355e1b3`
- Replayed integration commits only: `77f89a3`, `c968ded`, `bf13373`; `7c9ebb3` reconciles the module map after the rebase.
- This does **not** begin #85, use #67 as a prerequisite, or modify the #102 frontend / #103 MCP work. No `/api/v1` multi-Vault contract is introduced here.

## Preserved decisions and transitional boundary

The conflict resolution preserves current `development` runtime settings, authentication, scanning, and server composition while retaining the foundation's explicit vault lifecycle/readiness behavior. `VaultRuntime` is deliberately documented as the transitional single-configured-Vault seam; it is not the accepted registry or per-Vault runtime topology.

The accepted route remains:

- #85-#87: registry, definitions, and legacy import
- #88-#90: per-Vault runtimes, FIFO admission, restart/shutdown
- #91-#93: cache identity, reads, and search
- #94-#97: source implementations, managed checkout/sync, scheduling/recovery
- #98-#101: discovery and exact HTTP contracts through mutation/API freeze
- #102: frontend integration after #101
- #103: MCP integration after #101
- #104: final documentation, deployment, and cross-surface acceptance

## Interface-change checklist

Interface change: vault readiness/status baseline
Producer boundary: Runtime composition (`AppState` / `VaultRuntime`) and HTTP diagnostics
Kind: additive and behavior-changing
Old contract: startup and request paths assumed one immediately usable configured vault; no lifecycle capability snapshot was exposed
New contract: `/api/vault-status` exposes lifecycle/source/mode/capabilities; vault-dependent paths return a stable unavailable/indexing response until ready
Consumer boundaries: server/router, HTTP handlers, settings reindex, MCP routes/tool advertisement; searched through Code/Rust references and the complete branch diff
Compatibility/migration: existing local-vault happy paths remain supported; managed mode is opt-in; this is an intentionally intermediate single-Vault baseline replaced by #85-#101
Rollout/rollback: deploy only as a draft integration baseline; rollback is the pre-rebase PR head/backup branch; later tickets replace the transitional topology in dependency order
Evidence: focused `vault_runtime`, `app_state`, `server`, and `config` tests plus the full checks below

Interface change: managed Git source configuration
Producer boundary: application configuration and runtime composition
Kind: additive
Old contract: `HATCHDOOR_VAULT_SOURCE` selected the local configured vault
New contract: opt-in `git` / `managed-git` source accepts repository URL, checkout path, optional branch/subdirectory, and pull-only or bidirectional mode
Consumer boundaries: server startup, runtime capability derivation, Git sync composition, external deploy configuration
Compatibility/migration: default remains local; invalid or incomplete managed configuration fails closed; no implicit Vault or compatibility shim is added
Rollout/rollback: configure only when the owning source tickets are complete; remove the managed-source variables to return to local mode
Evidence: configuration/server tests and full checks below

Interface change: lifecycle-aware MCP write advertisement
Producer boundary: MCP tools/routes
Kind: behavior-changing
Old contract: configured MCP writes were advertised without vault lifecycle capability gating
New contract: write tools are advertised only when both MCP writes and the current lifecycle permit mutation
Consumer boundaries: MCP clients, MCP route dispatch, server MCP composition; unknown external clients may cache tool lists
Compatibility/migration: read/setup tools remain available; the exact vault-scoped MCP surface is intentionally deferred to #103 after the #101 API freeze
Rollout/rollback: ship with the lifecycle baseline or revert the integration branch; #103 owns the final multi-Vault contract
Evidence: MCP/server coverage in the full suite below

Architectural invariants checked: HTTP and MCP mutations remain routed through `src/vault/write/`; Markdown remains authoritative and SQLite disposable; authentication/origin requirements were preserved; search remains consistent with ADR-05; no new framework, service, trait layer, code generation, default-Vault inference, or compatibility shim was added. Rust/TypeScript wire coordination is N/A because frontend production work is explicitly deferred to #102.

## Validation

Run from the repository root at tested commit `7c9ebb3ceacbe2fb4c5516f7f19b8bf91355e1b3`:

- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo check --all-targets` — passed
- `cargo test vault_runtime` — passed (2)
- `cargo test app_state` — passed (12)
- `cargo test server` — passed (51)
- `cargo test config` with a fresh per-command `TMPDIR` — passed (31)
- `cargo test --all` — passed (483 total: 473 library, 7 evaluation, 3 CLI; 0 doc tests)
- `node scripts/check-module-map.mjs` — passed (167 production files assigned exactly once)
- `git diff --check origin/development...HEAD` — passed
- `docker compose config --quiet` with a temporary `.env -> .env.example` symlink — passed; the symlink was removed
- Standards review — no code finding after recording this interface checklist
- Spec review — no findings; confirmed exact base, limited replay, preserved decisions, and no #85/#67/#102/#103 scope

Frontend gates were not run because `frontend/**` is excluded and unchanged from `development`. Container build/runtime checks were not run because #84 changes neither packaging nor persistence behavior.

## Known intermediate failures

### Expected product gaps in this draft

- No `/data/state/vaults.json`, zero-Vault registry, `existing_git` source, or multi-Vault collection yet — owned by #85-#87.
- Runtime state is still a single configured Vault and does not yet have the accepted per-Vault runtime/FIFO/restart topology. The legacy `StartupTracker` forwarding seam and publicly mutable readiness fixture state also remain transitional — owned by #88-#90.
- SQLite identities, reads, and search remain single-Vault — owned by #91-#93.
- Local/existing-Git/managed checkout, synchronization, admission, and recovery are not complete — owned by #94-#97.
- Discovery and exact vault-qualified `/api/v1` reads/mutations are absent — owned by #98-#101.
- The reviewed #67 workspace is not integrated into production UI in this ticket — owned by #102 after #101.
- MCP remains the current interim scope-less surface — owned by #103 after #101.
- Final deployment/docs/cross-surface acceptance remain — owned by #104.

### Rebase and validation incidents

- A naive rebase exposed 77 unrelated commits from divergent fork history. It was aborted without retaining changes; the successful rebase used `--onto` to replay only the three PR commits.
- The first `/tmp` build exhausted that tmpfs while compiling vendored OpenSSL. Generated target output was removed and validation used the repository disk target.
- The sandbox initially could not resolve the registry for the new `arc-swap` dependency. The authorized network retry downloaded it successfully.
- FastEmbed's native-TLS build needed OpenSSL development artifacts unavailable on the VM. Validation reused the repository's already-built vendored OpenSSL 3.6.3 artifacts.
- Rustup attempted to sync the pinned 1.78 toolchain through a read-only home path. Validation used the installed Rust 1.97.1 `rustc`/`rustdoc` binaries directly.
- A repeated focused config test inherited a stale PID-based temporary settings file in this container. Re-running with a fresh per-command `TMPDIR` passed; this is test-environment contamination, not a product failure.
- Compose config initially stopped because `.env` was absent. Validation with the repository's `.env.example` as a temporary `.env` passed.
- GitHub initially refused to reopen the closed PR after its head branch moved, reporting that the branch had been force-pushed or recreated. The exact old head was temporarily restored under a lease, PR #31 was reopened, and the tested head was reapplied under a second exact lease; the final PR head was verified through the API.
- `gh pr edit` hit GitHub's deprecated Projects-classic GraphQL error. The same evidence body was applied through the pull-request REST endpoint and verified live.
- Git emitted stale credential-helper-path warnings around the authenticated HTTPS pushes, but each leased remote ref update succeeded and the final fork/PR SHA was independently confirmed as `7c9ebb3ceacbe2fb4c5516f7f19b8bf91355e1b3`.

These setup incidents do not create product follow-up tickets. The remaining functional failures are explicitly owned by #85-#104 as listed above.
