### PR TITLE
Add first-run Gemma model setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 HOST_VAULT_PATH=./vault
 # HOST_CACHE_PATH stores Hatchdoor's generated SQLite cache on the host.
 HOST_CACHE_PATH=./data/cache
+# HOST_MODELS_PATH stores downloaded embedding models and Gemma's local terms
+# acceptance receipt. Docker Compose makes this directory writable for Hatchdoor.
+HOST_MODELS_PATH=./models
 
 # Container/runtime paths. In Docker, these should match the mounted container paths.
 # For non-Docker cargo runs, set VAULT_PATH to your real local vault path instead.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,15 @@ frontend/dist
 .superpowers/
 # CodeGraph local index (machine-local, do not commit)
 .codegraph/
+
+# Private eval query set + review sheet (names hosts, people, IPs — never commit)
+eval/queries.local.jsonl
+eval/review-sheet.md
+# Authoring tooling for the private query set (hardcodes local vault paths)
+eval/*.local.py
+
+# Python bytecode from the eval authoring tooling
+__pycache__/
+
+# Eval query-set design handbook (names hosts, people, IPs — keep local only)
+docs/superpowers/specs/2026-07-25-eval-query-set-design.md

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ eval/queries.local.jsonl
 eval/review-sheet.md
 # Authoring tooling for the private query set (hardcodes local vault paths)
 eval/*.local.py
+# Sweep driver (drives the private query set)
+eval/*.local.sh
 
 # Python bytecode from the eval authoring tooling
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
   unchanged, but the initial indexing run re-embeds the vault.
 
 ### Added
+- First-run semantic-search setup. Hatchdoor now asks the single user to accept
+  the Gemma terms before downloading the default multilingual EmbeddingGemma
+  model, shows model-download and indexing progress in the UI and logs, and
+  keeps a local acceptance receipt with the persistent model files. Declining
+  Gemma removes its partial files and starts the Nomic Embed Text v1.5 fallback;
+  Nomic is explicitly identified as English-only and lower quality for
+  multilingual vaults. Public images ship neither model.
 - Direct attachment upload for agents: the `import_attachment` MCP tool accepts
   base64 file bytes inline (universal fallback for any MCP client), capped by the
   new `HATCHDOOR_MCP_MAX_BASE64_BYTES` (default 5 MiB, measured on the decoded
@@ -38,6 +45,9 @@
   surface a created, moved, archived, or uploaded item belongs to.
 
 ### Changed
+- Docker Compose now prepares the persistent `/models` bind mount for the
+  rootless runtime user. Set `HOST_MODELS_PATH` to retain downloaded models and
+  the local Gemma terms receipt across container replacement.
 - The `/mcp` request-body limit is raised to fit base64 attachment inflation so a
   legitimately sized upload is not rejected before the tool's own size check.
 - `POST /api/attachment` now accepts the MCP bearer token as an alternative to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,16 +278,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -385,15 +388,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -401,6 +403,35 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -435,15 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -496,16 +518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "daachorse"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +568,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,16 +626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +655,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -739,19 +766,19 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "4.9.1"
+version = "5.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c269a76bfc6cea69553b7d040acb16c793119cebd97c756d21e08d0f075ff8"
+checksum = "f3c8600c9ec79b51d60c19911fe14eac04fe9c2895e87d2a3e80e2213d645a32"
 dependencies = [
  "anyhow",
  "hf-hub",
  "image",
  "ndarray",
  "ort",
- "ort-sys",
- "rayon",
+ "safetensors",
+ "serde",
  "serde_json",
- "tokenizers 0.21.4",
+ "tokenizers 0.22.2",
 ]
 
 [[package]]
@@ -773,16 +800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -908,16 +925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,7 +1032,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1069,7 +1080,7 @@ dependencies = [
  "sqlite-vec",
  "tempfile",
  "text-splitter",
- "tokenizers 0.21.4",
+ "tokenizers 0.22.2",
  "tokenizers 0.23.1",
  "tokio",
  "tokio-stream",
@@ -1090,9 +1101,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "http",
@@ -1106,8 +1117,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "ureq",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1485,14 +1502,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1681,6 +1698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1717,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1864,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -1974,6 +2003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,12 +2047,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -2114,25 +2143,25 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
+ "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2",
- "tar",
+ "hmac-sha256",
+ "lzma-rust2",
  "ureq",
 ]
 
@@ -2147,6 +2176,15 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2204,6 +2242,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2638,6 +2682,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,17 +2812,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
 ]
 
 [[package]]
@@ -2979,17 +3025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,6 +3100,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,9 +3157,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3375,12 +3440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,22 +3507,38 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
+ "der",
  "flate2",
  "log",
  "native-tls",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "socks",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -3471,6 +3552,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3630,12 +3717,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
- "webpki-roots 1.0.9",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3759,15 +3846,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3930,16 +4008,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "y4m"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.19",
  "v_frame",
  "y4m",
 ]
@@ -308,6 +308,20 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "byteorder"
@@ -326,6 +340,48 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "candle-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ecb245093b0f791b89d3420c3df9c6d49c60ab63ba54db896bf8a3baf486706"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libc",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.19",
+ "tokenizers 0.22.2",
+ "yoke",
+ "zerocopy",
+ "zip",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa10b6ccc365b33210ce404fbf45e60d3e0bdac1004463cf1052e6ee1c1739a"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "castaway"
@@ -673,6 +729,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -771,6 +855,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c8600c9ec79b51d60c19911fe14eac04fe9c2895e87d2a3e80e2213d645a32"
 dependencies = [
  "anyhow",
+ "candle-core",
+ "candle-nn",
  "hf-hub",
  "image",
  "ndarray",
@@ -817,6 +903,18 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
 ]
 
 [[package]]
@@ -925,6 +1023,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,8 +1238,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -1066,10 +1287,12 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bytemuck",
+ "candle-core",
  "chrono",
  "dotenvy",
  "fastembed",
  "git2",
+ "hf-hub",
  "ignore",
  "libc",
  "notify",
@@ -1100,6 +1323,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hf-hub"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1344,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.19",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -1782,6 +2011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2285,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2392,6 +2642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,7 +2681,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.19",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2501,7 +2761,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2603,7 +2863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2734,6 +2994,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3004,6 +3270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,8 +3332,17 @@ dependencies = [
  "memchr",
  "pulldown-cmark",
  "strum",
- "thiserror",
+ "thiserror 2.0.19",
  "tokenizers 0.23.1",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3062,7 +3351,18 @@ version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3182,7 +3482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.19",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -3215,7 +3515,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.19",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ blake3 = "1"
 bytemuck = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dotenvy = "0.15"
-fastembed = "4"
+fastembed = "5"
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2", "vendored-openssl", "https"] }
 ignore = "0.4"
 libc = "0.2"
@@ -30,10 +30,11 @@ serde_yaml = "0.9"
 sqlite-vec = "0.1"
 text-splitter = { version = "0.32", features = ["markdown", "tokenizers"] }
 tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
-# FastEmbed 4 currently exposes its tokenizer through tokenizers 0.21. Keep
-# this alias for the read-only index microbenchmark, which inspects that model
-# tokenizer directly. Application chunking uses the model through Embedder.
-tokenizers-v21 = { package = "tokenizers", version = "0.21", default-features = false, features = ["onig"] }
+# FastEmbed 5 exposes its model tokenizer through tokenizers 0.22, while
+# text-splitter (application chunking) uses 0.23. Keep this version-matched
+# alias for the read-only index microbenchmark, which inspects the FastEmbed
+# model tokenizer directly and must speak its exact API version.
+tokenizers-fe = { package = "tokenizers", version = "0.22", default-features = false, features = ["onig"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.7", features = ["fs", "trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ axum = { version = "0.8", features = ["multipart"] }
 base64 = "0.22"
 blake3 = "1"
 bytemuck = "1"
+candle-core = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dotenvy = "0.15"
-fastembed = "5"
+fastembed = { version = "5", features = ["qwen3", "nomic-v2-moe"] }
+hf-hub = { version = "0.5", default-features = false, features = ["ureq", "native-tls"] }
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2", "vendored-openssl", "https"] }
 ignore = "0.4"
 libc = "0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,6 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY docs/starter-vault ./docs/starter-vault
 RUN cargo build --release --bin hatchdoor
-ENV FASTEMBED_CACHE_DIR=/opt/fastembed
-# The release binary depends on application source, so this layer is rebuilt
-# whenever that source changes. Keep the downloaded model in a BuildKit cache
-# mount and copy it into the image on every build; later builds reuse the mount
-# instead of downloading the model again.
-RUN --mount=type=cache,target=/var/cache/fastembed \
-    FASTEMBED_CACHE_DIR=/var/cache/fastembed \
-    ./target/release/hatchdoor --prefetch-embedder \
- && mkdir -p "$FASTEMBED_CACHE_DIR" \
- && cp -a /var/cache/fastembed/. "$FASTEMBED_CACHE_DIR"/
 
 FROM docker.io/library/node:26-slim AS frontend-builder
 WORKDIR /app/frontend
@@ -42,11 +32,9 @@ WORKDIR /app
 ENV HOST=0.0.0.0 \
     PORT=42824 \
     VAULT_PATH=/data/vault \
-    FASTEMBED_CACHE_DIR=/opt/fastembed \
     RUST_LOG=hatchdoor=info,tower_http=info,axum::rejection=warn
 
 COPY --from=rust-builder /app/target/release/hatchdoor /app/hatchdoor
-COPY --from=rust-builder /opt/fastembed /opt/fastembed
 COPY --from=frontend-builder /app/frontend/dist /app/frontend/dist
 
 EXPOSE 42824

--- a/README.md
+++ b/README.md
@@ -181,7 +181,29 @@ http://localhost:42824
 
 Enter the web bearer token when prompted.
 
-### 4. Container Image And Paths
+### 4. Choose Your Search Model
+
+Hatchdoor images include no model weights. On the first launch, Hatchdoor asks
+you to choose how semantic search is set up before it downloads anything.
+
+- **Set up Gemma** is the default. EmbeddingGemma is multilingual and provides
+  the best search quality. Read and accept the Gemma terms in the web UI (or
+  through the first-run MCP setup tools); Hatchdoor then downloads the model,
+  scans the vault, and builds the index automatically.
+- **Use Nomic instead** declines Gemma and starts the same setup with Nomic
+  Embed Text v1.5. It needs no Gemma acceptance, but it is English-only and is
+  less suitable for multilingual vaults.
+
+Accepting the Gemma terms only permits Hatchdoor to download and use that model.
+It does not change ownership of your vault or its content, and Hatchdoor does
+not send vault content anywhere. The downloaded model and the local acceptance
+receipt stay in `HOST_MODELS_PATH`, so they persist across container restarts.
+
+The UI and logs show download and indexing progress. Vault features remain
+unavailable until setup is ready; if a model download fails, Hatchdoor presents
+a retry action instead of silently changing models.
+
+### 5. Container Image And Paths
 
 The image is published on [Docker Hub](https://hub.docker.com/r/battermanz/hatchdoor):
 
@@ -202,6 +224,7 @@ Docker Compose mounts:
 | --- | --- |
 | `/data/vault` | Markdown vault, source of truth |
 | `/data/cache` | Generated SQLite cache |
+| `/models` | Downloaded search model and local Gemma terms receipt |
 
 ## Data And Safety Model
 
@@ -586,11 +609,8 @@ cd frontend
 npm run dev
 ```
 
-Optional: prefetch the embedder model used by semantic search:
-
-```bash
-cargo run -- --prefetch-embedder
-```
+The first-run model choice also applies to local development. Hatchdoor stores
+models in `./models` by default, so no model-prefetch command is required.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Edit `.env` and set at least these values:
 ```env
 HOST_VAULT_PATH=/absolute/path/to/your/markdown-vault
 HOST_CACHE_PATH=./data/cache
+HOST_MODELS_PATH=./models
 HATCHDOOR_WEB_BEARER_TOKEN=choose-a-long-random-token
 ```
 
@@ -159,6 +160,7 @@ What these mean:
 
 - `HOST_VAULT_PATH` is your Markdown vault on the host machine.
 - `HOST_CACHE_PATH` stores Hatchdoor's generated SQLite cache.
+- `HOST_MODELS_PATH` stores downloaded search models and the local Gemma terms receipt.
 - `HATCHDOOR_WEB_BEARER_TOKEN` protects your notes in the browser.
 
 Docker Compose binds Hatchdoor to `0.0.0.0` inside the container so the
@@ -250,6 +252,8 @@ For read-only browsing:
 
 - Mount the vault read-only if you want.
 - Keep the cache directory writable.
+- Keep the models directory writable. The supplied Compose file prepares it for
+  Hatchdoor's unprivileged runtime user automatically.
 
 For browser writes, MCP writes, attachment uploads, or git sync:
 
@@ -270,6 +274,7 @@ Copy `.env.example` to `.env` and adjust values.
 | --- | --- | --- |
 | `HOST_VAULT_PATH` | `./vault` | Host-side vault path for Docker Compose |
 | `HOST_CACHE_PATH` | `./data/cache` | Host-side cache directory for Docker Compose |
+| `HOST_MODELS_PATH` | `./models` | Persistent downloaded-model directory for Docker Compose |
 | `VAULT_PATH` | `/data/vault` | Runtime vault path read by Hatchdoor |
 | `HATCHDOOR_CACHE_DB` | `/data/cache/hatchdoor-cache.sqlite3` | Runtime SQLite cache file |
 | `HOST` | `127.0.0.1` | Bind host for local `cargo run` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 services:
+  model-permissions:
+    # Docker creates a missing bind-mount directory as root. Give the unprivileged
+    # Hatchdoor process ownership before it writes its local acceptance receipt
+    # or downloads model artifacts.
+    image: alpine:3.21
+    volumes:
+      - ${HOST_MODELS_PATH:-./models}:/models
+    command: ["chown", "-R", "65532:65532", "/models"]
+    restart: "no"
+
   hatchdoor:
     image: battermanz/hatchdoor:latest
     container_name: hatchdoor
@@ -16,6 +26,9 @@ services:
       # Model downloads and the local Gemma acceptance record persist across
       # image upgrades. Bind-mount this directory to avoid re-downloading.
       - ${HOST_MODELS_PATH:-./models}:/models
+    depends_on:
+      model-permissions:
+        condition: service_completed_successfully
     restart: unless-stopped
     healthcheck:
       # Distroless runtime has no shell/curl, so the binary probes its own

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
     volumes:
       - ${HOST_VAULT_PATH:-./vault}:/data/vault
       - ${HOST_CACHE_PATH:-./data/cache}:/data/cache
+      # Model downloads and the local Gemma acceptance record persist across
+      # image upgrades. Bind-mount this directory to avoid re-downloading.
+      - ${HOST_MODELS_PATH:-./models}:/models
     restart: unless-stopped
     healthcheck:
       # Distroless runtime has no shell/curl, so the binary probes its own

--- a/docs/embedding-sweep-decisions-2026-07-26.md
+++ b/docs/embedding-sweep-decisions-2026-07-26.md
@@ -1,0 +1,236 @@
+# Embedding sweep decisions — 2026-07-26
+
+This records the decisions taken while the embedding evaluation was in progress.
+The raw, per-query measurements are in [`eval/results.md`](../eval/results.md).
+
+## What was completed
+
+The initial exploratory grid covered four model/dimension configurations, three
+chunk settings, and contextual documents on and off: 24 completed cells. The
+application control is Nomic Embed Text v1.5 at native 768 dimensions; its
+current build defaults are 800-token chunks, 50-token overlap, and contextual
+document headers.
+
+The original 42-cell sweep was narrowed before the remaining models were run.
+This is intentional: the completed cells gave sufficiently consistent evidence
+to lock the document representation, so the remaining budget is better spent
+on model comparison.
+
+## Locked representation for the continuation
+
+Use **800-token chunks, 50-token overlap, and contextual documents enabled**.
+
+Why:
+
+- 800/50 was the best or tied-best general retrieval setting in the completed
+  configurations. It consistently produced the strongest Recall@10 and usually
+  the strongest Recall@5 and MRR.
+- Turning context off improved note coverage: it won Recall@5 in 10 of 12
+  like-for-like comparisons (two ties), and Recall@10 in 11 of 12.
+- Turning context on improved result quality: it won MRR in 11 of 12 comparisons
+  and correct-heading accuracy in all 12. It also usually reduced false positives.
+- Hatchdoor normally presents ranked results and routes people into a specific
+  note section, so first-result quality and heading accuracy are more valuable
+  than the extra broad-recall gain from context-off indexing.
+
+450/50 with context on remains the specialist choice for heading navigation:
+it had the strongest correct-heading score in every completed model/dimension
+configuration. It is not the general default because 800/50 had the better
+overall retrieval profile.
+
+## Model findings so far
+
+### Current control: Nomic Embed Text v1.5
+
+At the locked representation, the control scored Recall@5 0.822, Recall@10
+0.907, MRR 0.738, FP-rate@5 0.277, and correct-heading 0.750.
+
+### GTE Base English v1.5
+
+Do not promote this model. At the same representation it scored lower than the
+control on Recall@5 (0.814), Recall@10 (0.881), and MRR (0.700), with a higher
+FP-rate@5 (0.301). Correct-heading tied at 0.750. It remains a useful
+English-only floor/control rather than an upgrade.
+
+### Nomic Embed Text v2 MoE
+
+Native v2 MoE is the strongest completed candidate for raw recall. Its best
+cell, 800/50 with context off, reached Recall@5 0.915 and Recall@10 0.941.
+The balanced, contextual 800/50 cell scored Recall@5 0.864, Recall@10 0.924,
+MRR 0.771, and correct-heading 0.792: better than the current control on all
+of those quality measures, but with higher FP-rate@5 (0.325 versus 0.277).
+
+It is not an automatic deployment choice. Its build peak RSS was about 3.64 GB
+versus about 0.96 GB for the current model, and the model has a 512-token input
+limit, so an 800-token chunk can be truncated. The 256-dimensional variant did
+not provide a compelling quality/storage trade-off in the completed cells.
+
+## Continuation scope
+
+Run exactly these five model/dimension candidates at 800/50 with context on:
+
+1. Qwen3 Embedding 0.6B at 512 dimensions.
+2. EmbeddingGemma 300M Q4 at native 768 dimensions.
+3. EmbeddingGemma 300M Q4 at 256 dimensions.
+4. Snowflake Arctic Embed M v2 at native 768 dimensions.
+5. Snowflake Arctic Embed M v2 at 256 dimensions.
+
+EmbeddingGemma is included for benchmark comparison only. It uses Gemma terms,
+so a licensing review is required before considering it as Hatchdoor's default
+distributed model.
+
+## Completed continuation findings
+
+All five continuation cells completed. The native 768-dimensional
+**EmbeddingGemma 300M Q4** configuration is the best overall result in this
+evaluation.
+
+| Model | Recall@5 | Recall@10 | MRR | FP-rate@5 | Correct-heading | Build | Peak RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Current Nomic v1.5 | 0.822 | 0.907 | 0.738 | 0.277 | 0.750 | 895 s | 1.26 GB |
+| EmbeddingGemma Q4, native | **0.915** | **0.958** | 0.801 | 0.349 | 0.792 | **887 s** | **0.55 GB** |
+| Snowflake Arctic M v2, native | 0.907 | 0.932 | **0.810** | 0.313 | 0.792 | 1,071 s | 3.12 GB |
+| Nomic v2 MoE, native | 0.864 | 0.924 | 0.771 | 0.325 | 0.792 | 2,113 s | 3.64 GB |
+| Qwen3 0.6B, 512 dimensions | 0.737 | 0.847 | 0.654 | 0.277 | 0.792 | 5,617 s | 3.43 GB |
+
+### Interpretation
+
+- **Gemma Q4 native is the quality-and-efficiency winner.** Against the current
+  control, it adds 0.093 Recall@5, 0.051 Recall@10, and 0.063 MRR, improves
+  heading accuracy, uses less than half the peak build memory, and takes the
+  same time to build.
+- **Gemma's drawback is precision.** Its FP-rate@5 is 0.349, versus 0.277 for
+  the control. It retrieves more expected material, but it also places more
+  explicitly undesirable notes in the top five. This needs a qualitative check
+  of those false positives before rollout.
+- **Arctic native has the best first-hit ranking** (MRR 0.810) and a lower
+  FP-rate@5 than Gemma (0.313), but its recall is slightly lower and it needs
+  about 5.7 times Gemma's build RAM. That small MRR advantage does not justify
+  the operational cost as a general default.
+- **Qwen3 at 512 dimensions is rejected.** It is much slower and heavier than
+  the control while scoring worse. This finding applies to the tested
+  512-dimensional configuration, not an untested native 1,024-dimensional one.
+- **Do not use Gemma at 256 dimensions.** MRR falls from 0.801 to 0.689 and
+  Recall@5 from 0.915 to 0.831, while the retained SQLite cache only shrinks
+  from about 11.1 MB to 9.0 MB.
+- **Arctic at 256 dimensions is viable but not compelling.** It retains strong
+  quality (Recall@5 0.898, MRR 0.780), but has the same roughly 3.12 GB model
+  build-memory requirement as native Arctic.
+
+## Operational decisions
+
+- Preserve all 24 completed result sections; the continuation script must not
+  archive `eval/results.md` on startup.
+- Retain successful SQLite caches under `data/cache/sweep/` so candidates can
+  be inspected, rerun against another query set, or used for follow-up tests.
+  The script still removes a stale same-name cache before rebuilding and removes
+  a cache whose build fails.
+- Do not restart the sweep automatically after changing it. The user starts the
+  five-cell continuation manually with `bash eval/run-sweep.local.sh`.
+
+## Production recommendation and remaining gate
+
+Subject to accepting the Gemma terms, make **EmbeddingGemma300MQ4 at native
+768 dimensions with the Gemma retrieval-format v1 template, 800-token chunks,
+zero overlap, and contextual documents** the production candidate. It is the
+strongest quality-and-efficiency result in the completed sweep.
+
+Before changing the production embedder, review the Gemma terms and inspect the
+additional top-five false positives. If either blocks adoption, Arctic native
+is the strongest technical fallback, with the stated 3.12 GB build-memory cost.
+
+## Prompted Gemma chunk and overlap follow-up
+
+The first Gemma result used Hatchdoor's generic contextual text and no Gemma
+retrieval prompt. The follow-up corrected that representation to Gemma's
+retrieval contract:
+
+- query: `task: search result | query: <query>`;
+- document: `title: <note title> | text: Section: <heading path> <body>`.
+
+The corrected representation was tested at native 768 dimensions with context
+on. Results:
+
+| Chunk / overlap | Recall@5 | Recall@10 | MRR | FP-rate@5 | Correct-heading |
+|---|---:|---:|---:|---:|---:|
+| 800 / 0 | **0.958** | 0.958 | **0.846** | 0.361 | 0.833 |
+| 800 / 50 | **0.958** | 0.958 | **0.846** | 0.361 | 0.833 |
+| 800 / 100 | 0.958 | 0.958 | 0.838 | 0.361 | 0.833 |
+| 450 / 50 | 0.941 | 0.958 | 0.830 | **0.337** | **0.958** |
+| 1200 / 75 | 0.932 | **0.966** | 0.835 | 0.361 | 0.500 |
+| 1600 / 100 | 0.924 | 0.958 | 0.801 | 0.422 | 0.083 |
+
+### Decision
+
+Use **800 tokens with zero overlap** as the general configuration. It ties
+800/50 on every primary quality metric, builds faster (918 s versus 1,033 s),
+and avoids redundant content. The two caches are almost identical in size,
+which indicates that the Markdown-aware splitter rarely needed overlap to join
+an otherwise artificial boundary in this vault.
+
+This does not establish that zero overlap is universally best. It is the right
+choice for this structured Markdown vault, where title and heading context is
+embedded with every chunk. Re-evaluate it if the corpus gains substantial
+unstructured PDFs, transcripts, or long prose.
+
+450/50 remains the specialist setting for maximum heading precision. It is not
+the default because 800/0 has stronger general note retrieval and ranking.
+
+### Remaining validation before a production change
+
+- Review the Gemma terms.
+- Qualitatively inspect the extra top-five false positives: prompted Gemma's
+  FP-rate@5 is 0.361, above the Nomic v1.5 control's 0.277.
+- Run a small held-out query set or real-user search canary so the configuration
+  is not chosen solely on the set used for tuning.
+- Measure live query latency and a full re-index on the intended production VM.
+
+## Gemma indexing batch-size and CPU follow-up
+
+The question was whether Gemma's indexing CPU use could be raised to make a
+full build faster. This was a throughput test, not a retrieval-quality sweep:
+each cell used Gemma native with retrieval-format v1, contextual documents,
+800-token chunks, zero overlap, the same 378-note vault, and a fresh cache.
+No query evaluation was run because batching does not change the configured
+model or document representation.
+
+| Batch size | Build time | Process CPU | Peak RSS | Embed calls | Padding |
+|---:|---:|---:|---:|---:|---:|
+| 1 | **895.7 s** | 282% | **538 MB** | 775 | **0.0%** |
+| 2 | 1,068.7 s (+19%) | 299% | 577 MB | 538 | 14.3% |
+| 4 | 1,078.4 s (+20%) | 314% | 622 MB | 429 | 20.2% |
+
+All three cells processed the same 775 chunks and 381,165 real embedding
+tokens. The CPU figures are whole-process percentages: on the four-vCPU VM,
+batch 1 used about 70.5% of available aggregate CPU capacity, batch 2 about
+74.8%, and batch 4 about 78.6%.
+
+### Decision
+
+Keep **batch size 1**. It is both the fastest and the lowest-memory option.
+Batch 2 and batch 4 do use slightly more CPU, but this is counterproductive:
+the ONNX backend pads every batch to its longest input. Batch 2 performed
+63,780 padded tokens of extra work; batch 4 performed 96,657. The vault also
+has many one-chunk notes, so even at batch 2 and batch 4 the median effective
+call still contained only one input. Fewer calls therefore did not make up for
+the added padded computation.
+
+The evaluator retains `--batch-size` as a benchmark-only control, but the
+production `BuildOptions` default remains one input per call.
+
+### Why Nomic can show higher CPU use
+
+Hatchdoor does not give Nomic a special thread setting: both Nomic v1.5 and
+EmbeddingGemma Q4 are constructed through the same FastEmbed/ONNX Runtime
+path, with no model-specific session thread count in this code. The observed
+difference is therefore most plausibly in their exported ONNX graphs and
+kernels: Gemma Q4's quantized operations have less parallel work or are more
+memory-bound for parts of inference, whereas Nomic's graph keeps more cores
+busy. This is an inference, not an operator-level profile.
+
+Higher CPU use is not itself a performance goal. Gemma batch 1 completed in
+895.7 seconds—essentially the same full-build time as the prior Nomic control
+measurement—while the attempts to raise Gemma CPU use made it about 20% slower.
+An ONNX Runtime operator profile would be required to attribute the remaining
+idle CPU to specific kernels; there is no current evidence that pursuing it
+will improve indexing time.

--- a/docs/embedding-sweep-decisions-2026-07-26.md
+++ b/docs/embedding-sweep-decisions-2026-07-26.md
@@ -234,3 +234,19 @@ measurement—while the attempts to raise Gemma CPU use made it about 20% slower
 An ONNX Runtime operator profile would be required to attribute the remaining
 idle CPU to specific kernels; there is no current evidence that pursuing it
 will improve indexing time.
+
+## Reranking: rejected for the local CPU deployment
+
+The proposed multilingual reranker follow-up was stopped during its first
+cell: BGE Reranker v2 M3, using the locked Gemma retrieval cache, an initial
+candidate set of 20, and a 512-token query-document limit. After about 16
+minutes of wall time it was still evaluating the 125-query set, using roughly
+three CPU cores and 3.5 GB of resident memory. It had accumulated about 49
+minutes of CPU time.
+
+This is a performance-gate result, not a retrieval-quality result: the cell
+was intentionally stopped before it produced metrics. It is sufficient to
+reject cross-encoder reranking from Hatchdoor's local CPU search path. The
+added BGE/GTE test wiring and local Phase-1 harness were removed rather than
+continuing a model sweep whose resource profile cannot meet the interactive
+deployment target.

--- a/docs/embeddinggemma-license-options.md
+++ b/docs/embeddinggemma-license-options.md
@@ -1,0 +1,297 @@
+# EmbeddingGemma licensing and default-model options
+
+> Researched: 2026-07-26
+> Scope: Using EmbeddingGemma 300M Q4 as Hatchdoor's default embedding model
+> Status: Product-oriented licensing research, not formal legal advice
+
+## Executive summary
+
+Hatchdoor can use EmbeddingGemma as its default embedding model, including in a
+commercial product. However, EmbeddingGemma is subject to Google's custom Gemma
+Terms of Use and the incorporated Gemma Prohibited Use Policy. Those obligations
+cannot be made to disappear.
+
+The recommended architecture is:
+
+1. Configure EmbeddingGemma as Hatchdoor's preferred default.
+2. Do not include its weights in Hatchdoor releases or published container
+   images.
+3. On first run, present a short model-specific notice and record the user's
+   acceptance of the applicable Gemma terms.
+4. Download the model directly from its upstream host into a persistent cache on
+   the user's machine.
+5. Pin the upstream revision and verify the downloaded files.
+
+This preserves local inference after the initial download while minimizing the
+argument that Hatchdoor itself distributes the model weights.
+
+## Model identification
+
+The model evaluated in Hatchdoor is **EmbeddingGemma 300M Q4**:
+
+- `Q4` means a 4-bit quantized model; it does not mean Gemma 4.
+- Hatchdoor uses FastEmbed's `EmbeddingModel::EmbeddingGemma300MQ4`.
+- FastEmbed 5.17.3 obtains the model from
+  `onnx-community/embeddinggemma-300m-ONNX`.
+- The relevant artifacts are:
+  - `onnx/model_q4.onnx`
+  - `onnx/model_q4.onnx_data`
+
+This distinction matters because Gemma 4 uses the Apache License 2.0, while
+EmbeddingGemma remains listed in the Appendix governed by the custom Gemma Terms
+of Use.
+
+The Hugging Face metadata for both the official model and ONNX conversion
+identifies the license as `gemma`. The official Google repository requires
+manual acknowledgement of the license. The ONNX conversion is not gated, but
+that does not remove or change the license attached to the model.
+
+## Exact licensing position
+
+The applicable Gemma Terms of Use were last modified on April 1, 2026.
+
+### Permitted activity
+
+The terms permit use, reproduction, modification and distribution, provided
+their conditions are followed. Google's official EmbeddingGemma documentation
+expressly describes the model as licensed for responsible commercial use and
+allows developers to fine-tune and deploy it in their applications.
+
+The terms also say:
+
+- Google claims no rights in outputs generated using Gemma.
+- Outputs are not Model Derivatives.
+- Users remain responsible for their outputs and subsequent uses.
+
+For Hatchdoor, embedding vectors and vector indexes produced by the model should
+therefore be treated as user output rather than as Gemma-licensed model
+derivatives.
+
+### Use restrictions
+
+Use must comply with applicable laws and the incorporated Gemma Prohibited Use
+Policy. The policy broadly prohibits using or allowing others to use Gemma for
+activities including:
+
+- Rights-infringing content or activities.
+- Dangerous, illegal or malicious activities.
+- Harmful, abusive or misleading uses.
+- Certain privacy violations and non-consensual tracking.
+- Certain automated decisions affecting people's rights.
+- Sexually explicit content.
+- Attempts to bypass safety measures to enable prohibited conduct.
+
+These are use-based restrictions, which is why the license is not equivalent to
+an OSI-approved open-source license such as Apache 2.0 or MIT.
+
+### What counts as distribution
+
+The terms define Distribution broadly. It includes transmitting, publishing or
+otherwise sharing Gemma or a Model Derivative with a third party. It also
+expressly includes making Gemma or its functionality available through a hosted
+service, including via an API or web interface.
+
+Consequently:
+
+- Publishing a Docker image containing the model weights is Distribution.
+- Publishing model files in a release is Distribution.
+- Operating a Hatchdoor-hosted service that exposes EmbeddingGemma
+  functionality is Distribution, even if users never receive the weights.
+- A user's private, self-hosted Hatchdoor instance does not by itself make the
+  Hatchdoor project operator a hosted-service provider.
+
+### Redistribution obligations
+
+A party distributing Gemma or a Model Derivative must satisfy all of the
+following:
+
+1. Include the Section 3.2 use restrictions as an enforceable provision in an
+   agreement governing use or distribution of the model.
+2. Notify subsequent users that the model is subject to those restrictions.
+3. Give every third-party recipient a copy of the complete Gemma Terms of Use.
+   A link alone is not enough.
+4. Cause modified files to carry prominent notices stating that they were
+   modified.
+5. Accompany non-hosted distributions with a `NOTICE` text file containing:
+
+   > Gemma is provided under and subject to the Gemma Terms of Use found at ai.google.dev/gemma/terms
+
+Additional terms may be applied to modifications or a Model Derivative as a
+whole, but they must not conflict with the Gemma Terms.
+
+The terms do not explicitly require a click-through acceptance mechanism.
+Nevertheless, the requirement for an enforceable downstream restriction makes
+an installation or first-run acknowledgement safer than relying only on passive
+documentation.
+
+### Other material provisions
+
+- The model and outputs are provided as-is, without warranties.
+- Google broadly disclaims liability to the extent permitted by law.
+- Google may terminate the agreement for breach.
+- After termination, the recipient must stop using and distributing Gemma and
+  delete copies in their possession or control.
+- California law and courts in Santa Clara County govern the agreement.
+- The license does not grant rights to Google's trademarks or permit implying
+  endorsement.
+
+## Hatchdoor's current distribution shape
+
+Hatchdoor currently:
+
+- Uses Nomic Embed Text v1.5 in production.
+- Prefetches that model during the Docker build.
+- Copies the populated FastEmbed cache into the final runtime image.
+- Publishes the Hatchdoor application under the AGPL-3.0.
+
+If the Docker prefetch step were changed from Nomic to EmbeddingGemma without
+other architectural changes, every published Hatchdoor image would contain the
+Gemma weights. Hatchdoor would then be a model redistributor and would need to
+meet all the obligations above.
+
+The AGPL application and Gemma model can be distributed as separate components
+in an aggregate, but their licensing must be clearly separated:
+
+- Hatchdoor source and binaries remain AGPL-3.0.
+- EmbeddingGemma weights remain under the Gemma Terms.
+- Gemma's additional restrictions must not be presented as restrictions on the
+  AGPL-covered Hatchdoor code.
+
+## Option 1: Default model with direct runtime acquisition
+
+**Recommendation**
+
+Make EmbeddingGemma the logical default but do not ship its weights.
+
+Suggested flow:
+
+1. Hatchdoor starts and detects that the default model is not installed.
+2. It shows the model name, source, terms version and links to the complete
+   terms and prohibited-use policy.
+3. The administrator accepts the model-specific terms.
+4. Hatchdoor downloads the model directly from Hugging Face to a persistent
+   model-cache volume.
+5. Hatchdoor records the accepted terms version, model revision and timestamp.
+6. Subsequent use is fully local and offline.
+
+For unattended installations, an explicit environment variable could be
+supported, for example:
+
+```text
+HATCHDOOR_ACCEPT_GEMMA_TERMS=1
+```
+
+The acceptance record should still include the terms version in application
+state or logs.
+
+Important boundaries:
+
+- The download must go directly from the user's instance to the upstream host.
+- Hatchdoor-operated infrastructure should not proxy, mirror or cache the
+  weights.
+- The model repository revision should be pinned.
+- File hashes should be checked before the model is loaded.
+- The official image must not contain a build-cache residue or model layer.
+
+This approach offers the best balance of user convenience, offline operation
+after installation and reduced maintainer exposure. It is not a guarantee that
+a court would never characterize Hatchdoor as participating in distribution,
+but it gives the project a much stronger separation than bundling or mirroring
+the weights.
+
+## Option 2: Bundle the model with a compliance package
+
+Hatchdoor can retain its existing fully-offline-on-first-boot behavior and ship
+the model in its container image. The image must then contain a model-specific
+compliance package, for example:
+
+```text
+licenses/embeddinggemma/
+├── GEMMA_TERMS
+├── PROHIBITED_USE_POLICY
+├── NOTICE
+├── MODIFICATIONS
+└── SOURCE
+```
+
+The package should:
+
+- Contain a complete snapshot of the applicable Gemma Terms.
+- Contain the required `NOTICE` sentence verbatim.
+- Identify Google as the upstream model provider.
+- Identify `onnx-community/embeddinggemma-300m-ONNX` as the ONNX/Q4 conversion
+  source.
+- State prominently that the artifacts are converted and quantized versions.
+- Identify the exact upstream revision and artifact hashes.
+- Explain that the model is separate from the AGPL-covered Hatchdoor
+  application.
+
+The installer or first-run experience should also obtain model-specific
+acceptance and incorporate the Section 3.2 restrictions into the terms
+governing the weights.
+
+This is workable but creates continuing release-management obligations. Every
+published image and alternative distribution must retain the compliance
+package, and Google's terms should be checked before each release that updates
+the model.
+
+## Option 3: User-provided model or external provider
+
+Hatchdoor can prefer EmbeddingGemma whenever an administrator supplies an
+external model cache, while shipping no model and performing no automatic
+download.
+
+The administrator would:
+
+1. Obtain the model directly from Google or Hugging Face.
+2. Accept the provider's license flow.
+3. Mount the resulting cache into Hatchdoor.
+
+This provides the clearest separation for the Hatchdoor project but adds more
+installation friction.
+
+A managed EmbeddingGemma endpoint is another variation. In that arrangement,
+the model provider is responsible for distributing or hosting the model, while
+Hatchdoor sends text and receives embeddings. This conflicts with Hatchdoor's
+private, offline design and introduces credentials, cost and data-processing
+concerns. If Hatchdoor operates the endpoint itself, the Gemma hosted-service
+obligations apply to Hatchdoor again.
+
+## Recommendation for Hatchdoor
+
+Adopt Option 1:
+
+- EmbeddingGemma 300M Q4 is the preferred default.
+- Public Hatchdoor images contain no Gemma weights.
+- First run includes one lightweight, model-specific acknowledgement.
+- The user's instance downloads directly from the upstream repository.
+- The model is cached persistently and inference remains local afterward.
+- The repository revision and artifact hashes are pinned.
+
+If the project cannot accept even a one-time model-specific acknowledgement,
+the incorporated prohibited-use policy or the possibility of future compliance
+review, then EmbeddingGemma cannot be the default. In that case the default
+must remain a permissively licensed alternative, with EmbeddingGemma offered as
+a user-installed option.
+
+## Primary sources
+
+- [Gemma Terms of Use](https://ai.google.dev/gemma/terms)
+- [Gemma Prohibited Use Policy](https://ai.google.dev/gemma/prohibited_use_policy)
+- [EmbeddingGemma model overview](https://ai.google.dev/gemma/docs/embeddinggemma)
+- [Gemma Apache License 2.0 page](https://ai.google.dev/gemma/apache_2)
+- [Official EmbeddingGemma Hugging Face repository](https://huggingface.co/google/embeddinggemma-300m)
+- [Official repository metadata](https://huggingface.co/api/models/google/embeddinggemma-300m)
+- [ONNX/Q4 conversion repository](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX)
+- [ONNX/Q4 repository metadata](https://huggingface.co/api/models/onnx-community/embeddinggemma-300m-ONNX)
+- [FastEmbed-rs documentation](https://docs.rs/fastembed/latest/fastembed/enum.EmbeddingModel.html)
+
+## Relevant Hatchdoor files
+
+- `src/embed/fastembed_embedder.rs`
+- `src/server.rs`
+- `src/main.rs`
+- `Dockerfile`
+- `Cargo.toml`
+- `Cargo.lock`
+- `LICENSE`

--- a/docs/embeddinggemma-license-options.md
+++ b/docs/embeddinggemma-license-options.md
@@ -174,15 +174,9 @@ Suggested flow:
 5. Hatchdoor records the accepted terms version, model revision and timestamp.
 6. Subsequent use is fully local and offline.
 
-For unattended installations, an explicit environment variable could be
-supported, for example:
-
-```text
-HATCHDOOR_ACCEPT_GEMMA_TERMS=1
-```
-
-The acceptance record should still include the terms version in application
-state or logs.
+The acceptance record belongs next to the model files, rather than in logs or
+an environment variable. This keeps the model and the record of the terms that
+govern it together when the persistent model directory is moved or restored.
 
 Important boundaries:
 
@@ -295,3 +289,105 @@ a user-installed option.
 - `Cargo.toml`
 - `Cargo.lock`
 - `LICENSE`
+
+## Approved implementation decisions
+
+This section records the agreed product contract for implementation. It takes
+precedence over the options above where they differ.
+
+### Distribution and storage
+
+- Hatchdoor's public images ship **neither** EmbeddingGemma nor the Nomic v1.5
+  fallback weights. The Docker build must not prefetch either model or leave a
+  model-cache layer behind.
+- Models live only in a persistent `models/` directory. In Docker this is the
+  fixed path `/models`, with the supplied Compose configuration bind-mounting
+  `./models` to it. A direct local run uses `./models`. There is no model-path
+  environment setting.
+- Model versions use separate subdirectories, so a complete, verified version
+  is never overwritten by a partial replacement.
+- EmbeddingGemma is fetched directly, without a Hugging Face account or token,
+  from the benchmarked Q4 ONNX source:
+  `onnx-community/embeddinggemma-300m-ONNX`. Hatchdoor pins its exact revision
+  and verifies every required artifact against recorded hashes before loading
+  it.
+
+### First startup and fallback
+
+EmbeddingGemma 300M Q4 is the default model and has no manual “start setup”
+button. On a fresh installation, the startup flow is:
+
+```text
+Show Gemma terms → accept → download Gemma → scan vault → build index → ready
+```
+
+Acceptance must precede the download. Downloading creates a local copy of the
+model, so it is a reproduction governed by the Gemma terms—not merely a later
+inference/use concern.
+
+If the user declines, Hatchdoor deletes any partial Gemma model files and any
+Gemma cache/index, then automatically downloads **Nomic Embed Text v1.5** and
+indexes with it. Nomic is presented as the fallback: it has no Gemma acceptance
+step, but is English-only and lower quality than multilingual Gemma.
+
+If the user accepts Gemma but its download fails, Hatchdoor must not silently
+fall back to Nomic. It stops at a clear retry error, since an automatic switch
+would unexpectedly change search quality and language coverage.
+
+There is no ongoing model-settings screen and no model-switching flow after
+initial setup in this implementation. A user who declines Gemma stays on Nomic
+until a later feature deliberately adds a change path.
+
+### Terms acknowledgement and privacy copy
+
+The single Hatchdoor user may accept the terms either in the Web UI or through
+MCP. In MCP, a setup-required response presents the same notice and links; an
+explicit acceptance call starts the automatic download and indexing process.
+
+The Web UI notice is intentionally short and links to the complete Gemma Terms
+and Gemma Prohibited Use Policy. It must include this substance:
+
+> Accepting these terms only allows Hatchdoor to download and use the Gemma
+> model. It does not change ownership of your vault or its contents. Hatchdoor
+> does not send your notes to Google when indexing or searching. Once installed,
+> the model runs locally on this machine. Downloading the model contacts its
+> upstream host, but does not upload your vault contents.
+
+The acknowledgement is written only to an `acceptance.json` file beside the
+selected Gemma version. It records the terms version, terms URLs, acceptance
+time, pinned model revision, artifact manifest/hash set, and Hatchdoor version.
+It contains no vault data and is never sent to Hatchdoor, Google, or any other
+service.
+
+When a future Hatchdoor release knows of newer Gemma terms, it compares that
+version with the receipt. A mismatch requires fresh acceptance before Gemma is
+used again.
+
+### Startup progress and failure safety
+
+Hatchdoor already has a whole-app startup gate: the Web UI polls
+`/api/startup-status` once per second and blocks vault features until the index
+is ready. It already displays indexing percentage, ETA, notes, and chunks; logs
+emit the same indexing progress after ten seconds and then every minute.
+
+Gemma setup extends that existing state machine rather than creating a second
+setup interface:
+
+```text
+terms required → model downloading → existing scanning → existing indexing → ready
+```
+
+The existing indexing view and logs continue to provide their current detailed
+progress. The new terms and download states add only their state-specific copy
+and download progress. Until startup reaches `ready`, all vault features remain
+unavailable.
+
+Before downloading, Hatchdoor checks that there is enough free space for the
+model and a fresh index. Interrupted downloads resume and are hash-verified;
+if verification fails, Hatchdoor deletes the bad copy and retries once. A
+partially built index is never searched: it is discarded and rebuilt safely.
+
+Future model upgrades are not automatic. If an upgrade flow is later added, it
+must download and verify the new version, rebuild the index, and only then
+remove the previous model and index. A changed terms version requires fresh
+acceptance before that switch.

--- a/docs/embeddings-investigation-fastembed-v5.md
+++ b/docs/embeddings-investigation-fastembed-v5.md
@@ -1,0 +1,680 @@
+# Hatchdoor Embedding & Model Investigation
+
+> Updated for **FastEmbed v5** and current model options as of **24 July 2026**.
+
+## Executive recommendation
+
+Hatchdoor's embedding architecture is structurally sound, but its main retrieval-quality bottleneck is probably **not Nomic Embed Text v1.5 alone**. The larger opportunities are:
+
+1. embedding note context such as titles, headings, aliases and tags;
+2. reducing the default chunk size from 800 tokens;
+3. adding production reranking;
+4. making model selection and vector dimensions configurable;
+5. batching chunks efficiently;
+6. measuring changes against a representative multilingual evaluation set.
+
+Now that FastEmbed v5 can be used on every supported platform, the strongest practical upgrade to test first is:
+
+> **EmbeddingGemma 300M Q4**, initially at 768 dimensions and then at 256 dimensions through Matryoshka truncation and re-normalisation.
+
+The most important alternatives are:
+
+- **Nomic Embed Text v2 MoE** for a permissively licensed multilingual successor to Nomic v1.5;
+- **Qwen3 Embedding 0.6B** as a higher-compute multilingual quality ceiling;
+- **BGE-M3** as a separate dense + sparse + ColBERT retrieval experiment;
+- **Granite Embedding English R2** as a lightweight English-specific custom-ONNX candidate;
+- **Snowflake Arctic Embed M v2.0** as a CPU-oriented multilingual custom-ONNX candidate.
+
+Do not select a winner from public leaderboard scores alone. Benchmark these models on Hatchdoor's actual note structure, languages and query patterns.
+
+---
+
+## Current Hatchdoor architecture
+
+Hatchdoor currently:
+
+- loads **Nomic Embed Text v1.5** in production;
+- stores 768-dimensional vectors in SQLite through `sqlite-vec`;
+- correctly applies Nomic's asymmetric prefixes:
+  - `search_document:`
+  - `search_query:`
+- performs Markdown-aware, tokenizer-aware chunking;
+- defaults to approximately **800 tokens** with **50-token overlap**;
+- reuses embeddings through content hashes;
+- records embedder identity and rebuilds the vector cache when that identity changes;
+- has an `Embedder` abstraction that already separates:
+  - embedding generation,
+  - tokenizer access,
+  - dimensions,
+  - model identity,
+  - query/document formatting.
+
+This is a strong foundation for model experimentation.
+
+---
+
+# Retrieval-pipeline findings
+
+## 1. Model selection is too hard-coded
+
+The production model and dimensions should come from a single model specification rather than being repeated in startup and schema code.
+
+Recommended shape:
+
+```rust
+pub struct EmbeddingModelSpec {
+    pub id: &'static str,
+    pub dimensions: usize,
+    pub max_length: usize,
+    pub query_format: QueryFormat,
+    pub document_format: DocumentFormat,
+    pub backend: EmbeddingBackend,
+}
+```
+
+The specification should own:
+
+- model identifier;
+- backend type: ONNX, Candle or BGE-M3;
+- vector dimensions;
+- supported Matryoshka dimensions;
+- tokenizer;
+- maximum sequence length;
+- query and document instructions;
+- pooling and normalisation behaviour;
+- cache identity.
+
+The vector schema should derive its dimensions from this specification.
+
+---
+
+## 2. The 800-token default is probably too large
+
+Large chunks improve broad recall but often weaken precision because one vector represents several concepts.
+
+Benchmark at least:
+
+| Chunk target | Overlap | Expected role |
+|---:|---:|---|
+| 300 tokens | 40 | High precision |
+| 450 tokens | 50 | Likely best balance |
+| 800 tokens | 50 | Current baseline |
+
+A likely production range is **350–500 tokens**, especially after adding document context.
+
+---
+
+## 3. Embed contextual metadata
+
+Current input is effectively:
+
+```text
+search_document: <chunk>
+```
+
+Recommended conceptual input:
+
+```text
+Title: <note title>
+Aliases: <aliases>
+Tags: <selected tags>
+Section: <heading path>
+
+<chunk text>
+```
+
+Model-specific wrappers should then be applied around this canonical document representation.
+
+For EmbeddingGemma, for example:
+
+```text
+title: <note title> | text: Section: <heading path>
+
+<chunk text>
+```
+
+Avoid embedding every metadata field indiscriminately. Prefer stable, retrieval-relevant context:
+
+- note title;
+- heading path;
+- aliases;
+- a small number of tags;
+- optionally the note type or collection.
+
+---
+
+## 4. Batch by approximate sequence length
+
+Embedding one chunk per inference call avoids padding but creates unnecessary runtime overhead.
+
+Use length buckets, for example:
+
+- 0–128 tokens;
+- 129–256;
+- 257–512;
+- 513–1024;
+- longer only for models and use cases that justify it.
+
+Batching should be configurable because the best batch size differs significantly between an N100 and an M1 Pro.
+
+---
+
+## 5. Improve filtered semantic search
+
+Filtered semantic search should avoid scanning all stored vectors in Rust as the vault grows.
+
+Possible approaches:
+
+- retrieve a larger vector candidate pool, then filter;
+- pre-filter IDs through FTS or metadata and join through a temporary table;
+- maintain partitions for high-value filters;
+- combine FTS and dense candidate sets before reranking.
+
+---
+
+## 6. Use the existing evaluation harness as a release gate
+
+The repository already has the beginnings of a useful evaluation framework. Turn it into a reproducible model-selection suite with committed aggregate results.
+
+Measure:
+
+- Recall@5 and Recall@10;
+- MRR;
+- nDCG@10;
+- correct-note rate;
+- correct-heading rate;
+- cross-language retrieval;
+- index time;
+- incremental-index latency;
+- single-query latency;
+- peak memory;
+- model download size;
+- vector database size.
+
+Run each model with both:
+
+1. raw chunk text;
+2. contextualised chunk text.
+
+Otherwise model weaknesses may be confused with weak document representation.
+
+---
+
+# FastEmbed v5 model shortlist
+
+FastEmbed v5 provides ordinary ONNX text embeddings, dedicated Candle implementations for **Qwen3** and **Nomic v2 MoE**, a dedicated **BGE-M3** interface, sparse embeddings and reranking.
+
+## Summary
+
+| Priority | Model | Languages | Dimensions | Context | FastEmbed v5 route | CPU assessment |
+|---:|---|---|---:|---:|---|---|
+| 1 | EmbeddingGemma 300M Q4 | 100+ | 768; MRL 512/256/128 | 2,048 | Native ONNX model | Best first practical test |
+| 2 | Nomic Embed Text v2 MoE | ~100 | 768; MRL 256 | 512 | `nomic-v2-moe` Candle feature | Strong but benchmark memory and latency |
+| 3 | Qwen3 Embedding 0.6B | 100+ | Up to 1,024; MRL | 32K | `qwen3` Candle feature | Quality ceiling; relatively heavy |
+| 4 | BGE-M3 | 100+ | 1,024 dense plus sparse/ColBERT | 8,192 | Dedicated `Bgem3Embedding` | Heavy; valuable only as a retrieval-system experiment |
+| 5 | Granite English R2 | English | 768 | 8,192 | User-defined/custom ONNX | Excellent English CPU candidate |
+| 6 | Arctic Embed M v2.0 | 74 | 768; MRL 256 | 8,192 | User-defined/custom ONNX | Very interesting multilingual CPU candidate |
+
+MRL means Matryoshka Representation Learning: vectors can be truncated to selected lower dimensions and then normalised again.
+
+---
+
+# Recommended multilingual models
+
+## 1. EmbeddingGemma 300M Q4 — first upgrade to implement
+
+### Why it is compelling
+
+EmbeddingGemma combines:
+
+- approximately 300M parameters;
+- multilingual training covering more than 100 languages;
+- a 2,048-token input window;
+- 768-dimensional output;
+- Matryoshka dimensions including 512, 256 and 128;
+- dedicated query/document formatting;
+- a native quantised FastEmbed v5 model;
+- a good size-to-quality trade-off for local inference.
+
+FastEmbed v5 exposes variants including:
+
+- `EmbeddingGemma300M`;
+- `EmbeddingGemma300MQ`;
+- `EmbeddingGemma300MQ4`.
+
+### Recommended Hatchdoor experiment
+
+Benchmark:
+
+1. Q4 at 768 dimensions;
+2. Q4 truncated to 256 dimensions and re-normalised;
+3. contextual title/section embeddings;
+4. chunk targets of 300, 450 and 800 tokens.
+
+A 256-dimensional index would use roughly one third of the raw vector storage and memory bandwidth of the current 768-dimensional index.
+
+### Important caveat
+
+EmbeddingGemma uses the **Gemma terms**, not Apache 2.0. Review the terms before making it Hatchdoor's default distributed model.
+
+### Verdict
+
+**Best first practical FastEmbed v5 candidate.**
+
+---
+
+## 2. Nomic Embed Text v2 MoE — best Nomic-family upgrade
+
+### Why it belongs in the benchmark
+
+Nomic v2 offers:
+
+- multilingual coverage of roughly 100 languages;
+- 768-dimensional vectors;
+- Matryoshka reduction to 256 dimensions;
+- Apache 2.0 licensing;
+- familiar asymmetric prefixes:
+  - `search_query:`
+  - `search_document:`
+- a direct conceptual migration from Nomic v1.5;
+- a FastEmbed v5 Candle implementation behind `nomic-v2-moe`.
+
+It is a mixture-of-experts model intended to provide stronger multilingual retrieval than similarly sized dense encoders.
+
+### Main constraints
+
+- Its effective input limit is 512 tokens.
+- The model download and memory footprint are not especially small.
+- Candle performance may differ substantially from the ONNX path.
+- Sparse routing does not guarantee that it will be faster on an N100.
+
+### Recommended Hatchdoor experiment
+
+Benchmark:
+
+- 768 dimensions;
+- 256 dimensions;
+- 300- and 450-token chunks;
+- indexing and single-query latency separately;
+- N100 and M1 Pro memory peaks.
+
+### Verdict
+
+**Best permissively licensed multilingual successor to Nomic v1.5.**
+
+---
+
+## 3. Qwen3 Embedding 0.6B — multilingual quality ceiling
+
+### Strengths
+
+Qwen3 Embedding 0.6B provides:
+
+- more than 100 languages;
+- up to 32K context;
+- up to 1,024-dimensional output;
+- selectable lower dimensions;
+- instruction-aware query embeddings;
+- Apache 2.0 licensing;
+- a dedicated FastEmbed v5 Candle implementation behind `qwen3`.
+
+A Hatchdoor query instruction could be:
+
+```text
+Given a query against a personal Markdown knowledge base, retrieve passages
+that directly answer the query, including equivalent passages written in
+another language.
+```
+
+### Constraints
+
+It is a decoder-derived model with approximately 600M parameters. Expect:
+
+- higher indexing latency;
+- higher query latency;
+- greater memory use;
+- less attractive performance on an N100 than compact encoder models.
+
+The long context is not a reason to embed entire notes. Retrieval still benefits from focused chunks.
+
+### Recommended Hatchdoor experiment
+
+Use it as a ceiling rather than the expected default:
+
+- 512 dimensions;
+- optionally 1,024 dimensions;
+- 300- and 450-token chunks;
+- tailored query instruction;
+- M1 Pro first, N100 second.
+
+### Verdict
+
+**Best quality-ceiling experiment among the direct FastEmbed v5 options, but unlikely to be the low-power default.**
+
+---
+
+## 4. BGE-M3 — test the retrieval architecture, not just its dense vector
+
+BGE-M3 produces:
+
+- a 1,024-dimensional dense vector;
+- learned sparse token weights;
+- ColBERT-style multi-vectors;
+- multilingual representations;
+- support for long inputs.
+
+FastEmbed v5 provides a dedicated `Bgem3Embedding` interface for these outputs.
+
+### Why it is different
+
+Testing only its dense vector misses the main reason to use it. A meaningful experiment would compare:
+
+```text
+Current:
+FTS + dense retrieval + reciprocal-rank fusion
+
+Alternative:
+BGE-M3 dense + learned sparse + optional ColBERT late interaction
+```
+
+### Constraints
+
+- substantially heavier model;
+- larger dense vectors;
+- additional storage if sparse and multi-vector outputs are persisted;
+- more complicated indexing and ranking;
+- potentially poor N100 economics.
+
+### Verdict
+
+**Use only as a separate hybrid-retrieval research branch, not as the first model swap.**
+
+---
+
+# English-specific candidates
+
+A multilingual default is preferable for a vault containing English, French, Dutch and Spanish. English-only models are still useful for measuring how much multilingual support costs.
+
+## 1. Granite Embedding English R2 — preferred custom English candidate
+
+Granite English R2 offers:
+
+- 149M parameters;
+- 768 dimensions;
+- 8,192-token context;
+- Apache 2.0 licensing;
+- a ModernBERT-derived encoder;
+- strong retrieval, long-document and code-retrieval positioning.
+
+The small R2 variant offers:
+
+- 47M parameters;
+- 384 dimensions;
+- 8,192-token context.
+
+These are not currently first-class FastEmbed model enum entries, so integration would use a compatible ONNX export and the user-defined model interface.
+
+### Verdict
+
+- **Granite English R2:** best balanced English custom candidate.
+- **Granite Small English R2:** excellent speed and memory floor.
+
+---
+
+## 2. Existing FastEmbed English baselines
+
+Keep these inexpensive native comparisons:
+
+### GTE Base English v1.5 Quantized
+
+- 768 dimensions;
+- native FastEmbed integration;
+- realistic English challenger;
+- lower integration risk than a custom model.
+
+### BGE Small English v1.5 Quantized
+
+- 384 dimensions;
+- very lightweight;
+- useful latency and vector-size baseline;
+- likely weaker than newer models in raw semantic quality.
+
+### MixedBread Large v1 Quantized
+
+- 1,024 dimensions;
+- stronger-quality English baseline;
+- relatively expensive on low-power CPUs;
+- useful as an ONNX quality ceiling.
+
+---
+
+# Additional multilingual custom candidate
+
+## Snowflake Arctic Embed M v2.0
+
+Arctic Embed M v2.0 is worth testing after the direct v5 candidates because it offers:
+
+- approximately 305M total parameters, with relatively low transformer compute for its class;
+- 768-dimensional vectors;
+- a useful 256-dimensional Matryoshka option;
+- 8,192-token context;
+- 74 languages;
+- Apache 2.0 licensing;
+- published ONNX files.
+
+It is not currently a first-class FastEmbed model enum entry, so it would require a user-defined model or a small upstream contribution.
+
+### Verdict
+
+**Potentially the most interesting custom multilingual CPU model, but integration should follow the native v5 benchmark.**
+
+---
+
+# Models not prioritised
+
+## Jina Embeddings v3
+
+Technically strong, multilingual and long-context, but:
+
+- approximately 600M parameters;
+- non-commercial CC BY-NC licensing;
+- less attractive for a generally distributed open-source product.
+
+## Very large Qwen3 variants
+
+The 4B and 8B embedding models may raise benchmark scores, but they do not fit Hatchdoor's low-power, self-hosted deployment goal.
+
+## Multilingual E5 Large
+
+Still a useful historical baseline, but newer models offer more compelling quality/efficiency trade-offs.
+
+## ModernBERT Embed Large
+
+Available through FastEmbed, but large and 1,024-dimensional. Granite R2 is a more interesting English efficiency direction, while Qwen3 provides a more useful quality ceiling.
+
+---
+
+# Exact benchmark suite
+
+## Core suite
+
+| Test | Model | Dimensions | Purpose |
+|---:|---|---:|---|
+| 1 | Nomic Embed Text v1.5 | 768 | Current control |
+| 2 | Nomic Embed Text v1.5 Quantized | 768 | Quantisation control |
+| 3 | EmbeddingGemma 300M Q4 | 768 | Main practical challenger |
+| 4 | EmbeddingGemma 300M Q4 | 256 | Main storage-efficient challenger |
+| 5 | Nomic Embed Text v2 MoE | 768 | Nomic-family multilingual upgrade |
+| 6 | Nomic Embed Text v2 MoE | 256 | Compact Apache-licensed option |
+| 7 | Qwen3 Embedding 0.6B | 512 | Quality ceiling |
+| 8 | GTE Base English v1.5 Quantized | 768 | English native baseline |
+
+## Separate architecture experiment
+
+| Test | Model | Outputs |
+|---:|---|---|
+| 9 | BGE-M3 | Dense only |
+| 10 | BGE-M3 | Dense + sparse |
+| 11 | BGE-M3 | Dense + sparse + ColBERT |
+
+Do not mix BGE-M3's full multi-representation experiment into the first simple dense-model comparison.
+
+## Optional custom-model suite
+
+| Test | Model | Dimensions |
+|---:|---|---:|
+| 12 | Granite Small English R2 | 384 |
+| 13 | Granite English R2 | 768 |
+| 14 | Arctic Embed M v2.0 | 256 |
+| 15 | Arctic Embed M v2.0 | 768 |
+
+---
+
+# Evaluation matrix
+
+For every core model, test:
+
+## Document representation
+
+1. raw chunk;
+2. title + chunk;
+3. title + heading path + aliases + selected tags + chunk.
+
+## Chunking
+
+- 300 / 40;
+- 450 / 50;
+- 800 / 50.
+
+## Query categories
+
+- exact-name queries;
+- conceptual queries;
+- questions whose answer is under a specific heading;
+- queries using aliases rather than canonical terms;
+- English query → English note;
+- French/Dutch/Spanish query → same-language note;
+- cross-language query → note in another language;
+- queries requiring an exact code/configuration fragment;
+- broad exploratory questions.
+
+## Performance
+
+Record separately:
+
+- cold model load;
+- full initial indexing;
+- incremental note update;
+- batch throughput;
+- p50 and p95 query embedding latency;
+- total search latency;
+- peak resident memory;
+- model cache size;
+- vector database size.
+
+---
+
+# Production reranking recommendation
+
+Changing the dense model alone is unlikely to maximise retrieval quality.
+
+Recommended production flow:
+
+1. retrieve FTS candidates;
+2. retrieve dense-vector candidates;
+3. optionally retrieve learned sparse candidates;
+4. combine through reciprocal-rank fusion;
+5. rerank the top 20–40 candidates;
+6. return the top 5–10 chunks, with per-note deduplication.
+
+FastEmbed v5 includes reranking support, making this a natural next step after the dense-model benchmark.
+
+Measure reranking separately so its gains are not attributed to the embedding model.
+
+---
+
+# Implementation roadmap
+
+## Phase 1 — make models configurable
+
+- introduce `EmbeddingModelSpec`;
+- derive dimensions from the selected model;
+- include backend, model revision, dimensions, max length and formatting version in cache identity;
+- expose the active model through logs and a system endpoint;
+- rebuild the index automatically when any embedding-contract field changes.
+
+Suggested cache identity:
+
+```text
+fastembed-v5:embeddinggemma-300m-q4:dim=256:max=2048:format=v2
+```
+
+## Phase 2 — contextual chunks and chunk-size evaluation
+
+- create a canonical contextual document representation;
+- add model-specific wrappers;
+- benchmark 300, 450 and 800 tokens;
+- commit evaluation results.
+
+## Phase 3 — first v5 model benchmark
+
+Implement in this order:
+
+1. EmbeddingGemma 300M Q4;
+2. Nomic v2 MoE;
+3. Qwen3 Embedding 0.6B;
+4. existing GTE/BGE/MixedBread baselines.
+
+## Phase 4 — reranking
+
+- add a configurable reranker;
+- tune the candidate pool;
+- add per-note diversity;
+- record latency and quality impact.
+
+## Phase 5 — BGE-M3 research path
+
+Only proceed if ordinary hybrid retrieval plus reranking leaves a measurable quality gap.
+
+## Phase 6 — custom ONNX candidates
+
+Evaluate Granite R2 and Arctic Embed M v2.0 after the model registry and evaluation suite are stable.
+
+---
+
+# Final recommendation
+
+Keep **Nomic Embed Text v1.5** as the control, not necessarily as the permanent default.
+
+My recommended order is:
+
+1. **EmbeddingGemma 300M Q4** — best first practical upgrade;
+2. **Nomic Embed Text v2 MoE** — best Apache-licensed multilingual successor;
+3. **Qwen3 Embedding 0.6B** — quality ceiling;
+4. **BGE-M3** — separate multi-representation retrieval experiment;
+5. **Granite English R2 / Small R2** — custom English efficiency candidates;
+6. **Arctic Embed M v2.0** — custom multilingual CPU candidate.
+
+The likely winning production configuration is not simply “the newest model.” It is more likely to be:
+
+```text
+EmbeddingGemma Q4 or Nomic v2
++ 256-dimensional Matryoshka vectors
++ 350–500-token contextual chunks
++ FTS/vector fusion
++ reranking
+```
+
+The model should be selected only after measuring that complete pipeline on Hatchdoor's real multilingual vault.
+
+---
+
+# Primary references
+
+- FastEmbed v5 documentation: <https://docs.rs/fastembed/latest/fastembed/>
+- EmbeddingGemma 300M: <https://huggingface.co/google/embeddinggemma-300m>
+- Nomic Embed Text v2 MoE: <https://huggingface.co/nomic-ai/nomic-embed-text-v2-moe>
+- Qwen3 Embedding 0.6B: <https://huggingface.co/Qwen/Qwen3-Embedding-0.6B>
+- BGE-M3: <https://huggingface.co/BAAI/bge-m3>
+- Granite Embedding English R2: <https://huggingface.co/ibm-granite/granite-embedding-english-r2>
+- Snowflake Arctic Embed M v2.0: <https://huggingface.co/Snowflake/snowflake-arctic-embed-m-v2.0>

--- a/docs/fastembed-v5-upgrade-findings.md
+++ b/docs/fastembed-v5-upgrade-findings.md
@@ -1,0 +1,106 @@
+# FastEmbed v5 Upgrade — Feasibility Findings
+
+> Investigation notes captured on 2026-07-24 on branch `feature/fastembed-v5-models`
+> (off `development`). This is the *platform/build feasibility* base for a later
+> v5 implementation. For the model-selection strategy, see the companion doc
+> [`embeddings-investigation-fastembed-v5.md`](./embeddings-investigation-fastembed-v5.md).
+
+## Background: the v4 → v5 → v4 excursion
+
+During the dependency batch on `development` (commits `c7936e7`, `af80a79`,
+2026-07-21), FastEmbed 5 was attempted and reverted. The revert reason recorded
+in `docs/dependency-update-plan.md` was ONNX Runtime's AVX baseline requirement.
+FastEmbed 5 was never committed — `git log -S 'fastembed = "5"'` on `Cargo.toml`
+is empty. The excursion left two residues:
+
+- `docs/dependency-update-plan.md` notes "FastEmbed 5 is deferred … requires AVX here".
+- `Cargo.toml` keeps a `tokenizers-v21` alias, because FastEmbed 4 pins tokenizers 0.21
+  while the rest of the tree moved to tokenizers 0.23.
+
+This document re-examines whether that deferral still stands. **Conclusion: the
+original blockers are resolved by the current distroless Debian 13 target.**
+
+## Key finding 1 — AVX is an x86-only concern, irrelevant to ARM64
+
+AVX / AVX2 / AVX-512 are x86-64 instruction sets. ARM64 (aarch64) CPUs — the
+public demo host (`batteroraclearm`), Apple Silicon, Graviton — physically cannot
+execute them and never will; their SIMD equivalent is NEON (and SVE). ONNX
+Runtime's *x86-64* prebuilt binaries raised their baseline to require AVX, which
+would fault on an old AVX-less x86 host. On aarch64 a separate NEON-compiled
+binary is used and the AVX flag is a non-event. ARM64 is **not** "forever
+incompatible" — the AVX issue does not apply to it at all.
+
+## Key finding 2 — FastEmbed v5's backend ships prebuilt ARM64-Linux binaries
+
+FastEmbed v5.0.0's breaking change was upgrading its ONNX Runtime binding to
+`ort` `2.0.0-rc.10` (from ort 1.x) and removing Rayon. The `ort` crate's own
+platform matrix (`pykeio/ort`, `docs/core/platform.tsx`, `PLATFORMS_WITH_BINARIES`)
+explicitly includes prebuilt binaries for:
+
+- `linux/arm64`  ← the demo host
+- `linux/x64`    ← the primary deploy host
+- `macos/arm64`, `windows/arm64`, `ios/arm64`, `android/arm64`
+
+So an aarch64 container gets a native prebuilt binary with no build-from-source.
+
+## Key finding 3 — the real runtime floor is glibc / libstdc++, and we clear it
+
+`ort`'s prebuilt Linux binaries (x64 **and** arm64) require:
+
+> **glibc ≥ 2.39 & libstdc++ ≥ 13.2** (Ubuntu ≥ 24.04, Debian ≥ 13 "Trixie").
+
+This is a toolchain floor, not an ISA problem, and it applies on every arch.
+Hatchdoor's runtime image is `gcr.io/distroless/cc-debian13:nonroot`
+(`Dockerfile` line 39):
+
+- **Debian 13 "Trixie"** → glibc ~2.41 (≥ 2.39 ✓)
+- **`cc` variant** → ships `libgcc` + `libstdc++6` (from GCC 14, ≥ 13.2 ✓).
+  Note: the `base-debian13` variant does **not** ship libstdc++; the `cc`
+  variant is required and is what we use.
+
+**The base image is not a blocker.**
+
+## Remaining costs / decisions for the actual upgrade
+
+These are not blockers, but they are not free either — budget for them.
+
+1. **ort 2.0 API compile check.** Our FastEmbed surface is small and stable —
+   `TextEmbedding::try_new(InitOptions::new(model).with_max_length(..).with_show_download_progress(false))`
+   plus the `EmbeddingModel` enum (`src/embed/fastembed_embedder.rs:1,23-25`).
+   These survived into v5, and the v5 breaking changes (ort 2.0, Rayon removal)
+   don't obviously touch this surface — but confirm with an actual `cargo build`,
+   don't assume.
+
+2. **Forced full reindex (by design).** The cache keys on `embedder.identity()`,
+   which hardcodes `...-fastembed-v4` (`src/embed/fastembed_embedder.rs:99`).
+   Bumping to v5 means changing that string, which trips the identity-change
+   rebuild path (`src/cache/schema.rs:56-63`) — **every deployment wipes its
+   SQLite cache and re-embeds the whole vault on first boot after the upgrade**
+   (demo + all clients). Handled gracefully, but ship it knowingly, not silently.
+   (Cache schema is currently version `8`, `src/cache/schema.rs:9`.)
+
+3. **Build-time AVX on the x86 build host.** The Dockerfile runs the embedder at
+   *build* time (`--prefetch-embedder`, `Dockerfile:26-28`) to warm the model
+   cache. On the x86 build leg this executes ONNX Runtime → needs AVX on whatever
+   runs turbobuild. Modern build hosts have it; confirm before trusting CI. The
+   arm64 build leg is unaffected.
+
+4. **Drop the `tokenizers-v21` alias (cleanup).** The alias exists only because
+   FastEmbed 4 pins tokenizers 0.21; its sole user is
+   `src/bin/index_microbench.rs:7` (`use tokenizers_v21::Tokenizer;`). If v5 moves
+   to tokenizers 0.23+, drop the alias and point the microbench at the main
+   `tokenizers` dep. Optional, removes the wart the v4→v5→v4 saga left behind.
+
+## Bottom line
+
+The v5 deferral was correct for the *previous* target but is **no longer
+justified** on distroless Debian 13. The upgrade is viable. It is not a pure
+version bump: plan for an ort-2.0 compile pass, an identity change that forces a
+one-time full reindex everywhere, and a build-host AVX sanity check.
+
+## Sources
+
+- pykeio/ort platform matrix — `docs/core/platform.tsx` (`PLATFORMS_WITH_BINARIES`)
+- FastEmbed v5.0.0 release (ort 2.0.0-rc.10 upgrade, Rayon removal)
+- `docs/dependency-update-plan.md` (original v5 deferral rationale)
+- Local: `Dockerfile:39`, `src/embed/fastembed_embedder.rs:99`, `src/cache/schema.rs:9,56-63`

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -72,7 +72,7 @@ experience to a publishable bar. Tracked issues:
 Related but broader than pure UI polish: [#13 — Global Settings](https://github.com/BattermanZ/Hatchdoor/issues/13)
 and [#14 — Live editing content](https://github.com/BattermanZ/Hatchdoor/issues/14).
 
-_Horizon: **v2.4** (next feature line)._
+_Horizon: **v2.5.0**._
 
 ### Agent-driven ingestion
 

--- a/frontend/src/App.startup-auth.test.tsx
+++ b/frontend/src/App.startup-auth.test.tsx
@@ -1,0 +1,33 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+import { clearToken } from "./api/api";
+
+afterEach(() => {
+  cleanup();
+  clearToken();
+  vi.restoreAllMocks();
+});
+
+it("prompts for the web token when first-run model setup is unauthorized", async () => {
+  vi.spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ state: "terms_required" }), { status: 200 }),
+    )
+    .mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole("button", { name: "Accept terms and set up Gemma" });
+  await act(async () => {
+    screen.getByRole("button", { name: "Accept terms and set up Gemma" }).click();
+  });
+
+  expect(await screen.findByRole("dialog", { name: "Access token required" })).toBeVisible();
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,6 @@ export function VaultApp() {
   const [visualViewportHeight, setVisualViewportHeight] = useState(
     () => window.visualViewport?.height ?? window.innerHeight,
   );
-  const [authRequired, setAuthRequired] = useState(false);
   const [editRequestId, setEditRequestId] = useState(0);
   const location = useLocation();
   const navigate = useNavigate();
@@ -129,11 +128,6 @@ export function VaultApp() {
   const explorerPaneRef = useRef<HTMLElement | null>(null);
   const restoredExplorerScrollRef = useRef(false);
   const restoredLastNoteRef = useRef(false);
-
-  useEffect(() => {
-    onUnauthorized(() => setAuthRequired(true));
-    return () => onUnauthorized(null);
-  }, []);
 
   useEffect(() => {
     // Drafts only bridge an interrupted edit; drop ones older than a week.
@@ -387,15 +381,6 @@ export function VaultApp() {
         } as CSSProperties
       }
     >
-      {authRequired && (
-        <TokenPrompt
-          onSubmit={(token) => {
-            setToken(token);
-            setAuthRequired(false);
-            window.location.reload();
-          }}
-        />
-      )}
       <AppTopbar
         activeNote={activeNote}
         writeEnabled={writeEnabled}
@@ -587,11 +572,29 @@ export function VaultApp() {
   );
 }
 
-function App() {
+export function App() {
+  const [authRequired, setAuthRequired] = useState(false);
+
+  useEffect(() => {
+    onUnauthorized(() => setAuthRequired(true));
+    return () => onUnauthorized(null);
+  }, []);
+
   return (
-    <StartupGate>
-      <VaultApp />
-    </StartupGate>
+    <>
+      {authRequired ? (
+        <TokenPrompt
+          onSubmit={(token) => {
+            setToken(token);
+            setAuthRequired(false);
+            window.location.reload();
+          }}
+        />
+      ) : null}
+      <StartupGate>
+        <VaultApp />
+      </StartupGate>
+    </>
   );
 }
 

--- a/frontend/src/startup/StartupGate.test.tsx
+++ b/frontend/src/startup/StartupGate.test.tsx
@@ -65,6 +65,35 @@ describe("StartupGate", () => {
     expect(await screen.findByText("Private vault")).toBeVisible();
   });
 
+  it("explains Gemma terms before any model download and can accept them", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(statusResponse({ state: "terms_required" }))
+      .mockResolvedValueOnce(statusResponse({ state: "downloading" }));
+
+    render(
+      <StartupGate>
+        <div>Private vault</div>
+      </StartupGate>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Set up multilingual search" }),
+    ).toBeVisible();
+    expect(screen.getByText(/does not change ownership of your vault/i)).toBeVisible();
+    expect(screen.getByRole("link", { name: "Read Gemma Terms" })).toHaveAttribute(
+      "href",
+      "https://ai.google.dev/gemma/terms",
+    );
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Accept terms and set up Gemma" }).click();
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/model/accept-gemma", {
+      method: "POST",
+    });
+  });
+
   it("polls until the backend becomes ready", async () => {
     vi.useFakeTimers();
     const fetchMock = vi
@@ -101,12 +130,15 @@ describe("StartupGate", () => {
   });
 
   it("shows a safe error when indexing fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      statusResponse({
-        state: "failed",
-        message: "Indexing could not be completed.",
-      }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        statusResponse({
+          state: "failed",
+          message: "The search model could not be downloaded or loaded.",
+        }),
+      )
+      .mockResolvedValueOnce(statusResponse({ state: "downloading" }));
 
     render(
       <StartupGate>
@@ -118,5 +150,15 @@ describe("StartupGate", () => {
       await screen.findByRole("heading", { name: "Vault unavailable" }),
     ).toBeVisible();
     expect(screen.queryByText("Private vault")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("The search model could not be downloaded or loaded."),
+    ).toBeVisible();
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Retry setup" }).click();
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/model/retry", {
+      method: "POST",
+    });
   });
 });

--- a/frontend/src/startup/StartupGate.test.tsx
+++ b/frontend/src/startup/StartupGate.test.tsx
@@ -1,12 +1,14 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { clearToken, setToken } from "../api/api";
 import { StartupGate } from "./StartupGate";
 
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
+  clearToken();
 });
 
 function statusResponse(body: object) {
@@ -66,6 +68,7 @@ describe("StartupGate", () => {
   });
 
   it("explains Gemma terms before any model download and can accept them", async () => {
+    setToken("setup-token");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(statusResponse({ state: "terms_required" }))
@@ -89,9 +92,15 @@ describe("StartupGate", () => {
     await act(async () => {
       screen.getByRole("button", { name: "Accept terms and set up Gemma" }).click();
     });
-    expect(fetchMock).toHaveBeenLastCalledWith("/api/model/accept-gemma", {
-      method: "POST",
-    });
+    const [path, init] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(path).toBe("/api/model/accept-gemma");
+    expect(init).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.any(Headers),
+      }),
+    );
+    expect((init?.headers as Headers).get("Authorization")).toBe("Bearer setup-token");
   });
 
   it("polls until the backend becomes ready", async () => {
@@ -157,8 +166,8 @@ describe("StartupGate", () => {
     await act(async () => {
       screen.getByRole("button", { name: "Retry setup" }).click();
     });
-    expect(fetchMock).toHaveBeenLastCalledWith("/api/model/retry", {
-      method: "POST",
-    });
+    const [path, init] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(path).toBe("/api/model/retry");
+    expect(init).toEqual(expect.objectContaining({ method: "POST" }));
   });
 });

--- a/frontend/src/startup/StartupGate.tsx
+++ b/frontend/src/startup/StartupGate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 
 import { useTheme } from "../hooks/useTheme";
+import { apiFetch } from "../api/api";
 
 type StartupStatus =
   | { state: "terms_required" }
@@ -70,21 +71,21 @@ export function StartupGate({ children }: { children: ReactNode }) {
   }, []);
 
   const acceptGemma = async () => {
-    const response = await fetch("/api/model/accept-gemma", { method: "POST" });
+    const response = await apiFetch("/api/model/accept-gemma", { method: "POST" });
     if (response.ok) {
       setStatus({ state: "downloading", model: "EmbeddingGemma 300M Q4" });
     }
   };
 
   const declineGemma = async () => {
-    const response = await fetch("/api/model/decline-gemma", { method: "POST" });
+    const response = await apiFetch("/api/model/decline-gemma", { method: "POST" });
     if (response.ok) {
       setStatus({ state: "downloading", model: "Nomic Embed Text v1.5" });
     }
   };
 
   const retryModelSetup = async () => {
-    const response = await fetch("/api/model/retry", { method: "POST" });
+    const response = await apiFetch("/api/model/retry", { method: "POST" });
     if (response.ok) {
       setStatus({ state: "downloading" });
     }

--- a/frontend/src/startup/StartupGate.tsx
+++ b/frontend/src/startup/StartupGate.tsx
@@ -3,6 +3,14 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useTheme } from "../hooks/useTheme";
 
 type StartupStatus =
+  | { state: "terms_required" }
+  | {
+      state: "downloading";
+      model?: string;
+      downloaded_bytes?: number;
+      total_bytes?: number;
+      percent?: number;
+    }
   | { state: "scanning" }
   | {
       state: "indexing";
@@ -61,16 +69,41 @@ export function StartupGate({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  const acceptGemma = async () => {
+    const response = await fetch("/api/model/accept-gemma", { method: "POST" });
+    if (response.ok) {
+      setStatus({ state: "downloading", model: "EmbeddingGemma 300M Q4" });
+    }
+  };
+
+  const declineGemma = async () => {
+    const response = await fetch("/api/model/decline-gemma", { method: "POST" });
+    if (response.ok) {
+      setStatus({ state: "downloading", model: "Nomic Embed Text v1.5" });
+    }
+  };
+
+  const retryModelSetup = async () => {
+    const response = await fetch("/api/model/retry", { method: "POST" });
+    if (response.ok) {
+      setStatus({ state: "downloading" });
+    }
+  };
+
   if (status?.state === "ready") {
     return children;
   }
 
   const failed = status?.state === "failed";
   const indexing = status?.state === "indexing" ? status : null;
-  const percent = indexing?.percent ?? 0;
+  const downloading = status?.state === "downloading" ? status : null;
+  const termsRequired = status?.state === "terms_required";
+  const percent = indexing?.percent ?? downloading?.percent ?? 0;
   const eta = indexing?.eta_seconds;
   const progressLabel = indexing
     ? `${percent}% of embedding work complete`
+    : downloading?.percent !== undefined
+      ? `${percent}% of model download complete`
     : "Measuring the vault";
 
   return (
@@ -83,7 +116,9 @@ export function StartupGate({ children }: { children: ReactNode }) {
           </span>
           <span>HATCHDOOR</span>
         </div>
-        <span className="startup-crumb">Preparing vault</span>
+        <span className="startup-crumb">
+          {termsRequired ? "Model setup" : "Preparing vault"}
+        </span>
         <button
           type="button"
           className="icon-button startup-theme"
@@ -95,34 +130,82 @@ export function StartupGate({ children }: { children: ReactNode }) {
       </header>
 
       <main className="startup-main">
-        <p className="startup-kicker">SEARCH INDEX</p>
-        <h1>{failed ? "Vault unavailable" : "Preparing your vault"}</h1>
-        <p className="startup-lede" aria-live="polite">
-          {failed
+        <p className="startup-kicker">{termsRequired ? "SEARCH MODEL" : "SEARCH INDEX"}</p>
+        <h1>
+          {termsRequired
+            ? "Set up multilingual search"
+            : failed
+              ? "Vault unavailable"
+              : "Preparing your vault"}
+        </h1>
+        {termsRequired ? (
+          <section className="startup-terms" aria-label="Gemma terms">
+            <p>
+              Hatchdoor can download EmbeddingGemma, a multilingual search
+              model licensed under Google’s Gemma Terms and Prohibited Use
+              Policy.
+            </p>
+            <p>
+              Accepting these terms only allows Hatchdoor to download and use
+              the Gemma model. It does not change ownership of your vault or
+              its contents. Hatchdoor does not send your notes to Google when
+              indexing or searching.
+            </p>
+            <p>
+              <a href="https://ai.google.dev/gemma/terms" target="_blank" rel="noreferrer">
+                Read Gemma Terms
+              </a>{" "}
+              <a
+                href="https://ai.google.dev/gemma/prohibited_use_policy"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Read Prohibited Use Policy
+              </a>
+            </p>
+            <div className="startup-actions">
+              <button type="button" className="startup-primary" onClick={() => void acceptGemma()}>
+                Accept terms and set up Gemma
+              </button>
+              <button type="button" className="startup-secondary" onClick={() => void declineGemma()}>
+                Use Nomic instead
+              </button>
+            </div>
+            <p className="startup-fallback-note">
+              Nomic is the no-extra-terms fallback. It is English-only and not
+              as good as Gemma for multilingual search.
+            </p>
+          </section>
+        ) : (
+          <p className="startup-lede" aria-live="polite">
+            {failed
             ? (status.message ?? "Indexing could not be completed.")
             : connectionIssue
               ? "Waiting for Hatchdoor to respond…"
+              : downloading
+                ? `Downloading ${downloading.model ?? "the search model"}. Your vault stays locked until setup is complete.`
               : indexing
                 ? "Building the search index. Your notes stay locked until it is ready."
                 : "Scanning notes and measuring the work ahead…"}
-        </p>
+          </p>
+        )}
 
-        {!failed ? (
+        {!failed && !termsRequired ? (
           <>
             <div
-              className={`startup-progress ${indexing ? "" : "is-indeterminate"}`}
+              className={`startup-progress ${indexing || downloading?.percent !== undefined ? "" : "is-indeterminate"}`}
               role="progressbar"
               aria-label={progressLabel}
               aria-valuemin={0}
               aria-valuemax={100}
-              aria-valuenow={indexing ? percent : undefined}
+              aria-valuenow={indexing || downloading?.percent !== undefined ? percent : undefined}
             >
               <span style={{ transform: `scaleX(${percent / 100})` }} />
             </div>
 
             <div className="startup-progress-line" aria-live="polite">
-              <strong>{indexing ? `${percent}%` : "Scanning"}</strong>
-              <span>{formatEta(eta)}</span>
+              <strong>{indexing || downloading?.percent !== undefined ? `${percent}%` : downloading ? "Downloading" : "Scanning"}</strong>
+              <span>{indexing ? formatEta(eta) : downloading ? formatDownload(downloading.downloaded_bytes, downloading.total_bytes) : formatEta(eta)}</span>
             </div>
 
             {indexing ? (
@@ -144,12 +227,19 @@ export function StartupGate({ children }: { children: ReactNode }) {
               </dl>
             ) : null}
           </>
-        ) : (
+        ) : failed ? (
           <p className="startup-failure-help">
-            Check the Hatchdoor logs, correct the indexing error, then restart
-            the service.
+            Check the Hatchdoor logs, then retry setup.
+            <br />
+            <button
+              type="button"
+              className="startup-secondary"
+              onClick={() => void retryModelSetup()}
+            >
+              Retry setup
+            </button>
           </p>
-        )}
+        ) : null}
       </main>
     </div>
   );
@@ -164,4 +254,14 @@ function formatEta(seconds?: number) {
   if (seconds < 45) return "Less than a minute remaining";
   const minutes = Math.max(1, Math.round(seconds / 60));
   return `About ${minutes} min remaining`;
+}
+
+function formatDownload(downloaded?: number, total?: number) {
+  if (downloaded === undefined || total === undefined) return "Connecting to model source";
+  return `${formatBytes(downloaded)} of ${formatBytes(total)}`;
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/frontend/src/styles/startup.css
+++ b/frontend/src/styles/startup.css
@@ -86,6 +86,43 @@
   line-height: 1.5;
 }
 
+.startup-terms {
+  max-width: 620px;
+  margin: var(--space-6) 0 var(--space-10);
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.startup-terms p { margin: 0 0 var(--space-4); }
+
+.startup-terms a {
+  color: var(--ink);
+  text-decoration-color: var(--hot);
+  text-underline-offset: 0.2em;
+}
+
+.startup-actions { display: flex; flex-wrap: wrap; gap: var(--space-3); margin-top: var(--space-6); }
+
+.startup-primary,
+.startup-secondary {
+  border: 1px solid var(--ink);
+  border-radius: 0;
+  padding: 0.72rem 1rem;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+  transition: transform var(--dur-fast) var(--ease), background var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+
+.startup-primary { background: var(--ink); color: var(--bg); }
+.startup-secondary { background: transparent; color: var(--ink); border-color: var(--rule-strong); }
+.startup-primary:hover { background: var(--hot); border-color: var(--hot); }
+.startup-secondary:hover { border-color: var(--ink); }
+.startup-primary:active, .startup-secondary:active { transform: translateY(1px); }
+
+.startup-fallback-note { font-size: 0.84rem; color: var(--muted); }
+
 .startup-progress {
   position: relative;
   height: 8px;

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -17,6 +17,7 @@ use crate::vault::{VaultIndex, VaultScanConfig, seed_empty_vault};
 #[derive(Clone)]
 pub struct AppState {
     pub vault_path: PathBuf,
+    pub cache_db_path: PathBuf,
     pub cache: Arc<RwLock<VaultCache>>,
     pub vault_revision: Arc<AtomicU64>,
     pub vault_events: broadcast::Sender<u64>,
@@ -27,6 +28,12 @@ pub struct AppState {
     /// backs the advertised `tools.listChanged` capability.
     pub mcp_tools_changed: broadcast::Sender<()>,
     pub embedder: Arc<dyn Embedder>,
+    /// Concrete startup slot behind `embedder`; populated only after a model is
+    /// selected and downloaded.
+    pub runtime_embedder: Arc<crate::embed::RuntimeEmbedder>,
+    pub model_setup: Arc<crate::model_setup::ModelSetup>,
+    pub model_setup_started: Arc<std::sync::atomic::AtomicBool>,
+    pub startup_git_config: Arc<Option<crate::git::GitConfig>>,
     /// True when the web API is protected by `HATCHDOOR_WEB_BEARER_TOKEN`.
     pub web_auth_enabled: bool,
     /// True when public demo browsing is enabled and app-level writes are blocked.
@@ -303,16 +310,24 @@ mod tests {
 
     fn state_with_vault(vault_path: PathBuf) -> AppState {
         let embedder = test_embedder();
+        let state_root = vault_path.parent().expect("vault parent").to_path_buf();
         let cache = build_cache(&vault_path, embedder.as_ref()).expect("build cache");
         let (vault_events, _) = broadcast::channel(64);
         let (mcp_tools_changed, _) = broadcast::channel(16);
         AppState {
             vault_path,
+            cache_db_path: state_root.join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(crate::embed::RuntimeEmbedder::new()),
+            model_setup: Arc::new(crate::model_setup::ModelSetup::new(
+                state_root.join("models"),
+            )),
+            model_setup_started: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),

--- a/src/bin/eval.rs
+++ b/src/bin/eval.rs
@@ -1,4 +1,6 @@
-use hatchdoor::embed::{Embedder, FastembedEmbedder, MatryoshkaEmbedder};
+use hatchdoor::embed::{
+    Embedder, FastembedEmbedder, MatryoshkaEmbedder, NomicV2Embedder, Qwen3Embedder,
+};
 use hatchdoor::rerank::{FastembedReranker, Reranker};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -9,9 +11,18 @@ use std::sync::Arc;
 /// is threaded through every subcommand.
 fn load_embedder(id: &str, dim: Option<usize>) -> Result<Arc<dyn Embedder>, String> {
     let base: Arc<dyn Embedder> = match id {
-        "BGESmallENV15" => Arc::new(FastembedEmbedder::bge_small()?),
+        // Control (current production).
         "NomicEmbedTextV15" => Arc::new(FastembedEmbedder::nomic_v1_5()?),
-        "MxbaiEmbedLargeV1" => Arc::new(FastembedEmbedder::mxbai_large()?),
+        // English-only floor (native ONNX).
+        "GTEBaseENV15" => Arc::new(FastembedEmbedder::gte_base_en()?),
+        // Midsize multilingual, Candle backend.
+        "NomicEmbedTextV2Moe" => Arc::new(NomicV2Embedder::load()?),
+        // Large multilingual ceiling, Candle backend (native 1024-dim; sweep at --dim 512).
+        "Qwen3Embedding0_6B" => Arc::new(Qwen3Embedder::load()?),
+        // Multilingual 4-bit ONNX challenger. Gemma terms: benchmark-only for now.
+        "EmbeddingGemma300MQ4" => Arc::new(FastembedEmbedder::embedding_gemma_300m_q4()?),
+        // Second midsize multilingual, user-defined ONNX (not a native enum model).
+        "SnowflakeArcticEmbedMV2" => Arc::new(FastembedEmbedder::arctic_m_v2()?),
         other => return Err(format!("unknown model id: {other}")),
     };
     match dim {
@@ -20,30 +31,54 @@ fn load_embedder(id: &str, dim: Option<usize>) -> Result<Arc<dyn Embedder>, Stri
     }
 }
 
-fn load_reranker(id: &str) -> Result<Arc<dyn Reranker>, String> {
+fn load_reranker(id: &str, max_pair_tokens: usize) -> Result<Arc<dyn Reranker>, String> {
     match id {
-        "JINARerankerV1TurboEn" => Ok(Arc::new(FastembedReranker::jina_v1_turbo()?)),
-        "JINARerankerV2BaseMultilingual" => {
-            Ok(Arc::new(FastembedReranker::jina_v2_multilingual()?))
-        }
+        "JINARerankerV1TurboEn" => Ok(Arc::new(
+            FastembedReranker::jina_v1_turbo_with_max_pair_tokens(max_pair_tokens)?,
+        )),
+        "JINARerankerV2BaseMultilingual" => Ok(Arc::new(
+            FastembedReranker::jina_v2_multilingual_with_max_pair_tokens(max_pair_tokens)?,
+        )),
+        "BGERerankerV2M3" => Ok(Arc::new(
+            FastembedReranker::bge_reranker_v2_m3_with_max_pair_tokens(max_pair_tokens)?,
+        )),
+        "GTEMultilingualRerankerBase" => Ok(Arc::new(
+            FastembedReranker::gte_multilingual_base_with_max_pair_tokens(max_pair_tokens)?,
+        )),
         other => Err(format!("unknown reranker id: {other}")),
     }
+}
+
+/// Peak resident set size of this process so far, in MiB. On Linux `ru_maxrss`
+/// is reported in kibibytes. Returns 0.0 if the syscall fails.
+fn peak_rss_mb() -> f64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return 0.0;
+    }
+    let usage = unsafe { usage.assume_init() };
+    usage.ru_maxrss as f64 / 1024.0
 }
 
 fn print_usage() {
     eprintln!(
         "usage:
-  eval build --model <id> --cache <path> [--max-tokens <n>] [--overlap <n>] [--no-context]
+  eval build --model <id> --cache <path> [--max-tokens <n>] [--overlap <n>] [--batch-size <n>] [--no-context]
   eval run --model <id> --cache <path> --queries <path>
-  eval rerank --model <id> --cache <path> --reranker <id> --queries <path> [--initial-k <n>]
+  eval rerank --model <id> --cache <path> --reranker <id> --queries <path> [--initial-k <n>] [--max-pair-tokens <n>]
   eval hybrid --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
   eval compare --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
+  eval prefetch   (loads every sweep model + smoke-tests one embedding each)
 
 --dim <n> (any subcommand): reduce vectors to n dims via Matryoshka truncation.
           Must match between build and query runs on the same cache.
 
-models:    BGESmallENV15 | NomicEmbedTextV15 | MxbaiEmbedLargeV1
-rerankers: JINARerankerV1TurboEn | JINARerankerV2BaseMultilingual"
+models:    NomicEmbedTextV15 (control) | GTEBaseENV15 | NomicEmbedTextV2Moe
+	           | Qwen3Embedding0_6B | EmbeddingGemma300MQ4 | SnowflakeArcticEmbedMV2
+rerankers: JINARerankerV1TurboEn | JINARerankerV2BaseMultilingual
+	   | BGERerankerV2M3 | GTEMultilingualRerankerBase
+
+--dim per model in the sweep: Nomic v2 & Arctic at 768/256; Qwen3 (native 1024) at 512."
     );
 }
 
@@ -65,6 +100,7 @@ enum Cmd {
         reranker: String,
         queries: PathBuf,
         initial_k: usize,
+        max_pair_tokens: usize,
     },
     Hybrid {
         model: String,
@@ -80,7 +116,21 @@ enum Cmd {
         initial_k: usize,
         rrf_k: usize,
     },
+    /// Load every sweep model and embed a probe string, validating each produces
+    /// a finite, correctly-sized vector. Warms the HF cache and fail-fast checks
+    /// the wiring before the full sweep.
+    Prefetch,
 }
+
+/// The locked benchmark model set (see the eval-model-benchmark-set design).
+const SWEEP_MODELS: &[&str] = &[
+    "NomicEmbedTextV15",
+    "GTEBaseENV15",
+    "NomicEmbedTextV2Moe",
+    "Qwen3Embedding0_6B",
+    "EmbeddingGemma300MQ4",
+    "SnowflakeArcticEmbedMV2",
+];
 
 fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
     let mut it = argv.into_iter().skip(1);
@@ -90,9 +140,11 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
     let mut queries: Option<PathBuf> = None;
     let mut reranker: Option<String> = None;
     let mut initial_k: Option<usize> = None;
+    let mut max_pair_tokens: Option<usize> = None;
     let mut rrf_k: Option<usize> = None;
     let mut max_tokens: Option<usize> = None;
     let mut overlap: Option<usize> = None;
+    let mut batch_size: Option<usize> = None;
     let mut no_context = false;
     let mut dim: Option<usize> = None;
     while let Some(arg) = it.next() {
@@ -112,6 +164,16 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
                     raw.parse::<usize>()
                         .map_err(|e| format!("invalid --overlap {raw}: {e}"))?,
                 );
+            }
+            "--batch-size" => {
+                let raw = it.next().ok_or("missing value for --batch-size")?;
+                let parsed = raw
+                    .parse::<usize>()
+                    .map_err(|e| format!("invalid --batch-size {raw}: {e}"))?;
+                if parsed == 0 {
+                    return Err("--batch-size must be at least 1".to_string());
+                }
+                batch_size = Some(parsed);
             }
             "--no-context" => no_context = true,
             "--dim" => {
@@ -134,6 +196,16 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
                         .map_err(|e| format!("invalid --initial-k {raw}: {e}"))?,
                 );
             }
+            "--max-pair-tokens" => {
+                let raw = it.next().ok_or("missing value for --max-pair-tokens")?;
+                let parsed = raw
+                    .parse::<usize>()
+                    .map_err(|e| format!("invalid --max-pair-tokens {raw}: {e}"))?;
+                if parsed == 0 {
+                    return Err("--max-pair-tokens must be at least 1".to_string());
+                }
+                max_pair_tokens = Some(parsed);
+            }
             "--rrf-k" => {
                 let raw = it.next().ok_or("missing value for --rrf-k")?;
                 rrf_k = Some(
@@ -143,6 +215,10 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
             }
             other => return Err(format!("unknown flag: {other}")),
         }
+    }
+    // Prefetch needs neither --model nor --cache; it iterates the whole set.
+    if sub == "prefetch" {
+        return Ok((Cmd::Prefetch, dim));
     }
     let model = model.ok_or("missing --model")?;
     let cache = cache.ok_or("missing --cache")?;
@@ -154,6 +230,9 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
             }
             if let Some(o) = overlap {
                 opts.chunk.overlap_tokens = o;
+            }
+            if let Some(n) = batch_size {
+                opts.embedding_batch_size = n;
             }
             opts.context = !no_context;
             if opts.chunk.overlap_tokens >= opts.chunk.max_tokens {
@@ -176,12 +255,14 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
             let queries = queries.ok_or("missing --queries")?;
             let reranker = reranker.ok_or("missing --reranker")?;
             let initial_k = initial_k.unwrap_or(20);
+            let max_pair_tokens = max_pair_tokens.unwrap_or(512);
             Ok(Cmd::Rerank {
                 model,
                 cache,
                 reranker,
                 queries,
                 initial_k,
+                max_pair_tokens,
             })
         }
         "hybrid" => {
@@ -268,6 +349,7 @@ fn main() -> ExitCode {
                 }
             };
 
+            let build_started_at = chrono::Utc::now();
             let started = std::time::Instant::now();
             if let Err(e) = sqlite.replace_from_index_with_options_stamped(
                 &index,
@@ -279,15 +361,49 @@ fn main() -> ExitCode {
                 return ExitCode::from(1);
             }
             let elapsed = started.elapsed();
+            let build_finished_at = chrono::Utc::now();
+            let peak_rss_mb = peak_rss_mb();
+
+            // Persist wall-clock build window + peak memory alongside the
+            // duration so the sweep can report them per cache. `ru_maxrss` is the
+            // process high-water mark, so it captures the model load + embedding
+            // peak — i.e. whether this model fits in the box's memory.
+            let started_iso = build_started_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let finished_iso = build_finished_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            // Also stamp the build config so `eval run` can label each results
+            // section — the report header is otherwise just the model id, which
+            // is identical across a model's chunk/context/dim cells.
+            let dim_str = dim
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "native".to_string());
+            for (k, v) in [
+                ("build_started_at", started_iso.clone()),
+                ("build_finished_at", finished_iso.clone()),
+                ("build_peak_rss_mb", format!("{peak_rss_mb:.1}")),
+                ("build_max_tokens", opts.chunk.max_tokens.to_string()),
+                ("build_overlap", opts.chunk.overlap_tokens.to_string()),
+                ("build_context", opts.context.to_string()),
+                ("build_batch_size", opts.embedding_batch_size.to_string()),
+                ("build_dim", dim_str),
+            ] {
+                if let Err(e) = sqlite.set_metadata(k, &v) {
+                    eprintln!("warning: failed to stamp {k}: {e}");
+                }
+            }
+
             println!(
-                "build config: max_tokens={} overlap={} context={}",
-                opts.chunk.max_tokens, opts.chunk.overlap_tokens, opts.context
+                "build config: max_tokens={} overlap={} batch_size={} context={}",
+                opts.chunk.max_tokens,
+                opts.chunk.overlap_tokens,
+                opts.embedding_batch_size,
+                opts.context
             );
             println!(
-                "build complete: model={model} cache={} elapsed={:.1}s",
+                "build complete: model={model} cache={} elapsed={:.1}s peak_rss={peak_rss_mb:.1}MB",
                 cache.display(),
                 elapsed.as_secs_f64()
             );
+            println!("build window: {started_iso} → {finished_iso}");
             ExitCode::SUCCESS
         }
         Cmd::Run {
@@ -336,11 +452,14 @@ fn main() -> ExitCode {
                 }
             }
 
-            let build_dur: Option<f64> = sqlite
-                .get_metadata("build_duration_secs")
-                .ok()
-                .flatten()
-                .and_then(|s| s.parse::<f64>().ok());
+            let meta_str = |key: &str| sqlite.get_metadata(key).ok().flatten();
+            let meta_f64 = |key: &str| meta_str(key).and_then(|s| s.parse::<f64>().ok());
+            let build_info = hatchdoor::eval::report::BuildInfo {
+                duration_secs: meta_f64("build_duration_secs"),
+                started_at: meta_str("build_started_at"),
+                finished_at: meta_str("build_finished_at"),
+                peak_rss_mb: meta_f64("build_peak_rss_mb"),
+            };
 
             let qs = match hatchdoor::eval::query::load_jsonl(&queries) {
                 Ok(qs) => qs,
@@ -374,7 +493,28 @@ fn main() -> ExitCode {
                 }
             }
 
-            let report = hatchdoor::eval::metrics::aggregate(&model, &qs, &results);
+            let mut report = hatchdoor::eval::metrics::aggregate(&model, &qs, &results);
+
+            // Label the report section with the build config read back from the
+            // cache, so a model's six chunk/context/dim cells are distinguishable
+            // in results.md instead of sharing one `## <model>` header.
+            if let (Some(mt), Some(ov)) = (meta_str("build_max_tokens"), meta_str("build_overlap"))
+            {
+                let ctx = match meta_str("build_context").as_deref() {
+                    Some("false") => "off",
+                    _ => "on",
+                };
+                let d = meta_str("build_dim").unwrap_or_else(|| "native".to_string());
+                let batch = meta_str("build_batch_size").unwrap_or_else(|| "1".to_string());
+                let report_model = if model == "EmbeddingGemma300MQ4" {
+                    "EmbeddingGemma300MQ4 · retrieval-format v1"
+                } else {
+                    &model
+                };
+                report.model_id = format!(
+                    "{report_model} — chunk {mt}/{ov} · ctx {ctx} · dim {d} · batch {batch}"
+                );
+            }
 
             println!("\nmodel: {}", report.model_id);
             println!("queries: {}", qs.len());
@@ -429,7 +569,7 @@ fn main() -> ExitCode {
 
             let report_path = std::path::PathBuf::from("eval/results.md");
             if let Err(e) =
-                hatchdoor::eval::report::append_section(&report_path, &report, build_dur)
+                hatchdoor::eval::report::append_section(&report_path, &report, &build_info)
             {
                 eprintln!("warning: failed to write report: {e}");
             } else {
@@ -443,6 +583,7 @@ fn main() -> ExitCode {
             reranker: reranker_id,
             queries,
             initial_k,
+            max_pair_tokens,
         } => {
             if !cache.exists() {
                 eprintln!(
@@ -458,7 +599,7 @@ fn main() -> ExitCode {
                     return ExitCode::from(1);
                 }
             };
-            let reranker = match load_reranker(&reranker_id) {
+            let reranker = match load_reranker(&reranker_id, max_pair_tokens) {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("error loading reranker: {e}");
@@ -495,13 +636,18 @@ fn main() -> ExitCode {
                 }
             };
 
-            let run_id = format!("{} + {}", model, reranker.id());
+            let run_id = format!(
+                "{} + {} · pair max {}",
+                model,
+                reranker.id(),
+                max_pair_tokens
+            );
             let report =
                 hatchdoor::eval::metrics::aggregate_rerank(&run_id, reranker.id(), &qs, &results);
 
             println!(
-                "rerank complete: model={model} reranker={} initial_k={initial_k}",
-                reranker.id()
+                "rerank complete: model={model} reranker={} initial_k={initial_k} max_pair_tokens={max_pair_tokens}",
+                reranker.id(),
             );
             println!("  Recall@5  (any): {:.3}", report.recall_at_5_any);
             println!("  Recall@5  (all): {:.3}", report.recall_at_5_all);
@@ -523,9 +669,12 @@ fn main() -> ExitCode {
             }
 
             let results_md = std::path::PathBuf::from("eval/results.md");
-            if let Err(e) =
-                hatchdoor::eval::report::append_rerank_section(&results_md, &report, initial_k)
-            {
+            if let Err(e) = hatchdoor::eval::report::append_rerank_section(
+                &results_md,
+                &report,
+                initial_k,
+                max_pair_tokens,
+            ) {
                 eprintln!(
                     "warning: failed to append section to {}: {e}",
                     results_md.display()
@@ -674,6 +823,57 @@ fn main() -> ExitCode {
             }
             ExitCode::SUCCESS
         }
+        Cmd::Prefetch => {
+            use std::io::Write;
+            let probe = vec!["search test".to_string()];
+            let mut failures = 0usize;
+            for id in SWEEP_MODELS {
+                print!("{id}: loading… ");
+                std::io::stdout().flush().ok();
+                match load_embedder(id, dim) {
+                    Ok(embedder) => match embedder.embed(&probe) {
+                        Ok(vecs) if !vecs.is_empty() => {
+                            let v = &vecs[0];
+                            let expected = embedder.embedding_dim();
+                            let dim_ok = v.len() == expected;
+                            let finite = v.iter().all(|x| x.is_finite());
+                            let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                            let ok = dim_ok && finite;
+                            if !ok {
+                                failures += 1;
+                            }
+                            println!(
+                                "dim={} (expected {expected}) norm={norm:.4} finite={finite} => {}",
+                                v.len(),
+                                if ok { "OK" } else { "FAIL" }
+                            );
+                        }
+                        Ok(_) => {
+                            failures += 1;
+                            println!("FAIL (empty output)");
+                        }
+                        Err(e) => {
+                            failures += 1;
+                            println!("FAIL (embed: {e})");
+                        }
+                    },
+                    Err(e) => {
+                        failures += 1;
+                        println!("FAIL (load: {e})");
+                    }
+                }
+            }
+            if failures == 0 {
+                println!(
+                    "\nAll {} models loaded and produced valid embeddings.",
+                    SWEEP_MODELS.len()
+                );
+                ExitCode::SUCCESS
+            } else {
+                eprintln!("\n{failures} model(s) failed.");
+                ExitCode::from(1)
+            }
+        }
         Cmd::Hybrid {
             model,
             cache,
@@ -797,6 +997,7 @@ mod tests {
                 assert_eq!(opts.chunk.max_tokens, 800);
                 assert_eq!(opts.chunk.overlap_tokens, 50);
                 assert!(opts.context);
+                assert_eq!(opts.embedding_batch_size, 1);
             }
             _ => panic!("wrong variant"),
         }
@@ -918,12 +1119,14 @@ mod tests {
                 reranker,
                 queries,
                 initial_k,
+                max_pair_tokens,
             } => {
                 assert_eq!(model, "NomicEmbedTextV15");
                 assert_eq!(cache, PathBuf::from("/c.db"));
                 assert_eq!(reranker, "JINARerankerV1TurboEn");
                 assert_eq!(queries, PathBuf::from("/q.jsonl"));
                 assert_eq!(initial_k, 30);
+                assert_eq!(max_pair_tokens, 512);
             }
             _ => panic!("wrong variant"),
         }
@@ -945,7 +1148,14 @@ mod tests {
         ]))
         .expect("parse");
         match cmd {
-            Cmd::Rerank { initial_k, .. } => assert_eq!(initial_k, 20),
+            Cmd::Rerank {
+                initial_k,
+                max_pair_tokens,
+                ..
+            } => {
+                assert_eq!(initial_k, 20);
+                assert_eq!(max_pair_tokens, 512);
+            }
             _ => panic!("wrong variant"),
         }
     }

--- a/src/bin/eval.rs
+++ b/src/bin/eval.rs
@@ -406,6 +406,20 @@ fn main() -> ExitCode {
                         .unwrap_or_else(|| "n/a".to_string()),
                 );
             }
+            for group in &report.per_tier {
+                println!(
+                    "  [tier     {:>14}] n={:<3} R@5={:.3} R@10={:.3} MRR={:.3} heading={}",
+                    group.label,
+                    group.n,
+                    group.recall_at_5_any,
+                    group.recall_at_10_any,
+                    group.mrr,
+                    group
+                        .correct_heading_rate
+                        .map(|r| format!("{r:.3}"))
+                        .unwrap_or_else(|| "n/a".to_string()),
+                );
+            }
             for group in &report.per_language {
                 println!(
                     "  [language {:>14}] n={:<3} R@5={:.3} R@10={:.3} MRR={:.3}",

--- a/src/bin/eval.rs
+++ b/src/bin/eval.rs
@@ -1,15 +1,22 @@
-use hatchdoor::embed::{Embedder, FastembedEmbedder};
+use hatchdoor::embed::{Embedder, FastembedEmbedder, MatryoshkaEmbedder};
 use hatchdoor::rerank::{FastembedReranker, Reranker};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
 
-fn load_embedder(id: &str) -> Result<Arc<dyn Embedder>, String> {
-    match id {
-        "BGESmallENV15" => Ok(Arc::new(FastembedEmbedder::bge_small()?)),
-        "NomicEmbedTextV15" => Ok(Arc::new(FastembedEmbedder::nomic_v1_5()?)),
-        "MxbaiEmbedLargeV1" => Ok(Arc::new(FastembedEmbedder::mxbai_large()?)),
-        other => Err(format!("unknown model id: {other}")),
+/// Load a model by id, optionally reduced to `dim` dimensions via Matryoshka
+/// truncation. `dim` must be applied identically at build and query time, so it
+/// is threaded through every subcommand.
+fn load_embedder(id: &str, dim: Option<usize>) -> Result<Arc<dyn Embedder>, String> {
+    let base: Arc<dyn Embedder> = match id {
+        "BGESmallENV15" => Arc::new(FastembedEmbedder::bge_small()?),
+        "NomicEmbedTextV15" => Arc::new(FastembedEmbedder::nomic_v1_5()?),
+        "MxbaiEmbedLargeV1" => Arc::new(FastembedEmbedder::mxbai_large()?),
+        other => return Err(format!("unknown model id: {other}")),
+    };
+    match dim {
+        Some(d) => Ok(Arc::new(MatryoshkaEmbedder::new(base, d)?)),
+        None => Ok(base),
     }
 }
 
@@ -26,11 +33,14 @@ fn load_reranker(id: &str) -> Result<Arc<dyn Reranker>, String> {
 fn print_usage() {
     eprintln!(
         "usage:
-  eval build --model <id> --cache <path>
+  eval build --model <id> --cache <path> [--max-tokens <n>] [--overlap <n>] [--no-context]
   eval run --model <id> --cache <path> --queries <path>
   eval rerank --model <id> --cache <path> --reranker <id> --queries <path> [--initial-k <n>]
   eval hybrid --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
   eval compare --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
+
+--dim <n> (any subcommand): reduce vectors to n dims via Matryoshka truncation.
+          Must match between build and query runs on the same cache.
 
 models:    BGESmallENV15 | NomicEmbedTextV15 | MxbaiEmbedLargeV1
 rerankers: JINARerankerV1TurboEn | JINARerankerV2BaseMultilingual"
@@ -42,6 +52,7 @@ enum Cmd {
     Build {
         model: String,
         cache: PathBuf,
+        opts: hatchdoor::cache::BuildOptions,
     },
     Run {
         model: String,
@@ -71,7 +82,7 @@ enum Cmd {
     },
 }
 
-fn parse_args(argv: Vec<String>) -> Result<Cmd, String> {
+fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
     let mut it = argv.into_iter().skip(1);
     let sub = it.next().ok_or_else(|| "missing subcommand".to_string())?;
     let mut model: Option<String> = None;
@@ -80,10 +91,36 @@ fn parse_args(argv: Vec<String>) -> Result<Cmd, String> {
     let mut reranker: Option<String> = None;
     let mut initial_k: Option<usize> = None;
     let mut rrf_k: Option<usize> = None;
+    let mut max_tokens: Option<usize> = None;
+    let mut overlap: Option<usize> = None;
+    let mut no_context = false;
+    let mut dim: Option<usize> = None;
     while let Some(arg) = it.next() {
         match arg.as_str() {
             "--model" => model = Some(it.next().ok_or("missing value for --model")?),
             "--cache" => cache = Some(PathBuf::from(it.next().ok_or("missing value for --cache")?)),
+            "--max-tokens" => {
+                let raw = it.next().ok_or("missing value for --max-tokens")?;
+                max_tokens = Some(
+                    raw.parse::<usize>()
+                        .map_err(|e| format!("invalid --max-tokens {raw}: {e}"))?,
+                );
+            }
+            "--overlap" => {
+                let raw = it.next().ok_or("missing value for --overlap")?;
+                overlap = Some(
+                    raw.parse::<usize>()
+                        .map_err(|e| format!("invalid --overlap {raw}: {e}"))?,
+                );
+            }
+            "--no-context" => no_context = true,
+            "--dim" => {
+                let raw = it.next().ok_or("missing value for --dim")?;
+                dim = Some(
+                    raw.parse::<usize>()
+                        .map_err(|e| format!("invalid --dim {raw}: {e}"))?,
+                );
+            }
             "--queries" => {
                 queries = Some(PathBuf::from(
                     it.next().ok_or("missing value for --queries")?,
@@ -109,8 +146,24 @@ fn parse_args(argv: Vec<String>) -> Result<Cmd, String> {
     }
     let model = model.ok_or("missing --model")?;
     let cache = cache.ok_or("missing --cache")?;
-    match sub.as_str() {
-        "build" => Ok(Cmd::Build { model, cache }),
+    let cmd = match sub.as_str() {
+        "build" => {
+            let mut opts = hatchdoor::cache::BuildOptions::default();
+            if let Some(m) = max_tokens {
+                opts.chunk.max_tokens = m;
+            }
+            if let Some(o) = overlap {
+                opts.chunk.overlap_tokens = o;
+            }
+            opts.context = !no_context;
+            if opts.chunk.overlap_tokens >= opts.chunk.max_tokens {
+                return Err(format!(
+                    "--overlap ({}) must be smaller than --max-tokens ({})",
+                    opts.chunk.overlap_tokens, opts.chunk.max_tokens
+                ));
+            }
+            Ok(Cmd::Build { model, cache, opts })
+        }
         "run" => {
             let queries = queries.ok_or("missing --queries")?;
             Ok(Cmd::Run {
@@ -156,12 +209,13 @@ fn parse_args(argv: Vec<String>) -> Result<Cmd, String> {
             })
         }
         other => Err(format!("unknown subcommand: {other}")),
-    }
+    }?;
+    Ok((cmd, dim))
 }
 
 fn main() -> ExitCode {
     dotenvy::dotenv().ok();
-    let cmd = match parse_args(std::env::args().collect()) {
+    let (cmd, dim) = match parse_args(std::env::args().collect()) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("error: {e}");
@@ -170,7 +224,7 @@ fn main() -> ExitCode {
         }
     };
     match cmd {
-        Cmd::Build { model, cache } => {
+        Cmd::Build { model, cache, opts } => {
             tracing_subscriber::fmt()
                 .with_env_filter(
                     tracing_subscriber::EnvFilter::try_from_default_env()
@@ -181,7 +235,7 @@ fn main() -> ExitCode {
             let vault_path = std::env::var("VAULT_PATH").unwrap_or_else(|_| "./vault".to_string());
             let vault_path = std::path::PathBuf::from(vault_path);
 
-            let embedder = match load_embedder(&model) {
+            let embedder = match load_embedder(&model, dim) {
                 Ok(e) => e,
                 Err(e) => {
                     eprintln!("error: {e}");
@@ -215,13 +269,20 @@ fn main() -> ExitCode {
             };
 
             let started = std::time::Instant::now();
-            if let Err(e) =
-                sqlite.replace_from_index_with_embedder_stamped(&index, embedder.as_ref(), &model)
-            {
+            if let Err(e) = sqlite.replace_from_index_with_options_stamped(
+                &index,
+                embedder.as_ref(),
+                &model,
+                &opts,
+            ) {
                 eprintln!("error populating cache: {e}");
                 return ExitCode::from(1);
             }
             let elapsed = started.elapsed();
+            println!(
+                "build config: max_tokens={} overlap={} context={}",
+                opts.chunk.max_tokens, opts.chunk.overlap_tokens, opts.context
+            );
             println!(
                 "build complete: model={model} cache={} elapsed={:.1}s",
                 cache.display(),
@@ -234,7 +295,7 @@ fn main() -> ExitCode {
             cache,
             queries,
         } => {
-            let embedder = match load_embedder(&model) {
+            let embedder = match load_embedder(&model, dim) {
                 Ok(e) => e,
                 Err(e) => {
                     eprintln!("error: {e}");
@@ -348,7 +409,7 @@ fn main() -> ExitCode {
                 );
                 return ExitCode::from(1);
             }
-            let embedder = match load_embedder(&model) {
+            let embedder = match load_embedder(&model, dim) {
                 Ok(e) => e,
                 Err(e) => {
                     eprintln!("error loading embedder: {e}");
@@ -444,7 +505,7 @@ fn main() -> ExitCode {
                 );
                 return ExitCode::from(1);
             }
-            let embedder = match load_embedder(&model) {
+            let embedder = match load_embedder(&model, dim) {
                 Ok(e) => e,
                 Err(e) => {
                     eprintln!("error loading embedder: {e}");
@@ -585,7 +646,7 @@ fn main() -> ExitCode {
                 );
                 return ExitCode::from(1);
             }
-            let embedder = match load_embedder(&model) {
+            let embedder = match load_embedder(&model, dim) {
                 Ok(e) => e,
                 Err(e) => {
                     eprintln!("error loading embedder: {e}");
@@ -675,7 +736,7 @@ mod tests {
 
     #[test]
     fn parses_build_command() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "build",
             "--model",
@@ -685,9 +746,15 @@ mod tests {
         ]))
         .expect("parse");
         match cmd {
-            Cmd::Build { model, cache } => {
+            Cmd::Build {
+                model, cache, opts, ..
+            } => {
                 assert_eq!(model, "BGESmallENV15");
                 assert_eq!(cache, PathBuf::from("/tmp/x.db"));
+                // Defaults when no build flags are passed.
+                assert_eq!(opts.chunk.max_tokens, 800);
+                assert_eq!(opts.chunk.overlap_tokens, 50);
+                assert!(opts.context);
             }
             _ => panic!("wrong variant"),
         }
@@ -695,7 +762,7 @@ mod tests {
 
     #[test]
     fn parses_run_command_with_queries() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "run",
             "--model",
@@ -722,7 +789,7 @@ mod tests {
 
     #[test]
     fn parses_compare_command() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "compare",
             "--model",
@@ -757,7 +824,7 @@ mod tests {
 
     #[test]
     fn parses_compare_command_defaults() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "compare",
             "--model",
@@ -787,7 +854,7 @@ mod tests {
 
     #[test]
     fn parses_rerank_command() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "rerank",
             "--model",
@@ -822,7 +889,7 @@ mod tests {
 
     #[test]
     fn parses_rerank_command_default_initial_k() {
-        let cmd = parse_args(argv(&[
+        let (cmd, _dim) = parse_args(argv(&[
             "eval",
             "rerank",
             "--model",

--- a/src/bin/eval.rs
+++ b/src/bin/eval.rs
@@ -31,20 +31,12 @@ fn load_embedder(id: &str, dim: Option<usize>) -> Result<Arc<dyn Embedder>, Stri
     }
 }
 
-fn load_reranker(id: &str, max_pair_tokens: usize) -> Result<Arc<dyn Reranker>, String> {
+fn load_reranker(id: &str) -> Result<Arc<dyn Reranker>, String> {
     match id {
-        "JINARerankerV1TurboEn" => Ok(Arc::new(
-            FastembedReranker::jina_v1_turbo_with_max_pair_tokens(max_pair_tokens)?,
-        )),
-        "JINARerankerV2BaseMultilingual" => Ok(Arc::new(
-            FastembedReranker::jina_v2_multilingual_with_max_pair_tokens(max_pair_tokens)?,
-        )),
-        "BGERerankerV2M3" => Ok(Arc::new(
-            FastembedReranker::bge_reranker_v2_m3_with_max_pair_tokens(max_pair_tokens)?,
-        )),
-        "GTEMultilingualRerankerBase" => Ok(Arc::new(
-            FastembedReranker::gte_multilingual_base_with_max_pair_tokens(max_pair_tokens)?,
-        )),
+        "JINARerankerV1TurboEn" => Ok(Arc::new(FastembedReranker::jina_v1_turbo()?)),
+        "JINARerankerV2BaseMultilingual" => {
+            Ok(Arc::new(FastembedReranker::jina_v2_multilingual()?))
+        }
         other => Err(format!("unknown reranker id: {other}")),
     }
 }
@@ -65,7 +57,7 @@ fn print_usage() {
         "usage:
   eval build --model <id> --cache <path> [--max-tokens <n>] [--overlap <n>] [--batch-size <n>] [--no-context]
   eval run --model <id> --cache <path> --queries <path>
-  eval rerank --model <id> --cache <path> --reranker <id> --queries <path> [--initial-k <n>] [--max-pair-tokens <n>]
+  eval rerank --model <id> --cache <path> --reranker <id> --queries <path> [--initial-k <n>]
   eval hybrid --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
   eval compare --model <id> --cache <path> --queries <path> [--initial-k <n>] [--rrf-k <n>]
   eval prefetch   (loads every sweep model + smoke-tests one embedding each)
@@ -76,7 +68,6 @@ fn print_usage() {
 models:    NomicEmbedTextV15 (control) | GTEBaseENV15 | NomicEmbedTextV2Moe
 	           | Qwen3Embedding0_6B | EmbeddingGemma300MQ4 | SnowflakeArcticEmbedMV2
 rerankers: JINARerankerV1TurboEn | JINARerankerV2BaseMultilingual
-	   | BGERerankerV2M3 | GTEMultilingualRerankerBase
 
 --dim per model in the sweep: Nomic v2 & Arctic at 768/256; Qwen3 (native 1024) at 512."
     );
@@ -100,7 +91,6 @@ enum Cmd {
         reranker: String,
         queries: PathBuf,
         initial_k: usize,
-        max_pair_tokens: usize,
     },
     Hybrid {
         model: String,
@@ -140,7 +130,6 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
     let mut queries: Option<PathBuf> = None;
     let mut reranker: Option<String> = None;
     let mut initial_k: Option<usize> = None;
-    let mut max_pair_tokens: Option<usize> = None;
     let mut rrf_k: Option<usize> = None;
     let mut max_tokens: Option<usize> = None;
     let mut overlap: Option<usize> = None;
@@ -196,16 +185,6 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
                         .map_err(|e| format!("invalid --initial-k {raw}: {e}"))?,
                 );
             }
-            "--max-pair-tokens" => {
-                let raw = it.next().ok_or("missing value for --max-pair-tokens")?;
-                let parsed = raw
-                    .parse::<usize>()
-                    .map_err(|e| format!("invalid --max-pair-tokens {raw}: {e}"))?;
-                if parsed == 0 {
-                    return Err("--max-pair-tokens must be at least 1".to_string());
-                }
-                max_pair_tokens = Some(parsed);
-            }
             "--rrf-k" => {
                 let raw = it.next().ok_or("missing value for --rrf-k")?;
                 rrf_k = Some(
@@ -255,14 +234,12 @@ fn parse_args(argv: Vec<String>) -> Result<(Cmd, Option<usize>), String> {
             let queries = queries.ok_or("missing --queries")?;
             let reranker = reranker.ok_or("missing --reranker")?;
             let initial_k = initial_k.unwrap_or(20);
-            let max_pair_tokens = max_pair_tokens.unwrap_or(512);
             Ok(Cmd::Rerank {
                 model,
                 cache,
                 reranker,
                 queries,
                 initial_k,
-                max_pair_tokens,
             })
         }
         "hybrid" => {
@@ -583,7 +560,6 @@ fn main() -> ExitCode {
             reranker: reranker_id,
             queries,
             initial_k,
-            max_pair_tokens,
         } => {
             if !cache.exists() {
                 eprintln!(
@@ -599,7 +575,7 @@ fn main() -> ExitCode {
                     return ExitCode::from(1);
                 }
             };
-            let reranker = match load_reranker(&reranker_id, max_pair_tokens) {
+            let reranker = match load_reranker(&reranker_id) {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("error loading reranker: {e}");
@@ -636,18 +612,13 @@ fn main() -> ExitCode {
                 }
             };
 
-            let run_id = format!(
-                "{} + {} · pair max {}",
-                model,
-                reranker.id(),
-                max_pair_tokens
-            );
+            let run_id = format!("{} + {}", model, reranker.id());
             let report =
                 hatchdoor::eval::metrics::aggregate_rerank(&run_id, reranker.id(), &qs, &results);
 
             println!(
-                "rerank complete: model={model} reranker={} initial_k={initial_k} max_pair_tokens={max_pair_tokens}",
-                reranker.id(),
+                "rerank complete: model={model} reranker={} initial_k={initial_k}",
+                reranker.id()
             );
             println!("  Recall@5  (any): {:.3}", report.recall_at_5_any);
             println!("  Recall@5  (all): {:.3}", report.recall_at_5_all);
@@ -669,12 +640,9 @@ fn main() -> ExitCode {
             }
 
             let results_md = std::path::PathBuf::from("eval/results.md");
-            if let Err(e) = hatchdoor::eval::report::append_rerank_section(
-                &results_md,
-                &report,
-                initial_k,
-                max_pair_tokens,
-            ) {
+            if let Err(e) =
+                hatchdoor::eval::report::append_rerank_section(&results_md, &report, initial_k)
+            {
                 eprintln!(
                     "warning: failed to append section to {}: {e}",
                     results_md.display()
@@ -1119,14 +1087,12 @@ mod tests {
                 reranker,
                 queries,
                 initial_k,
-                max_pair_tokens,
             } => {
                 assert_eq!(model, "NomicEmbedTextV15");
                 assert_eq!(cache, PathBuf::from("/c.db"));
                 assert_eq!(reranker, "JINARerankerV1TurboEn");
                 assert_eq!(queries, PathBuf::from("/q.jsonl"));
                 assert_eq!(initial_k, 30);
-                assert_eq!(max_pair_tokens, 512);
             }
             _ => panic!("wrong variant"),
         }
@@ -1148,14 +1114,7 @@ mod tests {
         ]))
         .expect("parse");
         match cmd {
-            Cmd::Rerank {
-                initial_k,
-                max_pair_tokens,
-                ..
-            } => {
-                assert_eq!(initial_k, 20);
-                assert_eq!(max_pair_tokens, 512);
-            }
+            Cmd::Rerank { initial_k, .. } => assert_eq!(initial_k, 20),
             _ => panic!("wrong variant"),
         }
     }

--- a/src/bin/eval.rs
+++ b/src/bin/eval.rs
@@ -354,10 +354,13 @@ fn main() -> ExitCode {
             for q in &qs {
                 match sqlite.semantic_search(embedder.as_ref(), &q.query, 10) {
                     Ok(hits) => {
-                        let top_k: Vec<String> = hits.into_iter().map(|h| h.note_slug).collect();
+                        let top_k: Vec<String> = hits.iter().map(|h| h.note_slug.clone()).collect();
+                        let top_k_headings: Vec<Option<String>> =
+                            hits.iter().map(|h| h.heading_path.clone()).collect();
                         results.push(hatchdoor::eval::metrics::QueryResult {
                             query_id: q.id.clone(),
                             top_k,
+                            top_k_headings,
                         });
                     }
                     Err(e) => {
@@ -365,6 +368,7 @@ fn main() -> ExitCode {
                         results.push(hatchdoor::eval::metrics::QueryResult {
                             query_id: q.id.clone(),
                             top_k: Vec::new(),
+                            top_k_headings: Vec::new(),
                         });
                     }
                 }
@@ -384,6 +388,30 @@ fn main() -> ExitCode {
             );
             println!("MRR:                 {:.3}", report.mrr);
             println!("FP-rate@5:           {:.3}", report.fp_rate_at_5);
+            match report.correct_heading_rate {
+                Some(rate) => println!("Correct-heading:     {rate:.3}"),
+                None => println!("Correct-heading:     n/a (no heading-scoped queries)"),
+            }
+            for group in &report.per_category {
+                println!(
+                    "  [category {:>14}] n={:<3} R@5={:.3} R@10={:.3} MRR={:.3} heading={}",
+                    group.label,
+                    group.n,
+                    group.recall_at_5_any,
+                    group.recall_at_10_any,
+                    group.mrr,
+                    group
+                        .correct_heading_rate
+                        .map(|r| format!("{r:.3}"))
+                        .unwrap_or_else(|| "n/a".to_string()),
+                );
+            }
+            for group in &report.per_language {
+                println!(
+                    "  [language {:>14}] n={:<3} R@5={:.3} R@10={:.3} MRR={:.3}",
+                    group.label, group.n, group.recall_at_5_any, group.recall_at_10_any, group.mrr,
+                );
+            }
 
             let report_path = std::path::PathBuf::from("eval/results.md");
             if let Err(e) =

--- a/src/bin/index_microbench.rs
+++ b/src/bin/index_microbench.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::time::{Duration, Instant};
 
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use hatchdoor::embed::contextual_document;
 use rusqlite::{Connection, OpenFlags};
 use tokenizers_fe::Tokenizer;
 
@@ -14,8 +15,23 @@ const SAMPLE_NOTES: usize = 16;
 struct CachedChunk {
     note_slug: String,
     ordinal: i64,
+    title: String,
+    heading_path: Option<String>,
     content: String,
     raw_tokens: usize,
+}
+
+impl CachedChunk {
+    /// The exact text the indexing pipeline embeds for this chunk: the model
+    /// document prefix wrapped around the shared contextual document (title +
+    /// heading path + body). Mirrors production so token counts and latency
+    /// stay representative.
+    fn embed_input(&self) -> String {
+        format!(
+            "{DOC_PREFIX}{}",
+            contextual_document(&self.title, self.heading_path.as_deref(), &self.content)
+        )
+    }
 }
 
 struct BenchResult {
@@ -117,17 +133,31 @@ fn load_model(max_length: usize) -> Result<TextEmbedding, String> {
     .map_err(|error| format!("failed loading Nomic model at max_length={max_length}: {error}"))
 }
 
-fn read_chunks(path: &str) -> Result<Vec<(String, i64, String)>, String> {
+type ChunkRow = (String, i64, String, Option<String>, String);
+
+fn read_chunks(path: &str) -> Result<Vec<ChunkRow>, String> {
     let connection = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .map_err(|error| format!("failed opening cache read-only: {error}"))?;
     let mut statement = connection
-        .prepare("SELECT note_slug, ordinal, content FROM chunks ORDER BY note_slug, ordinal")
+        .prepare(
+            "SELECT c.note_slug, c.ordinal, n.title, c.heading_path, c.content \
+             FROM chunks c JOIN notes n ON n.slug = c.note_slug \
+             ORDER BY c.note_slug, c.ordinal",
+        )
         .map_err(|error| format!("failed preparing chunk query: {error}"))?;
     let rows = statement
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })
         .map_err(|error| format!("failed querying chunks: {error}"))?;
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("failed reading chunks: {error}"))
@@ -143,23 +173,30 @@ fn untruncated_tokenizer(tokenizer: &Tokenizer) -> Result<Tokenizer, String> {
 }
 
 fn measure_raw_tokens(
-    rows: Vec<(String, i64, String)>,
+    rows: Vec<ChunkRow>,
     tokenizer: &Tokenizer,
 ) -> Result<Vec<CachedChunk>, String> {
     rows.into_iter()
-        .map(|(note_slug, ordinal, content)| {
-            let input = format!("{DOC_PREFIX}{content}");
-            let raw_tokens = tokenizer
-                .encode(input, true)
-                .map_err(|error| format!("failed tokenizing {note_slug}#{ordinal}: {error}"))?
-                .get_ids()
-                .len();
-            Ok(CachedChunk {
+        .map(|(note_slug, ordinal, title, heading_path, content)| {
+            let mut chunk = CachedChunk {
                 note_slug,
                 ordinal,
+                title,
+                heading_path,
                 content,
-                raw_tokens,
-            })
+                raw_tokens: 0,
+            };
+            chunk.raw_tokens = tokenizer
+                .encode(chunk.embed_input(), true)
+                .map_err(|error| {
+                    format!(
+                        "failed tokenizing {}#{}: {error}",
+                        chunk.note_slug, chunk.ordinal
+                    )
+                })?
+                .get_ids()
+                .len();
+            Ok(chunk)
         })
         .collect()
 }
@@ -238,7 +275,7 @@ fn bench_per_note(
     for note in notes {
         let inputs = note
             .iter()
-            .map(|chunk| format!("{DOC_PREFIX}{}", chunk.content))
+            .map(CachedChunk::embed_input)
             .collect::<Vec<_>>();
         vectors.extend(
             model
@@ -261,7 +298,7 @@ fn bench_individual(
     for chunk in notes.iter().flatten() {
         vectors.extend(
             model
-                .embed(vec![format!("{DOC_PREFIX}{}", chunk.content)], None)
+                .embed(vec![chunk.embed_input()], None)
                 .map_err(|error| {
                     format!(
                         "individual benchmark embed failed for {}#{}: {error}",

--- a/src/bin/index_microbench.rs
+++ b/src/bin/index_microbench.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use rusqlite::{Connection, OpenFlags};
-use tokenizers_v21::Tokenizer;
+use tokenizers_fe::Tokenizer;
 
 const DOC_PREFIX: &str = "search_document: ";
 const DEFAULT_CACHE: &str = "data/cache/hatchdoor-cache.sqlite3";

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -4,6 +4,7 @@ mod populate;
 mod queries;
 mod schema;
 
+pub use populate::BuildOptions;
 pub use queries::SemanticHit;
 
 use std::fs;

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -187,6 +187,7 @@ impl SqliteCache {
                     match prepare_note_for_embedding(
                         &tx,
                         slug,
+                        &entry.title,
                         content,
                         entry.layer.clone(),
                         embed_this_note,
@@ -1313,16 +1314,54 @@ struct PreparedNote {
     vector_reuse_elapsed: Duration,
 }
 
+/// Document-side embedding input: the note's contextual header (its title and
+/// the chunk's heading path) followed by the chunk body. Anchoring each chunk
+/// to its note and section keeps mid-note chunks from embedding as anonymous
+/// fragments. The model's `doc_prefix` is applied around this; queries are
+/// unchanged (asymmetric embedding, richer document side only).
+fn contextual_document(title: &str, heading_path: Option<&str>, body: &str) -> String {
+    let header = match heading_path {
+        Some(path) if !path.is_empty() => format!("{title} > {path}"),
+        _ => title.to_string(),
+    };
+    if header.is_empty() {
+        body.to_string()
+    } else {
+        format!("{header}\n\n{body}")
+    }
+}
+
+/// Reuse/change-detection hash for a chunk's *embedded input*, not just its
+/// body. Folding in the contextual header means a heading edit — which changes
+/// a downstream chunk's `heading_path` without touching its body — invalidates
+/// the cached vector instead of silently reusing one that no longer matches its
+/// input. The model `doc_prefix` is deliberately excluded: it is constant for a
+/// given model and any model change already forces a full rebuild via
+/// `Embedder::identity()`.
+fn embedding_reuse_hash(title: &str, heading_path: Option<&str>, body: &str) -> String {
+    let doc = contextual_document(title, heading_path, body);
+    blake3::hash(doc.as_bytes()).to_hex().to_string()
+}
+
 fn prepare_note_for_embedding(
     tx: &Transaction<'_>,
     slug: String,
+    title: &str,
     content: String,
     layer: Option<String>,
     embed: bool,
     embedder: &dyn Embedder,
 ) -> Result<PreparedNote, String> {
     let chunking_started = Instant::now();
-    let chunking = chunk_note(&content, embedder, ChunkOptions::default());
+    let mut chunking = chunk_note(&content, embedder, ChunkOptions::default());
+    // Rehash each chunk over its *embedded input* (title + heading path + body),
+    // not just its body. This is the vector-reuse key, so a heading edit — which
+    // changes a downstream chunk's heading path without touching its body — now
+    // invalidates the cached vector instead of silently reusing a stale one.
+    for chunk in &mut chunking.chunks {
+        chunk.content_hash =
+            embedding_reuse_hash(title, chunk.heading_path.as_deref(), &chunk.content);
+    }
     let chunking_elapsed = chunking_started.elapsed();
 
     // A note we are not embedding still gets chunk rows (keyword search) but no
@@ -1355,7 +1394,10 @@ fn prepare_note_for_embedding(
         .chunks
         .iter()
         .map(|chunk| {
-            let input = format!("{doc_prefix}{}", chunk.content);
+            let input = format!(
+                "{doc_prefix}{}",
+                contextual_document(title, chunk.heading_path.as_deref(), &chunk.content)
+            );
             let input_tokens = embedder
                 .token_count(input.as_str(), true)
                 .map_err(|error| format!("failed measuring tokens for '{slug}': {error}"))?;
@@ -1370,7 +1412,10 @@ fn prepare_note_for_embedding(
     let mut indices_needing_embed: Vec<usize> = Vec::new();
     for (idx, chunk) in chunking.chunks.iter().enumerate() {
         if !preserved.contains_key(&chunk.content_hash) {
-            texts_to_embed.push(format!("{doc_prefix}{}", chunk.content));
+            texts_to_embed.push(format!(
+                "{doc_prefix}{}",
+                contextual_document(title, chunk.heading_path.as_deref(), &chunk.content)
+            ));
             indices_needing_embed.push(idx);
         }
     }
@@ -2160,8 +2205,9 @@ mod chunk_integration_tests {
     use tempfile::TempDir;
 
     use super::{
-        estimated_remaining, format_count, format_elapsed, format_eta, format_note_count,
-        indexing_progress_message, progress_log_delay,
+        contextual_document, embedding_reuse_hash, estimated_remaining, format_count,
+        format_elapsed, format_eta, format_note_count, indexing_progress_message,
+        progress_log_delay,
     };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
@@ -2523,5 +2569,179 @@ mod chunk_integration_tests {
             "about 3 minutes remaining"
         );
         assert_eq!(format_elapsed(Duration::from_secs(166)), "2m 46s");
+    }
+
+    #[test]
+    fn contextual_document_prepends_title_and_heading_path() {
+        let doc = contextual_document(
+            "Postgres runbook",
+            Some("Backups > Restoring"),
+            "Stop the service first.",
+        );
+        assert_eq!(
+            doc,
+            "Postgres runbook > Backups > Restoring\n\nStop the service first."
+        );
+    }
+
+    #[test]
+    fn contextual_document_without_heading_uses_title_only() {
+        let doc = contextual_document("Postgres runbook", None, "Stop the service first.");
+        assert_eq!(doc, "Postgres runbook\n\nStop the service first.");
+    }
+
+    #[test]
+    fn reuse_hash_changes_when_heading_changes_but_body_does_not() {
+        // A downstream chunk keeps its body when the heading above it is edited,
+        // but its embedded input (which now carries the heading path) changes,
+        // so its cached vector must be invalidated rather than reused.
+        let before = embedding_reuse_hash("Note", Some("Old heading"), "shared body");
+        let after = embedding_reuse_hash("Note", Some("New heading"), "shared body");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn reuse_hash_changes_when_title_changes_but_body_does_not() {
+        let before = embedding_reuse_hash("Alpha", None, "shared body");
+        let after = embedding_reuse_hash("Bravo", None, "shared body");
+        assert_ne!(before, after);
+    }
+
+    /// Records every text handed to `embed` so a test can assert the exact
+    /// document-side input, delegating the vectors to a deterministic stub.
+    struct RecordingEmbedder {
+        inner: StubEmbedder,
+        inputs: std::sync::Mutex<Vec<String>>,
+    }
+    impl RecordingEmbedder {
+        fn new(dim: usize) -> Self {
+            Self {
+                inner: StubEmbedder::new(dim),
+                inputs: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn recorded(&self) -> Vec<String> {
+            self.inputs.lock().expect("recording mutex").clone()
+        }
+    }
+    impl Embedder for RecordingEmbedder {
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+            self.inputs
+                .lock()
+                .expect("recording mutex")
+                .extend(texts.iter().cloned());
+            self.inner.embed(texts)
+        }
+        fn embedding_dim(&self) -> usize {
+            self.inner.embedding_dim()
+        }
+        fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+            self.inner.token_count(text, add_special_tokens)
+        }
+    }
+
+    #[test]
+    fn indexing_embeds_chunk_with_title_and_heading_context() {
+        let dir = make_vault(&[(
+            "Postgres runbook.md",
+            "# Backups\n\nStop the service first.",
+        )]);
+        let cache = SqliteCache::in_memory(384).expect("open");
+        let index = VaultIndex::build(dir.path()).expect("build");
+        let embedder = RecordingEmbedder::new(384);
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("populate");
+        let recorded = embedder.recorded();
+        assert!(
+            recorded
+                .iter()
+                .any(|t| t.starts_with("Postgres runbook > Backups\n\n")),
+            "embedded input should carry title + heading context, got: {recorded:?}"
+        );
+    }
+
+    #[test]
+    fn editing_a_heading_re_embeds_downstream_chunks_but_reuses_untouched_sections() {
+        // Section Alpha is large enough to span multiple chunks: its heading
+        // lives only in the first chunk, so later Alpha chunks keep their body
+        // verbatim while their heading path points at "Alpha". Section Beta is a
+        // separate, untouched section. Renaming the Alpha heading must re-embed
+        // ALL Alpha chunks (including the downstream body-unchanged ones, whose
+        // heading path changed) while Beta's chunk is reused. Under a body-only
+        // reuse key the downstream Alpha chunks would be wrongly reused.
+        let big_alpha_body = "alpha ".repeat(1200);
+        let note = format!("# Alpha\n\n{big_alpha_body}\n\n# Beta\n\nbeta body");
+        let dir = make_vault(&[("Runbook.md", note.as_str())]);
+        let cache = SqliteCache::in_memory(384).expect("open");
+
+        let first = RecordingEmbedder::new(384);
+        let index = VaultIndex::build(dir.path()).expect("build");
+        cache
+            .replace_from_index_with_embedder(&index, &first)
+            .expect("first populate");
+        let first_inputs = first.recorded();
+        let alpha_chunks = first_inputs
+            .iter()
+            .filter(|t| t.starts_with("Runbook > Alpha\n\n"))
+            .count();
+        assert!(
+            alpha_chunks >= 2,
+            "test needs Alpha to span multiple chunks, got {alpha_chunks}: {first_inputs:?}"
+        );
+
+        // Rename only the Alpha heading; every byte of body text is untouched.
+        std::fs::write(
+            dir.path().join("Runbook.md"),
+            note.replace("# Alpha", "# Alpha Prime"),
+        )
+        .expect("rewrite");
+
+        let second = RecordingEmbedder::new(384);
+        let reindex = VaultIndex::build(dir.path()).expect("rebuild");
+        cache
+            .replace_from_index_with_embedder(&reindex, &second)
+            .expect("second populate");
+        let second_inputs = second.recorded();
+
+        let re_embedded_alpha = second_inputs
+            .iter()
+            .filter(|t| t.starts_with("Runbook > Alpha Prime\n\n"))
+            .count();
+        assert_eq!(
+            re_embedded_alpha, alpha_chunks,
+            "every Alpha chunk must re-embed under the renamed heading, including \
+             downstream chunks whose body did not change; got {second_inputs:?}"
+        );
+        assert!(
+            !second_inputs.iter().any(|t| t.contains("> Beta\n\n")),
+            "the untouched Beta section must be reused, not re-embedded; got {second_inputs:?}"
+        );
+    }
+
+    #[test]
+    fn indexing_stores_header_inclusive_reuse_hash() {
+        let dir = make_vault(&[("Runbook.md", "# Backups\n\nrestore steps")]);
+        let cache = SqliteCache::in_memory(384).expect("open");
+        let index = VaultIndex::build(dir.path()).expect("build");
+        let embedder = StubEmbedder::new(384);
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("populate");
+        let (content, heading_path, stored_hash): (String, Option<String>, String) = cache
+            .connection()
+            .expect("conn")
+            .query_row(
+                "SELECT content, heading_path, content_hash FROM chunks WHERE note_slug = ?1",
+                ["runbook"],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("chunk row");
+        let expected = embedding_reuse_hash("Runbook", heading_path.as_deref(), &content);
+        assert_eq!(
+            stored_hash, expected,
+            "stored chunk hash must be over the contextual document, so a heading \
+             edit invalidates the cached vector instead of reusing a stale one"
+        );
     }
 }

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -1314,23 +1314,6 @@ struct PreparedNote {
     vector_reuse_elapsed: Duration,
 }
 
-/// Document-side embedding input: the note's contextual header (its title and
-/// the chunk's heading path) followed by the chunk body. Anchoring each chunk
-/// to its note and section keeps mid-note chunks from embedding as anonymous
-/// fragments. The model's `doc_prefix` is applied around this; queries are
-/// unchanged (asymmetric embedding, richer document side only).
-fn contextual_document(title: &str, heading_path: Option<&str>, body: &str) -> String {
-    let header = match heading_path {
-        Some(path) if !path.is_empty() => format!("{title} > {path}"),
-        _ => title.to_string(),
-    };
-    if header.is_empty() {
-        body.to_string()
-    } else {
-        format!("{header}\n\n{body}")
-    }
-}
-
 /// Reuse/change-detection hash for a chunk's *embedded input*, not just its
 /// body. Folding in the contextual header means a heading edit — which changes
 /// a downstream chunk's `heading_path` without touching its body — invalidates
@@ -1339,7 +1322,7 @@ fn contextual_document(title: &str, heading_path: Option<&str>, body: &str) -> S
 /// given model and any model change already forces a full rebuild via
 /// `Embedder::identity()`.
 fn embedding_reuse_hash(title: &str, heading_path: Option<&str>, body: &str) -> String {
-    let doc = contextual_document(title, heading_path, body);
+    let doc = crate::embed::contextual_document(title, heading_path, body);
     blake3::hash(doc.as_bytes()).to_hex().to_string()
 }
 
@@ -1396,7 +1379,11 @@ fn prepare_note_for_embedding(
         .map(|chunk| {
             let input = format!(
                 "{doc_prefix}{}",
-                contextual_document(title, chunk.heading_path.as_deref(), &chunk.content)
+                crate::embed::contextual_document(
+                    title,
+                    chunk.heading_path.as_deref(),
+                    &chunk.content
+                )
             );
             let input_tokens = embedder
                 .token_count(input.as_str(), true)
@@ -1414,7 +1401,11 @@ fn prepare_note_for_embedding(
         if !preserved.contains_key(&chunk.content_hash) {
             texts_to_embed.push(format!(
                 "{doc_prefix}{}",
-                contextual_document(title, chunk.heading_path.as_deref(), &chunk.content)
+                crate::embed::contextual_document(
+                    title,
+                    chunk.heading_path.as_deref(),
+                    &chunk.content
+                )
             ));
             indices_needing_embed.push(idx);
         }
@@ -2205,9 +2196,8 @@ mod chunk_integration_tests {
     use tempfile::TempDir;
 
     use super::{
-        contextual_document, embedding_reuse_hash, estimated_remaining, format_count,
-        format_elapsed, format_eta, format_note_count, indexing_progress_message,
-        progress_log_delay,
+        embedding_reuse_hash, estimated_remaining, format_count, format_elapsed, format_eta,
+        format_note_count, indexing_progress_message, progress_log_delay,
     };
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
@@ -2569,25 +2559,6 @@ mod chunk_integration_tests {
             "about 3 minutes remaining"
         );
         assert_eq!(format_elapsed(Duration::from_secs(166)), "2m 46s");
-    }
-
-    #[test]
-    fn contextual_document_prepends_title_and_heading_path() {
-        let doc = contextual_document(
-            "Postgres runbook",
-            Some("Backups > Restoring"),
-            "Stop the service first.",
-        );
-        assert_eq!(
-            doc,
-            "Postgres runbook > Backups > Restoring\n\nStop the service first."
-        );
-    }
-
-    #[test]
-    fn contextual_document_without_heading_uses_title_only() {
-        let doc = contextual_document("Postgres runbook", None, "Stop the service first.");
-        assert_eq!(doc, "Postgres runbook\n\nStop the service first.");
     }
 
     #[test]

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -34,6 +34,10 @@ pub struct BuildOptions {
     /// body-only reuse hash — kept so the benchmark can measure the header's
     /// contribution in isolation.
     pub context: bool,
+    /// Maximum number of same-note chunks submitted to one embedder call.
+    /// Production keeps the conservative one-input default; eval can raise this
+    /// to measure whether ONNX batching improves build throughput.
+    pub embedding_batch_size: usize,
 }
 
 impl Default for BuildOptions {
@@ -41,6 +45,7 @@ impl Default for BuildOptions {
         Self {
             chunk: ChunkOptions::default(),
             context: true,
+            embedding_batch_size: 1,
         }
     }
 }
@@ -477,11 +482,11 @@ impl IndexingMetrics {
             .extend(stats.embedding_input_token_lengths.iter().copied());
         if stats.embedder_calls > 0 {
             self.embedding_call_input_counts
-                .extend(std::iter::repeat_n(1, stats.embedder_calls));
+                .extend(stats.embedding_call_input_counts.iter().copied());
             self.embedding_call_token_counts
-                .extend(stats.embedding_input_token_lengths.iter().copied());
+                .extend(stats.embedding_call_token_counts.iter().copied());
             self.embedding_call_padded_token_counts
-                .extend(stats.embedding_input_token_lengths.iter().copied());
+                .extend(stats.embedding_call_padded_token_counts.iter().copied());
             self.embedding_call_durations
                 .extend(stats.embedding_call_durations.iter().copied());
         }
@@ -1339,6 +1344,9 @@ pub struct ChunkStats {
     pub embedding_input_tokens: usize,
     pub embedding_padded_tokens: usize,
     pub embedding_input_token_lengths: Vec<usize>,
+    embedding_call_input_counts: Vec<usize>,
+    embedding_call_token_counts: Vec<usize>,
+    embedding_call_padded_token_counts: Vec<usize>,
     embedding_call_durations: Vec<Duration>,
     chunk_measurements: Vec<ChunkMeasurement>,
     pub pipeline: Duration,
@@ -1369,18 +1377,16 @@ struct PreparedNote {
     indices_needing_embed: Vec<usize>,
     embedding_input_bytes: usize,
     embedding_input_token_lengths: Vec<usize>,
+    embedding_batch_size: usize,
     chunk_measurements: Vec<ChunkMeasurement>,
     chunking_elapsed: Duration,
     vector_reuse_elapsed: Duration,
 }
 
-/// Reuse/change-detection hash for a chunk's *embedded input*, not just its
-/// body. Folding in the contextual header means a heading edit — which changes
-/// a downstream chunk's `heading_path` without touching its body — invalidates
-/// the cached vector instead of silently reusing one that no longer matches its
-/// input. The model `doc_prefix` is deliberately excluded: it is constant for a
-/// given model and any model change already forces a full rebuild via
-/// `Embedder::identity()`.
+/// Reuse/change-detection hash for Hatchdoor's canonical contextual document.
+/// This is retained for tests; production vector reuse hashes the complete
+/// model-formatted embedding input in [`chunk_reuse_hash`].
+#[cfg(test)]
 fn embedding_reuse_hash(title: &str, heading_path: Option<&str>, body: &str) -> String {
     let doc = crate::embed::contextual_document(title, heading_path, body);
     blake3::hash(doc.as_bytes()).to_hex().to_string()
@@ -1389,29 +1395,29 @@ fn embedding_reuse_hash(title: &str, heading_path: Option<&str>, body: &str) -> 
 /// Vector-reuse key for a chunk under the active build options: header-inclusive
 /// when contextual embedding is on, body-only when off. The two representations
 /// must never collide in a shared cache, so they hash different inputs.
-fn chunk_reuse_hash(context: bool, title: &str, heading_path: Option<&str>, body: &str) -> String {
-    if context {
-        embedding_reuse_hash(title, heading_path, body)
-    } else {
-        blake3::hash(body.as_bytes()).to_hex().to_string()
-    }
+fn chunk_reuse_hash(
+    context: bool,
+    embedder: &dyn Embedder,
+    title: &str,
+    heading_path: Option<&str>,
+    body: &str,
+) -> String {
+    let input = chunk_embed_input(context, embedder, title, heading_path, body);
+    blake3::hash(input.as_bytes()).to_hex().to_string()
 }
 
 /// The document text embedded for a chunk under the active build options.
 fn chunk_embed_input(
     context: bool,
-    doc_prefix: &str,
+    embedder: &dyn Embedder,
     title: &str,
     heading_path: Option<&str>,
     body: &str,
 ) -> String {
     if context {
-        format!(
-            "{doc_prefix}{}",
-            crate::embed::contextual_document(title, heading_path, body)
-        )
+        embedder.document_input(title, heading_path, body)
     } else {
-        format!("{doc_prefix}{body}")
+        format!("{}{}", embedder.doc_prefix(), body)
     }
 }
 
@@ -1439,6 +1445,7 @@ fn prepare_note_for_embedding(
     for chunk in &mut chunking.chunks {
         chunk.content_hash = chunk_reuse_hash(
             opts.context,
+            embedder,
             title,
             chunk.heading_path.as_deref(),
             &chunk.content,
@@ -1459,6 +1466,7 @@ fn prepare_note_for_embedding(
             indices_needing_embed: Vec::new(),
             embedding_input_bytes: 0,
             embedding_input_token_lengths: Vec::new(),
+            embedding_batch_size: opts.embedding_batch_size,
             chunk_measurements: Vec::new(),
             chunking_elapsed,
             vector_reuse_elapsed: Duration::ZERO,
@@ -1471,14 +1479,13 @@ fn prepare_note_for_embedding(
         preserve_existing_vectors(tx, &slug, layer.as_deref(), &chunking.chunks, &existing)?;
     let vector_reuse_elapsed = reuse_started.elapsed();
 
-    let doc_prefix = embedder.doc_prefix();
     let chunk_measurements = chunking
         .chunks
         .iter()
         .map(|chunk| {
             let input = chunk_embed_input(
                 opts.context,
-                doc_prefix,
+                embedder,
                 title,
                 chunk.heading_path.as_deref(),
                 &chunk.content,
@@ -1499,7 +1506,7 @@ fn prepare_note_for_embedding(
         if !preserved.contains_key(&chunk.content_hash) {
             texts_to_embed.push(chunk_embed_input(
                 opts.context,
-                doc_prefix,
+                embedder,
                 title,
                 chunk.heading_path.as_deref(),
                 &chunk.content,
@@ -1537,6 +1544,7 @@ fn prepare_note_for_embedding(
         indices_needing_embed,
         embedding_input_bytes,
         embedding_input_token_lengths,
+        embedding_batch_size: opts.embedding_batch_size,
         chunk_measurements: embedded_chunk_measurements,
         chunking_elapsed,
         vector_reuse_elapsed,
@@ -1561,6 +1569,7 @@ fn embed_prepared_note(
         indices_needing_embed,
         embedding_input_bytes,
         embedding_input_token_lengths,
+        embedding_batch_size,
         chunk_measurements,
         chunking_elapsed,
         vector_reuse_elapsed,
@@ -1576,6 +1585,9 @@ fn embed_prepared_note(
             embedding_input_tokens: 0,
             embedding_padded_tokens: 0,
             embedding_input_token_lengths: Vec::new(),
+            embedding_call_input_counts: Vec::new(),
+            embedding_call_token_counts: Vec::new(),
+            embedding_call_padded_token_counts: Vec::new(),
             embedding_call_durations: Vec::new(),
             chunk_measurements: Vec::new(),
             pipeline: pipeline_started.elapsed() + chunking_elapsed + vector_reuse_elapsed,
@@ -1616,6 +1628,9 @@ fn embed_prepared_note(
             embedding_input_tokens: 0,
             embedding_padded_tokens: 0,
             embedding_input_token_lengths: Vec::new(),
+            embedding_call_input_counts: Vec::new(),
+            embedding_call_token_counts: Vec::new(),
+            embedding_call_padded_token_counts: Vec::new(),
             embedding_call_durations: Vec::new(),
             chunk_measurements: Vec::new(),
             pipeline: pipeline_started.elapsed() + chunking_elapsed + vector_reuse_elapsed,
@@ -1627,27 +1642,42 @@ fn embed_prepared_note(
     }
 
     let embedding_input_tokens: usize = embedding_input_token_lengths.iter().sum();
-    // Each chunk is embedded in its own call. This avoids BatchLongest padding
-    // short chunks to the longest sibling chunk in the same note.
-    let embedding_padded_tokens = embedding_input_tokens;
+    // The backend pads a batch to its longest input. Keep the batches within a
+    // note so vectors retain their original chunk order; the eval harness uses
+    // this controlled variant before considering a larger cross-note scheduler.
+    let batch_size = embedding_batch_size.max(1);
+    let mut embedding_padded_tokens = 0;
     let embedding_started = Instant::now();
     let mut new_vectors = Vec::with_capacity(texts_to_embed.len());
-    let mut embedding_call_durations = Vec::with_capacity(texts_to_embed.len());
-    for (text, input_tokens) in texts_to_embed
-        .iter()
-        .zip(embedding_input_token_lengths.iter().copied())
+    let calls = texts_to_embed.len().div_ceil(batch_size);
+    let mut embedding_call_durations = Vec::with_capacity(calls);
+    let mut embedding_call_input_counts = Vec::with_capacity(calls);
+    let mut embedding_call_token_counts = Vec::with_capacity(calls);
+    let mut embedding_call_padded_token_counts = Vec::with_capacity(calls);
+    for (texts, token_lengths) in texts_to_embed
+        .chunks(batch_size)
+        .zip(embedding_input_token_lengths.chunks(batch_size))
     {
+        let input_tokens: usize = token_lengths.iter().sum();
+        let padded_tokens = token_lengths.iter().copied().max().unwrap_or(0) * texts.len();
         let call_started = Instant::now();
-        let mut vectors = embedder.embed(std::slice::from_ref(text))?;
+        let vectors = embedder.embed(texts)?;
         embedding_call_durations.push(call_started.elapsed());
-        if vectors.len() != 1 {
+        if vectors.len() != texts.len() {
             return Err(format!(
-                "embedder returned {} vectors for one input",
-                vectors.len()
+                "embedder returned {} vectors for {} inputs",
+                vectors.len(),
+                texts.len()
             ));
         }
-        new_vectors.push(vectors.remove(0));
-        progress.chunks_processed.fetch_add(1, Ordering::Relaxed);
+        embedding_padded_tokens += padded_tokens;
+        embedding_call_input_counts.push(texts.len());
+        embedding_call_token_counts.push(input_tokens);
+        embedding_call_padded_token_counts.push(padded_tokens);
+        new_vectors.extend(vectors);
+        progress
+            .chunks_processed
+            .fetch_add(texts.len(), Ordering::Relaxed);
         progress
             .tokens_processed
             .fetch_add(input_tokens, Ordering::Relaxed);
@@ -1679,7 +1709,8 @@ fn embed_prepared_note(
                 .unwrap_or(0),
             elapsed_ms = duration_ms(embedding_elapsed),
             tokens_per_second,
-            calls = texts_to_embed.len(),
+            calls,
+            batch_size,
             "Embedding note performance"
         );
     }
@@ -1725,11 +1756,14 @@ fn embed_prepared_note(
     Ok(ChunkStats {
         embedded: indices_needing_embed.len(),
         reused: chunking.chunks.len() - indices_needing_embed.len(),
-        embedder_calls: texts_to_embed.len(),
+        embedder_calls: calls,
         embedding_input_bytes,
         embedding_input_tokens,
         embedding_padded_tokens,
         embedding_input_token_lengths,
+        embedding_call_input_counts,
+        embedding_call_token_counts,
+        embedding_call_padded_token_counts,
         embedding_call_durations,
         chunk_measurements,
         pipeline: pipeline_started.elapsed() + chunking_elapsed + vector_reuse_elapsed,
@@ -2568,7 +2602,23 @@ mod chunk_integration_tests {
                 .largest_batch
                 .load(std::sync::atomic::Ordering::SeqCst),
             1,
-            "indexing must avoid cross-chunk padding"
+            "the default must preserve one-input embedding calls"
+        );
+
+        let batched_cache = SqliteCache::in_memory(384).expect("open batched cache");
+        let batched_opts = BuildOptions {
+            embedding_batch_size: 2,
+            ..BuildOptions::default()
+        };
+        batched_cache
+            .replace_from_index_with_options(&index, &embedder, &batched_opts)
+            .expect("populate batched");
+        assert_eq!(
+            embedder
+                .largest_batch
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "a benchmark-selected batch size must reach the embedder"
         );
     }
 
@@ -2759,6 +2809,7 @@ mod chunk_integration_tests {
                 overlap_tokens: 5,
             },
             context: true,
+            embedding_batch_size: 1,
         };
         small_cache
             .replace_from_index_with_options(&index, &embedder, &opts)
@@ -2781,6 +2832,7 @@ mod chunk_integration_tests {
         let opts = BuildOptions {
             chunk: ChunkOptions::default(),
             context: false,
+            embedding_batch_size: 1,
         };
         cache
             .replace_from_index_with_options(&index, &embedder, &opts)

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -22,6 +22,29 @@ use super::parse::{
     file_snapshot, parse_frontmatter_metadata,
 };
 
+/// Build-time variables the benchmark can sweep. Production uses `Default`
+/// (800/50 chunks, contextual documents); the eval harness overrides them per
+/// cache to compare configurations. Model choice and vector dimension are
+/// carried by the embedder itself (see the Matryoshka decorator), not here.
+#[derive(Debug, Clone)]
+pub struct BuildOptions {
+    pub chunk: ChunkOptions,
+    /// When true, each chunk embeds with its title + heading-path header (and
+    /// hashes over that). When false, the pre-context behaviour: raw body only,
+    /// body-only reuse hash — kept so the benchmark can measure the header's
+    /// contribution in isolation.
+    pub context: bool,
+}
+
+impl Default for BuildOptions {
+    fn default() -> Self {
+        Self {
+            chunk: ChunkOptions::default(),
+            context: true,
+        }
+    }
+}
+
 pub enum UpsertOutcome {
     /// The note row was written; `content` is the file text already read (and
     /// hashed) during the upsert, threaded on so chunking reuses it instead of
@@ -52,7 +75,24 @@ impl SqliteCache {
         embedder: &dyn Embedder,
         on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
     ) -> Result<(), String> {
-        self.replace_with_options(index, embedder, on_progress, embed_layers_enabled())
+        self.replace_with_options(
+            index,
+            embedder,
+            on_progress,
+            embed_layers_enabled(),
+            &BuildOptions::default(),
+        )
+    }
+
+    /// Populate with explicit [`BuildOptions`] (chunk size, context toggle). The
+    /// benchmark entry point; production paths use the defaulting wrappers.
+    pub fn replace_from_index_with_options(
+        &self,
+        index: &VaultIndex,
+        embedder: &dyn Embedder,
+        opts: &BuildOptions,
+    ) -> Result<(), String> {
+        self.replace_with_options(index, embedder, None, embed_layers_enabled(), opts)
     }
 
     /// Core populate. `embed_layers` (`HATCHDOOR_EMBED_LAYERS`, default true)
@@ -66,6 +106,7 @@ impl SqliteCache {
         embedder: &dyn Embedder,
         on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
         embed_layers: bool,
+        opts: &BuildOptions,
     ) -> Result<(), String> {
         // If the embedding model changed since the last build, rebuild from
         // scratch so no vectors from the old model are reused (mixed-model vector
@@ -192,6 +233,7 @@ impl SqliteCache {
                         entry.layer.clone(),
                         embed_this_note,
                         embedder,
+                        opts,
                     ) {
                         Ok(prepared) => prepared_notes.push(prepared),
                         Err(error) => {
@@ -366,8 +408,26 @@ impl SqliteCache {
         embedder: &dyn Embedder,
         embedder_id: &str,
     ) -> Result<(), String> {
+        self.replace_from_index_with_options_stamped(
+            index,
+            embedder,
+            embedder_id,
+            &BuildOptions::default(),
+        )
+    }
+
+    /// Stamped populate with explicit [`BuildOptions`]. Records the model id and
+    /// build duration alongside the vectors so a benchmark cache is
+    /// self-describing.
+    pub fn replace_from_index_with_options_stamped(
+        &self,
+        index: &VaultIndex,
+        embedder: &dyn Embedder,
+        embedder_id: &str,
+        opts: &BuildOptions,
+    ) -> Result<(), String> {
         let started = std::time::Instant::now();
-        self.replace_from_index_with_embedder(index, embedder)?;
+        self.replace_from_index_with_options(index, embedder, opts)?;
         let secs = started.elapsed().as_secs_f64();
         self.set_metadata("embedder_id", embedder_id)?;
         self.set_metadata("build_duration_secs", &format!("{secs:.3}"))?;
@@ -1326,6 +1386,39 @@ fn embedding_reuse_hash(title: &str, heading_path: Option<&str>, body: &str) -> 
     blake3::hash(doc.as_bytes()).to_hex().to_string()
 }
 
+/// Vector-reuse key for a chunk under the active build options: header-inclusive
+/// when contextual embedding is on, body-only when off. The two representations
+/// must never collide in a shared cache, so they hash different inputs.
+fn chunk_reuse_hash(context: bool, title: &str, heading_path: Option<&str>, body: &str) -> String {
+    if context {
+        embedding_reuse_hash(title, heading_path, body)
+    } else {
+        blake3::hash(body.as_bytes()).to_hex().to_string()
+    }
+}
+
+/// The document text embedded for a chunk under the active build options.
+fn chunk_embed_input(
+    context: bool,
+    doc_prefix: &str,
+    title: &str,
+    heading_path: Option<&str>,
+    body: &str,
+) -> String {
+    if context {
+        format!(
+            "{doc_prefix}{}",
+            crate::embed::contextual_document(title, heading_path, body)
+        )
+    } else {
+        format!("{doc_prefix}{body}")
+    }
+}
+
+// Each parameter is a distinct, independently-sourced input (transaction, note
+// identity fields, the embedder, and the build options); bundling them into a
+// struct purely to satisfy the lint would add ceremony without clarity.
+#[allow(clippy::too_many_arguments)]
 fn prepare_note_for_embedding(
     tx: &Transaction<'_>,
     slug: String,
@@ -1334,16 +1427,22 @@ fn prepare_note_for_embedding(
     layer: Option<String>,
     embed: bool,
     embedder: &dyn Embedder,
+    opts: &BuildOptions,
 ) -> Result<PreparedNote, String> {
     let chunking_started = Instant::now();
-    let mut chunking = chunk_note(&content, embedder, ChunkOptions::default());
-    // Rehash each chunk over its *embedded input* (title + heading path + body),
-    // not just its body. This is the vector-reuse key, so a heading edit — which
-    // changes a downstream chunk's heading path without touching its body — now
-    // invalidates the cached vector instead of silently reusing a stale one.
+    let mut chunking = chunk_note(&content, embedder, opts.chunk);
+    // Rehash each chunk over its *embedded input* (title + heading path + body
+    // when contextual), not just its body. This is the vector-reuse key, so a
+    // heading edit — which changes a downstream chunk's heading path without
+    // touching its body — invalidates the cached vector instead of silently
+    // reusing a stale one.
     for chunk in &mut chunking.chunks {
-        chunk.content_hash =
-            embedding_reuse_hash(title, chunk.heading_path.as_deref(), &chunk.content);
+        chunk.content_hash = chunk_reuse_hash(
+            opts.context,
+            title,
+            chunk.heading_path.as_deref(),
+            &chunk.content,
+        );
     }
     let chunking_elapsed = chunking_started.elapsed();
 
@@ -1377,13 +1476,12 @@ fn prepare_note_for_embedding(
         .chunks
         .iter()
         .map(|chunk| {
-            let input = format!(
-                "{doc_prefix}{}",
-                crate::embed::contextual_document(
-                    title,
-                    chunk.heading_path.as_deref(),
-                    &chunk.content
-                )
+            let input = chunk_embed_input(
+                opts.context,
+                doc_prefix,
+                title,
+                chunk.heading_path.as_deref(),
+                &chunk.content,
             );
             let input_tokens = embedder
                 .token_count(input.as_str(), true)
@@ -1399,13 +1497,12 @@ fn prepare_note_for_embedding(
     let mut indices_needing_embed: Vec<usize> = Vec::new();
     for (idx, chunk) in chunking.chunks.iter().enumerate() {
         if !preserved.contains_key(&chunk.content_hash) {
-            texts_to_embed.push(format!(
-                "{doc_prefix}{}",
-                crate::embed::contextual_document(
-                    title,
-                    chunk.heading_path.as_deref(),
-                    &chunk.content
-                )
+            texts_to_embed.push(chunk_embed_input(
+                opts.context,
+                doc_prefix,
+                title,
+                chunk.heading_path.as_deref(),
+                &chunk.content,
             ));
             indices_needing_embed.push(idx);
         }
@@ -1720,7 +1817,13 @@ mod tests {
         let embedder = StubEmbedder::new(384);
         let index = VaultIndex::build(dir.path()).expect("index");
         cache
-            .replace_with_options(&index, &embedder, None, embed_layers)
+            .replace_with_options(
+                &index,
+                &embedder,
+                None,
+                embed_layers,
+                &BuildOptions::default(),
+            )
             .expect("populate");
         (dir, cache, embedder)
     }
@@ -1840,7 +1943,7 @@ mod tests {
         // Reindex the SAME vault (no content change) with the flag now true.
         let index = VaultIndex::build(dir.path()).expect("reindex");
         cache
-            .replace_with_options(&index, &embedder, None, true)
+            .replace_with_options(&index, &embedder, None, true, &BuildOptions::default())
             .expect("re-embed");
 
         let semantic = cache
@@ -2196,10 +2299,11 @@ mod chunk_integration_tests {
     use tempfile::TempDir;
 
     use super::{
-        embedding_reuse_hash, estimated_remaining, format_count, format_elapsed, format_eta,
-        format_note_count, indexing_progress_message, progress_log_delay,
+        BuildOptions, embedding_reuse_hash, estimated_remaining, format_count, format_elapsed,
+        format_eta, format_note_count, indexing_progress_message, progress_log_delay,
     };
     use crate::cache::SqliteCache;
+    use crate::chunk::ChunkOptions;
     use crate::embed::{Embedder, StubEmbedder};
     use crate::vault::VaultIndex;
 
@@ -2630,6 +2734,83 @@ mod chunk_integration_tests {
                 .any(|t| t.starts_with("Postgres runbook > Backups\n\n")),
             "embedded input should carry title + heading context, got: {recorded:?}"
         );
+    }
+
+    #[test]
+    fn build_options_chunk_size_controls_chunk_count() {
+        // A note that fits one default 800-token chunk splits into several under
+        // a small max_tokens, proving chunk options thread through the build.
+        let body = "word ".repeat(300);
+        let note = format!("# Note\n\n{body}");
+        let dir = make_vault(&[("Note.md", note.as_str())]);
+        let embedder = StubEmbedder::new(384);
+        let index = VaultIndex::build(dir.path()).expect("build");
+
+        let default_cache = SqliteCache::in_memory(384).expect("open");
+        default_cache
+            .replace_from_index_with_options(&index, &embedder, &BuildOptions::default())
+            .expect("default build");
+        let default_chunks = note_chunk_count(&default_cache, "note");
+
+        let small_cache = SqliteCache::in_memory(384).expect("open");
+        let opts = BuildOptions {
+            chunk: ChunkOptions {
+                max_tokens: 60,
+                overlap_tokens: 5,
+            },
+            context: true,
+        };
+        small_cache
+            .replace_from_index_with_options(&index, &embedder, &opts)
+            .expect("small build");
+        let small_chunks = note_chunk_count(&small_cache, "note");
+
+        assert_eq!(default_chunks, 1, "300 tokens fit one default chunk");
+        assert!(
+            small_chunks > default_chunks,
+            "60-token chunks must split the note: {small_chunks} vs {default_chunks}"
+        );
+    }
+
+    #[test]
+    fn build_options_context_off_embeds_raw_body_with_body_only_hash() {
+        let dir = make_vault(&[("Runbook.md", "# Backups\n\nrestore steps")]);
+        let cache = SqliteCache::in_memory(384).expect("open");
+        let embedder = RecordingEmbedder::new(384);
+        let index = VaultIndex::build(dir.path()).expect("build");
+        let opts = BuildOptions {
+            chunk: ChunkOptions::default(),
+            context: false,
+        };
+        cache
+            .replace_from_index_with_options(&index, &embedder, &opts)
+            .expect("populate");
+
+        let recorded = embedder.recorded();
+        assert!(
+            recorded.iter().any(|t| t == "# Backups\n\nrestore steps"),
+            "context off must embed the raw body, got: {recorded:?}"
+        );
+        assert!(
+            !recorded.iter().any(|t| t.contains("Runbook > Backups")),
+            "context off must not prepend the title/heading header: {recorded:?}"
+        );
+
+        // The stored reuse hash must be body-only when context is off, so the two
+        // representations never collide in a shared cache and reuse stays correct.
+        let stored: String = cache
+            .connection()
+            .expect("conn")
+            .query_row(
+                "SELECT content_hash FROM chunks WHERE note_slug = ?1",
+                ["runbook"],
+                |r| r.get(0),
+            )
+            .expect("hash");
+        let body_only = blake3::hash("# Backups\n\nrestore steps".as_bytes())
+            .to_hex()
+            .to_string();
+        assert_eq!(stored, body_only);
     }
 
     #[test]

--- a/src/chunk/chunker.rs
+++ b/src/chunk/chunker.rs
@@ -1,5 +1,8 @@
-use super::normalize::{extract_frontmatter_metadata, strip_code_fences, strip_frontmatter};
+use super::normalize::{
+    extract_frontmatter_metadata, in_fenced, strip_code_fences, strip_frontmatter,
+};
 use crate::embed::Embedder;
+use std::ops::Range;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
@@ -53,7 +56,7 @@ pub fn chunk_note(raw_content: &str, embedder: &dyn Embedder, opts: ChunkOptions
     let body = strip_frontmatter(raw_content);
     let normalized = strip_code_fences(body);
 
-    if normalized.trim().is_empty() {
+    if normalized.text.trim().is_empty() {
         return NoteChunking {
             chunks: Vec::new(),
             tags: metadata.tags,
@@ -68,12 +71,13 @@ pub fn chunk_note(raw_content: &str, embedder: &dyn Embedder, opts: ChunkOptions
     let splitter = MarkdownSplitter::new(config);
 
     let mut chunks = Vec::new();
-    for (ordinal, (byte_start, piece)) in splitter.chunk_indices(&normalized).enumerate() {
+    for (ordinal, (byte_start, piece)) in splitter.chunk_indices(&normalized.text).enumerate() {
         let byte_end = byte_start + piece.len();
         // Scan up to the start of the first non-heading content within this chunk
         // so that headings at the very beginning of a chunk are captured.
-        let heading_scan_end = heading_content_start(piece, byte_start);
-        let heading_path = derive_heading_path(&normalized, heading_scan_end);
+        let heading_scan_end = heading_content_start(piece, byte_start, &normalized.fenced);
+        let heading_path =
+            derive_heading_path(&normalized.text, heading_scan_end, &normalized.fenced);
         let content = piece.to_string();
         let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
         chunks.push(Chunk {
@@ -97,14 +101,18 @@ pub fn chunk_note(raw_content: &str, embedder: &dyn Embedder, opts: ChunkOptions
 /// Returns the byte offset (relative to `content` start) of the first non-heading
 /// line in `piece`, offset by `piece_start`. This allows headings that open a chunk
 /// to be included in the heading path scan.
-fn heading_content_start(piece: &str, piece_start: usize) -> usize {
+fn heading_content_start(piece: &str, piece_start: usize, fenced: &[Range<usize>]) -> usize {
     let mut offset = piece_start;
-    for line in piece.lines() {
-        let trimmed = line.trim_start();
+    for line in piece.split_inclusive('\n') {
+        let text = line.strip_suffix('\n').unwrap_or(line);
+        let text = text.strip_suffix('\r').unwrap_or(text);
+        let trimmed = text.trim_start();
         let level = trimmed.chars().take_while(|c| *c == '#').count();
-        if level > 0 && level <= 3 && !trimmed[level..].trim().is_empty() {
-            // This is a heading line; advance past it (+ 1 for '\n')
-            offset += line.len() + 1;
+        let is_heading = level > 0 && level <= 3 && !trimmed[level..].trim().is_empty();
+        // A `#`-prefixed line inside a fenced code block is not a heading.
+        if is_heading && !in_fenced(fenced, offset) {
+            // This is a heading line; advance past it (the '\n' is included).
+            offset += line.len();
         } else {
             // First non-heading content; stop here
             break;
@@ -114,11 +122,24 @@ fn heading_content_start(piece: &str, piece_start: usize) -> usize {
 }
 
 #[allow(dead_code)]
-fn derive_heading_path(content: &str, byte_offset: usize) -> Option<String> {
+fn derive_heading_path(
+    content: &str,
+    byte_offset: usize,
+    fenced: &[Range<usize>],
+) -> Option<String> {
     let prefix = &content[..byte_offset.min(content.len())];
     let mut stack: [Option<String>; 3] = [None, None, None];
-    for line in prefix.lines() {
-        let trimmed = line.trim_start();
+    let mut pos = 0usize;
+    for line in prefix.split_inclusive('\n') {
+        let line_start = pos;
+        pos += line.len();
+        // A `#`-prefixed line inside a fenced code block is not a heading.
+        if in_fenced(fenced, line_start) {
+            continue;
+        }
+        let text = line.strip_suffix('\n').unwrap_or(line);
+        let text = text.strip_suffix('\r').unwrap_or(text);
+        let trimmed = text.trim_start();
         let level = trimmed.chars().take_while(|c| *c == '#').count();
         if level == 0 || level > 3 {
             continue;
@@ -219,6 +240,49 @@ mod tests {
         let joined: String = result.chunks.iter().map(|c| c.content.clone()).collect();
         assert!(joined.contains("fn foo()"));
         assert!(!joined.contains("```"));
+    }
+
+    #[test]
+    fn shebang_and_comments_inside_code_fences_are_not_headings() {
+        // A `#!/...` shebang and a `# comment` inside a fenced block must not be
+        // parsed as ATX headings and pollute the heading path of later chunks.
+        let content = "\
+# Real Title
+
+```bash
+#!/usr/bin/env bash
+# not a heading
+echo one
+echo two
+```
+
+## Ownership handling
+
+body content that lands in a separate later chunk";
+        let opts = ChunkOptions {
+            max_tokens: 8,
+            overlap_tokens: 0,
+        };
+        let result = chunk(content, opts);
+        assert!(result.chunks.len() >= 2, "expected multiple chunks");
+        for c in &result.chunks {
+            let path = c.heading_path.as_deref().unwrap_or("");
+            assert!(
+                !path.contains("/usr/bin/env"),
+                "fenced shebang leaked into heading path: {path:?}"
+            );
+            assert!(
+                !path.contains("not a heading"),
+                "fenced comment leaked into heading path: {path:?}"
+            );
+        }
+        // The real heading after the fence is still derived correctly.
+        let last = result.chunks.last().expect("chunk");
+        let path = last.heading_path.as_deref().unwrap_or("");
+        assert!(
+            path.contains("Ownership handling"),
+            "real heading lost after fence: {path:?}"
+        );
     }
 
     #[test]

--- a/src/chunk/normalize.rs
+++ b/src/chunk/normalize.rs
@@ -32,16 +32,49 @@ pub fn strip_frontmatter(content: &str) -> &str {
     content
 }
 
+/// Result of [`strip_code_fences`]: the normalized body with fence marker lines
+/// removed but fence *contents* preserved, plus the byte ranges within `text`
+/// that fall inside fenced code blocks.
 #[allow(dead_code)]
-pub fn strip_code_fences(content: &str) -> String {
+pub struct Normalized {
+    pub text: String,
+    /// Byte ranges in `text` that lie inside fenced code blocks (marker lines
+    /// excluded). Sorted ascending and non-overlapping. Heading derivation must
+    /// skip lines whose start falls inside one of these, otherwise a
+    /// `#!/usr/bin/env bash` shebang or `#` comment inside a fence is mistaken
+    /// for an ATX heading.
+    pub fenced: Vec<std::ops::Range<usize>>,
+}
+
+/// Returns true if `pos` (a byte offset into `Normalized::text`) lies inside a
+/// fenced code block.
+#[allow(dead_code)]
+pub fn in_fenced(fenced: &[std::ops::Range<usize>], pos: usize) -> bool {
+    fenced.iter().any(|r| r.contains(&pos))
+}
+
+#[allow(dead_code)]
+pub fn strip_code_fences(content: &str) -> Normalized {
     let mut out = String::with_capacity(content.len());
+    let mut fenced = Vec::new();
+    // `Some(start)` while inside a fence; `start` is the offset in `out` of the
+    // first content byte after the opening marker.
+    let mut fence_start: Option<usize> = None;
     for line in content.split_inclusive('\n') {
         if line.trim_start().starts_with("```") {
+            match fence_start.take() {
+                Some(start) => fenced.push(start..out.len()),
+                None => fence_start = Some(out.len()),
+            }
             continue;
         }
         out.push_str(line);
     }
-    out
+    if let Some(start) = fence_start {
+        // Unterminated fence: treat the remainder as fenced.
+        fenced.push(start..out.len());
+    }
+    Normalized { text: out, fenced }
 }
 
 #[allow(dead_code)]
@@ -135,7 +168,30 @@ mod tests {
     #[test]
     fn strip_code_fences_removes_fence_lines_keeps_contents() {
         let input = "before\n```rust\nfn foo() {}\n```\nafter";
-        assert_eq!(strip_code_fences(input), "before\nfn foo() {}\nafter");
+        let result = strip_code_fences(input);
+        assert_eq!(result.text, "before\nfn foo() {}\nafter");
+    }
+
+    #[test]
+    fn strip_code_fences_reports_fenced_content_ranges() {
+        let input = "before\n```rust\nfn foo() {}\n```\nafter";
+        let result = strip_code_fences(input);
+        // The fenced range covers exactly "fn foo() {}\n" within the output.
+        assert_eq!(result.fenced.len(), 1);
+        let r = result.fenced[0].clone();
+        assert_eq!(&result.text[r], "fn foo() {}\n");
+    }
+
+    #[test]
+    fn strip_code_fences_handles_unterminated_fence() {
+        let input = "before\n```rust\nfn foo() {}\n";
+        let result = strip_code_fences(input);
+        assert_eq!(result.text, "before\nfn foo() {}\n");
+        assert_eq!(result.fenced.len(), 1);
+        assert!(in_fenced(
+            &result.fenced,
+            result.text.find("fn foo").unwrap()
+        ));
     }
 
     #[test]

--- a/src/embed/candle_embedder.rs
+++ b/src/embed/candle_embedder.rs
@@ -1,0 +1,158 @@
+//! Candle-backed embedders for FastEmbed v5's Qwen3 and Nomic v2 MoE models,
+//! which are not part of the ONNX `EmbeddingModel` enum and are only available
+//! behind the `qwen3` / `nomic-v2-moe` feature flags. Each wraps the fastembed
+//! candle type behind a `Mutex` (inference is `&mut`-free but the model is not
+//! guaranteed `Sync`) plus a separately-loaded tokenizer for `token_count`
+//! (the fastembed candle types don't expose their internal tokenizer).
+//!
+//! Native output dimensions are fixed by the model; the `--dim` sweep applies
+//! [`super::MatryoshkaEmbedder`] on top for the reduced-dimension variants.
+
+use std::sync::Mutex;
+
+use candle_core::{DType, Device};
+use fastembed::{NomicV2MoeTextEmbedding, Qwen3TextEmbedding};
+use tokenizers::Tokenizer;
+
+use super::{Embedder, hub};
+
+/// Cache identity for a candle embedder. Mirrors the ONNX scheme but carries a
+/// `candle` marker so a candle-built index is never reused as if it held vectors
+/// from the (different) ONNX runtime, and `-ctx1` records the contextual
+/// document contract, exactly as `fastembed_embedder`.
+fn candle_identity(id: &str, dim: usize, max_length: usize) -> String {
+    format!("{id}-{dim}-max{max_length}-fastembed-v5-candle-ctx1")
+}
+
+/// Qwen3 Embedding 0.6B — multilingual quality ceiling. Native 1024-dim output
+/// with last-token pooling. No task prefixes: Qwen3's optional query instruction
+/// is tuning we keep off for a clean benchmark baseline.
+pub struct Qwen3Embedder {
+    model: Mutex<Qwen3TextEmbedding>,
+    tokenizer: Tokenizer,
+    dim: usize,
+    max_length: usize,
+    id: &'static str,
+}
+
+impl Qwen3Embedder {
+    const REPO: &'static str = "Qwen/Qwen3-Embedding-0.6B";
+    const DIM: usize = 1024;
+    const MAX_LENGTH: usize = 1024;
+
+    pub fn load() -> Result<Self, String> {
+        let model =
+            Qwen3TextEmbedding::from_hf(Self::REPO, &Device::Cpu, DType::F32, Self::MAX_LENGTH)
+                .map_err(|e| format!("failed to load Qwen3 embedding model: {e}"))?;
+        let tokenizer = hub::fetch_tokenizer(Self::REPO)?;
+        Ok(Self {
+            model: Mutex::new(model),
+            tokenizer,
+            dim: Self::DIM,
+            max_length: Self::MAX_LENGTH,
+            id: "Qwen3Embedding0_6B",
+        })
+    }
+}
+
+impl Embedder for Qwen3Embedder {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.model
+            .lock()
+            .map_err(|e| format!("Qwen3 embedder mutex poisoned: {e}"))?
+            .embed(texts)
+            .map_err(|e| format!("Qwen3 embed call failed: {e}"))
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn identity(&self) -> String {
+        candle_identity(self.id, self.dim, self.max_length)
+    }
+
+    fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+        self.tokenizer
+            .encode(text, add_special_tokens)
+            .map(|encoding| encoding.get_ids().len())
+            .map_err(|error| format!("failed tokenizing text: {error}"))
+    }
+}
+
+/// Nomic Embed Text v2 MoE — midsize multilingual, Apache 2.0. Native 768-dim
+/// output. Uses the same asymmetric prefixes as v1.5.
+///
+/// NOTE: the model's effective input limit is 512 tokens, so at the 800-token
+/// chunk config the model truncates the tail — a real property of this model to
+/// keep in mind when reading its numbers, not a harness bug.
+pub struct NomicV2Embedder {
+    model: Mutex<NomicV2MoeTextEmbedding>,
+    tokenizer: Tokenizer,
+    dim: usize,
+    max_length: usize,
+    id: &'static str,
+}
+
+impl NomicV2Embedder {
+    const REPO: &'static str = "nomic-ai/nomic-embed-text-v2-moe";
+    const DIM: usize = 768;
+    const MAX_LENGTH: usize = 512;
+
+    pub fn load() -> Result<Self, String> {
+        let model = NomicV2MoeTextEmbedding::from_hf(
+            Self::REPO,
+            &Device::Cpu,
+            DType::F32,
+            Self::MAX_LENGTH,
+        )
+        .map_err(|e| format!("failed to load Nomic v2 MoE embedding model: {e}"))?;
+        let tokenizer = hub::fetch_tokenizer(Self::REPO)?;
+        Ok(Self {
+            model: Mutex::new(model),
+            tokenizer,
+            dim: Self::DIM,
+            max_length: Self::MAX_LENGTH,
+            id: "NomicEmbedTextV2Moe",
+        })
+    }
+}
+
+impl Embedder for NomicV2Embedder {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.model
+            .lock()
+            .map_err(|e| format!("Nomic v2 embedder mutex poisoned: {e}"))?
+            .embed(texts)
+            .map_err(|e| format!("Nomic v2 embed call failed: {e}"))
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn identity(&self) -> String {
+        candle_identity(self.id, self.dim, self.max_length)
+    }
+
+    fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+        self.tokenizer
+            .encode(text, add_special_tokens)
+            .map(|encoding| encoding.get_ids().len())
+            .map_err(|error| format!("failed tokenizing text: {error}"))
+    }
+
+    fn doc_prefix(&self) -> &'static str {
+        "search_document: "
+    }
+
+    fn query_prefix(&self) -> &'static str {
+        "search_query: "
+    }
+}

--- a/src/embed/context.rs
+++ b/src/embed/context.rs
@@ -1,0 +1,55 @@
+//! Document-side embedding input construction, shared by the indexing pipeline
+//! and the index microbenchmark so the two never drift apart.
+
+/// The text embedded for a chunk: the note's contextual header (its title and
+/// the chunk's heading path) followed by the chunk body. Anchoring each chunk to
+/// its note and section keeps mid-note chunks from embedding as anonymous
+/// fragments. The model's `doc_prefix` is applied around this; queries are
+/// unchanged (asymmetric embedding, richer document side only).
+pub fn contextual_document(title: &str, heading_path: Option<&str>, body: &str) -> String {
+    let header = match heading_path {
+        Some(path) if !path.is_empty() => format!("{title} > {path}"),
+        _ => title.to_string(),
+    };
+    if header.is_empty() {
+        body.to_string()
+    } else {
+        format!("{header}\n\n{body}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contextual_document;
+
+    #[test]
+    fn prepends_title_and_heading_path() {
+        let doc = contextual_document(
+            "Postgres runbook",
+            Some("Backups > Restoring"),
+            "Stop the service first.",
+        );
+        assert_eq!(
+            doc,
+            "Postgres runbook > Backups > Restoring\n\nStop the service first."
+        );
+    }
+
+    #[test]
+    fn without_heading_uses_title_only() {
+        let doc = contextual_document("Postgres runbook", None, "Stop the service first.");
+        assert_eq!(doc, "Postgres runbook\n\nStop the service first.");
+    }
+
+    #[test]
+    fn empty_heading_path_is_treated_as_absent() {
+        let doc = contextual_document("Note", Some(""), "body");
+        assert_eq!(doc, "Note\n\nbody");
+    }
+
+    #[test]
+    fn empty_title_and_no_heading_falls_back_to_body() {
+        let doc = contextual_document("", None, "body");
+        assert_eq!(doc, "body");
+    }
+}

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -36,6 +36,18 @@ pub trait Embedder: Send + Sync {
     fn query_prefix(&self) -> &'static str {
         ""
     }
+
+    /// Complete document-side input for contextual embeddings. Most models use
+    /// Hatchdoor's canonical title + heading + body representation with an
+    /// optional task prefix; models with a trained document template can
+    /// override this method.
+    fn document_input(&self, title: &str, heading_path: Option<&str>, body: &str) -> String {
+        format!(
+            "{}{}",
+            self.doc_prefix(),
+            crate::embed::contextual_document(title, heading_path, body)
+        )
+    }
 }
 
 /// Deterministic test embedder. Hashes each input to a fixed-dim vector so

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use tokenizers::{Tokenizer, models::wordlevel::WordLevel, pre_tokenizers::whitespace::Whitespace};
 
 /// In-process text embedder. Loaded once at startup, shared via Arc.
@@ -47,6 +49,86 @@ pub trait Embedder: Send + Sync {
             self.doc_prefix(),
             crate::embed::contextual_document(title, heading_path, body)
         )
+    }
+}
+
+/// A startup-safe embedder slot. The HTTP server can expose the terms/download
+/// gate before a real model is loaded; protected vault routes stay unavailable
+/// until [`RuntimeEmbedder::set`] installs the selected model.
+pub struct RuntimeEmbedder {
+    inner: RwLock<Option<Arc<dyn Embedder>>>,
+    kind: std::sync::atomic::AtomicU8,
+}
+
+impl RuntimeEmbedder {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(None),
+            kind: std::sync::atomic::AtomicU8::new(0),
+        }
+    }
+
+    pub fn set(&self, embedder: Arc<dyn Embedder>, gemma: bool) {
+        *self.inner.write().expect("runtime embedder poisoned") = Some(embedder);
+        self.kind.store(
+            if gemma { 2 } else { 1 },
+            std::sync::atomic::Ordering::Release,
+        );
+    }
+
+    fn active(&self) -> Result<Arc<dyn Embedder>, String> {
+        self.inner
+            .read()
+            .expect("runtime embedder poisoned")
+            .clone()
+            .ok_or_else(|| "embedding model setup is not complete".to_string())
+    }
+}
+
+impl Default for RuntimeEmbedder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Embedder for RuntimeEmbedder {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        self.active()?.embed(texts)
+    }
+
+    fn embedding_dim(&self) -> usize {
+        768
+    }
+
+    fn identity(&self) -> String {
+        self.active()
+            .map(|embedder| embedder.identity())
+            .unwrap_or_else(|_| "model-setup-pending-768".to_string())
+    }
+
+    fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+        self.active()?.token_count(text, add_special_tokens)
+    }
+
+    fn doc_prefix(&self) -> &'static str {
+        match self.kind.load(std::sync::atomic::Ordering::Acquire) {
+            1 => "search_document: ",
+            _ => "",
+        }
+    }
+
+    fn query_prefix(&self) -> &'static str {
+        match self.kind.load(std::sync::atomic::Ordering::Acquire) {
+            1 => "search_query: ",
+            2 => "task: search result | query: ",
+            _ => "",
+        }
+    }
+
+    fn document_input(&self, title: &str, heading_path: Option<&str>, body: &str) -> String {
+        self.active()
+            .map(|embedder| embedder.document_input(title, heading_path, body))
+            .unwrap_or_else(|_| crate::embed::contextual_document(title, heading_path, body))
     }
 }
 
@@ -163,5 +245,14 @@ mod tests {
                 .expect("encode"),
             3
         );
+    }
+
+    #[test]
+    fn runtime_embedder_refuses_work_until_a_model_is_selected() {
+        let runtime = RuntimeEmbedder::new();
+        assert!(runtime.embed(&["hello".to_string()]).is_err());
+        runtime.set(Arc::new(StubEmbedder::new(768)), false);
+        assert_eq!(runtime.embed(&["hello".to_string()]).unwrap()[0].len(), 768);
+        assert_eq!(runtime.query_prefix(), "search_query: ");
     }
 }

--- a/src/embed/fastembed_embedder.rs
+++ b/src/embed/fastembed_embedder.rs
@@ -1,9 +1,14 @@
+use std::sync::Mutex;
+
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 use super::Embedder;
 
 pub struct FastembedEmbedder {
-    model: TextEmbedding,
+    // FastEmbed 5 dropped Rayon; `TextEmbedding::embed` now takes `&mut self`.
+    // The `Embedder` contract is `&self` behind a shared `Arc`, so serialize
+    // inference through a Mutex rather than leaking `&mut` up the trait.
+    model: Mutex<TextEmbedding>,
     dim: usize,
     max_length: usize,
     id: &'static str,
@@ -27,7 +32,7 @@ impl FastembedEmbedder {
         )
         .map_err(|e| format!("failed to load embedding model {id}: {e}"))?;
         Ok(Self {
-            model,
+            model: Mutex::new(model),
             dim,
             max_length,
             id,
@@ -82,7 +87,9 @@ impl Embedder for FastembedEmbedder {
             return Ok(Vec::new());
         }
         self.model
-            .embed(texts.to_vec(), None)
+            .lock()
+            .map_err(|e| format!("embedder mutex poisoned: {e}"))?
+            .embed(texts, None)
             .map_err(|e| format!("embed call failed: {e}"))
     }
 
@@ -96,13 +103,15 @@ impl Embedder for FastembedEmbedder {
         // Bumping FastEmbed must never leave vectors from the prior runtime in
         // the same SQLite index.
         format!(
-            "{}-{}-max{}-fastembed-v4",
+            "{}-{}-max{}-fastembed-v5",
             self.id, self.dim, self.max_length
         )
     }
 
     fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
         self.model
+            .lock()
+            .map_err(|e| format!("embedder mutex poisoned: {e}"))?
             .tokenizer
             .encode(text, add_special_tokens)
             .map(|encoding| encoding.get_ids().len())

--- a/src/embed/fastembed_embedder.rs
+++ b/src/embed/fastembed_embedder.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use fastembed::{
@@ -36,9 +37,30 @@ impl FastembedEmbedder {
         doc_prefix: &'static str,
         query_prefix: &'static str,
     ) -> Result<Self, String> {
+        Self::load_in(
+            model,
+            dim,
+            max_length,
+            id,
+            doc_prefix,
+            query_prefix,
+            fastembed::get_cache_dir().into(),
+        )
+    }
+
+    fn load_in(
+        model: EmbeddingModel,
+        dim: usize,
+        max_length: usize,
+        id: &'static str,
+        doc_prefix: &'static str,
+        query_prefix: &'static str,
+        cache_dir: PathBuf,
+    ) -> Result<Self, String> {
         let model = TextEmbedding::try_new(
             InitOptions::new(model)
                 .with_max_length(max_length)
+                .with_cache_dir(cache_dir)
                 .with_show_download_progress(false),
         )
         .map_err(|e| format!("failed to load embedding model {id}: {e}"))?;
@@ -82,6 +104,18 @@ impl FastembedEmbedder {
         )
     }
 
+    pub fn nomic_v1_5_in(cache_dir: PathBuf) -> Result<Self, String> {
+        Self::load_in(
+            EmbeddingModel::NomicEmbedTextV15,
+            768,
+            1024,
+            "NomicEmbedTextV15",
+            "search_document: ",
+            "search_query: ",
+            cache_dir,
+        )
+    }
+
     pub fn mxbai_large() -> Result<Self, String> {
         Self::load(
             EmbeddingModel::MxbaiEmbedLargeV1,
@@ -112,13 +146,18 @@ impl FastembedEmbedder {
     /// 2,048-token input limit and supports Matryoshka truncation for the
     /// storage-efficient 256-dimensional evaluation variant.
     pub fn embedding_gemma_300m_q4() -> Result<Self, String> {
-        let mut embedder = Self::load(
+        Self::embedding_gemma_300m_q4_in(fastembed::get_cache_dir().into())
+    }
+
+    pub fn embedding_gemma_300m_q4_in(cache_dir: PathBuf) -> Result<Self, String> {
+        let mut embedder = Self::load_in(
             EmbeddingModel::EmbeddingGemma300MQ4,
             768,
             2048,
             "EmbeddingGemma300MQ4",
             "",
             "task: search result | query: ",
+            cache_dir,
         )?;
         // EmbeddingGemma's retrieval training uses different query and document
         // templates. This is intentionally a model-specific document format,

--- a/src/embed/fastembed_embedder.rs
+++ b/src/embed/fastembed_embedder.rs
@@ -98,14 +98,7 @@ impl Embedder for FastembedEmbedder {
     }
 
     fn identity(&self) -> String {
-        // Sequence length and the FastEmbed/ONNX Runtime generation affect
-        // embeddings, so both are part of the persisted cache identity.
-        // Bumping FastEmbed must never leave vectors from the prior runtime in
-        // the same SQLite index.
-        format!(
-            "{}-{}-max{}-fastembed-v5",
-            self.id, self.dim, self.max_length
-        )
+        embedder_identity(self.id, self.dim, self.max_length)
     }
 
     fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
@@ -124,6 +117,34 @@ impl Embedder for FastembedEmbedder {
 
     fn query_prefix(&self) -> &'static str {
         self.query_prefix
+    }
+}
+
+/// Persisted cache identity for a FastEmbed model. Every field that changes the
+/// produced vectors is encoded so a mismatch forces a full rebuild rather than
+/// mixing incompatible embeddings in one index:
+/// - model id and dimension: the embedding space itself;
+/// - max sequence length: truncation point;
+/// - `fastembed-v5`: the FastEmbed/ONNX Runtime generation;
+/// - `ctx1`: the document contract (title + heading header, see
+///   `contextual_document` in the cache populate path).
+fn embedder_identity(id: &str, dim: usize, max_length: usize) -> String {
+    format!("{id}-{dim}-max{max_length}-fastembed-v5-ctx1")
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::embedder_identity;
+
+    #[test]
+    fn identity_marks_the_contextual_embedding_contract() {
+        // The `-ctx1` marker records that documents are embedded with a
+        // title/heading header. Bumping it forces a one-time cache rebuild so
+        // vectors from the pre-context contract are never reused.
+        assert_eq!(
+            embedder_identity("NomicEmbedTextV15", 768, 2048),
+            "NomicEmbedTextV15-768-max2048-fastembed-v5-ctx1"
+        );
     }
 }
 

--- a/src/embed/fastembed_embedder.rs
+++ b/src/embed/fastembed_embedder.rs
@@ -1,8 +1,17 @@
 use std::sync::Mutex;
 
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use fastembed::{
+    EmbeddingModel, InitOptions, InitOptionsUserDefined, Pooling, TextEmbedding, TokenizerFiles,
+    UserDefinedEmbeddingModel,
+};
 
 use super::Embedder;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DocumentFormat {
+    HatchdoorContextual,
+    GemmaRetrievalV1,
+}
 
 pub struct FastembedEmbedder {
     // FastEmbed 5 dropped Rayon; `TextEmbedding::embed` now takes `&mut self`.
@@ -14,6 +23,8 @@ pub struct FastembedEmbedder {
     id: &'static str,
     doc_prefix: &'static str,
     query_prefix: &'static str,
+    document_format: DocumentFormat,
+    identity_suffix: &'static str,
 }
 
 impl FastembedEmbedder {
@@ -38,6 +49,8 @@ impl FastembedEmbedder {
             id,
             doc_prefix,
             query_prefix,
+            document_format: DocumentFormat::HatchdoorContextual,
+            identity_suffix: "",
         })
     }
 
@@ -79,6 +92,101 @@ impl FastembedEmbedder {
             "",
         )
     }
+
+    /// GTE Base English v1.5 — native ONNX. English-only floor for the
+    /// multilingual benchmark. No task-instruction prefixes. `max_length` is set
+    /// to 1024 so the 800-token chunk sweep (plus context header) is not
+    /// truncated.
+    pub fn gte_base_en() -> Result<Self, String> {
+        Self::load(
+            EmbeddingModel::GTEBaseENV15,
+            768,
+            1024,
+            "GTEBaseENV15",
+            "",
+            "",
+        )
+    }
+
+    /// EmbeddingGemma 300M Q4 — multilingual 4-bit ONNX model. It has a
+    /// 2,048-token input limit and supports Matryoshka truncation for the
+    /// storage-efficient 256-dimensional evaluation variant.
+    pub fn embedding_gemma_300m_q4() -> Result<Self, String> {
+        let mut embedder = Self::load(
+            EmbeddingModel::EmbeddingGemma300MQ4,
+            768,
+            2048,
+            "EmbeddingGemma300MQ4",
+            "",
+            "task: search result | query: ",
+        )?;
+        // EmbeddingGemma's retrieval training uses different query and document
+        // templates. This is intentionally a model-specific document format,
+        // not merely a prefix, because the note title has its own field.
+        embedder.document_format = DocumentFormat::GemmaRetrievalV1;
+        // The cached vectors are incompatible with the earlier plain-context
+        // Gemma experiment, even though the weights and output dimensions match.
+        embedder.identity_suffix = "-gemma-retrieval-v1";
+        Ok(embedder)
+    }
+
+    /// Wrap an already-constructed `TextEmbedding` (e.g. a user-defined ONNX
+    /// model) so it reuses the same embed / token_count / identity path as the
+    /// enum-based models.
+    fn from_text_embedding(
+        model: TextEmbedding,
+        dim: usize,
+        max_length: usize,
+        id: &'static str,
+        doc_prefix: &'static str,
+        query_prefix: &'static str,
+    ) -> Self {
+        Self {
+            model: Mutex::new(model),
+            dim,
+            max_length,
+            id,
+            doc_prefix,
+            query_prefix,
+            document_format: DocumentFormat::HatchdoorContextual,
+            identity_suffix: "",
+        }
+    }
+
+    /// Snowflake Arctic Embed M v2.0 — midsize multilingual, a retrieval
+    /// fine-tune of gte-multilingual-base. Not a native FastEmbed enum model, so
+    /// it is loaded as a user-defined ONNX model: the fp32 `onnx/model.onnx` with
+    /// CLS pooling (per the repo's `1_Pooling/config.json`). The model card
+    /// specifies a `"query: "` prefix for queries and no document prefix.
+    /// Downloads ~1.2 GB on first use.
+    pub fn arctic_m_v2() -> Result<Self, String> {
+        const REPO: &str = "Snowflake/snowflake-arctic-embed-m-v2.0";
+        const MAX_LENGTH: usize = 1024;
+
+        let onnx_file = super::hub::fetch_bytes(REPO, "onnx/model.onnx")?;
+        let tokenizer_files = TokenizerFiles {
+            tokenizer_file: super::hub::fetch_bytes(REPO, "tokenizer.json")?,
+            config_file: super::hub::fetch_bytes(REPO, "config.json")?,
+            special_tokens_map_file: super::hub::fetch_bytes(REPO, "special_tokens_map.json")?,
+            tokenizer_config_file: super::hub::fetch_bytes(REPO, "tokenizer_config.json")?,
+        };
+        let user_model =
+            UserDefinedEmbeddingModel::new(onnx_file, tokenizer_files).with_pooling(Pooling::Cls);
+        let model = TextEmbedding::try_new_from_user_defined(
+            user_model,
+            InitOptionsUserDefined::new().with_max_length(MAX_LENGTH),
+        )
+        .map_err(|e| format!("failed to load Arctic M v2.0 user-defined model: {e}"))?;
+
+        Ok(Self::from_text_embedding(
+            model,
+            768,
+            MAX_LENGTH,
+            "SnowflakeArcticEmbedMV2",
+            "",
+            "query: ",
+        ))
+    }
 }
 
 impl Embedder for FastembedEmbedder {
@@ -98,7 +206,11 @@ impl Embedder for FastembedEmbedder {
     }
 
     fn identity(&self) -> String {
-        embedder_identity(self.id, self.dim, self.max_length)
+        format!(
+            "{}{}",
+            embedder_identity(self.id, self.dim, self.max_length),
+            self.identity_suffix
+        )
     }
 
     fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
@@ -118,6 +230,30 @@ impl Embedder for FastembedEmbedder {
     fn query_prefix(&self) -> &'static str {
         self.query_prefix
     }
+
+    fn document_input(&self, title: &str, heading_path: Option<&str>, body: &str) -> String {
+        match self.document_format {
+            DocumentFormat::HatchdoorContextual => format!(
+                "{}{}",
+                self.doc_prefix,
+                crate::embed::contextual_document(title, heading_path, body)
+            ),
+            DocumentFormat::GemmaRetrievalV1 => gemma_retrieval_document(title, heading_path, body),
+        }
+    }
+}
+
+fn gemma_retrieval_document(title: &str, heading_path: Option<&str>, body: &str) -> String {
+    let title = if title.trim().is_empty() {
+        "none"
+    } else {
+        title
+    };
+    let text = match heading_path {
+        Some(path) if !path.is_empty() => format!("Section: {path}\n\n{body}"),
+        _ => body.to_string(),
+    };
+    format!("title: {title} | text: {text}")
 }
 
 /// Persisted cache identity for a FastEmbed model. Every field that changes the
@@ -134,7 +270,7 @@ fn embedder_identity(id: &str, dim: usize, max_length: usize) -> String {
 
 #[cfg(test)]
 mod identity_tests {
-    use super::embedder_identity;
+    use super::{embedder_identity, gemma_retrieval_document};
 
     #[test]
     fn identity_marks_the_contextual_embedding_contract() {
@@ -144,6 +280,14 @@ mod identity_tests {
         assert_eq!(
             embedder_identity("NomicEmbedTextV15", 768, 2048),
             "NomicEmbedTextV15-768-max2048-fastembed-v5-ctx1"
+        );
+    }
+
+    #[test]
+    fn gemma_retrieval_document_uses_official_title_text_template() {
+        assert_eq!(
+            gemma_retrieval_document("Runbook", Some("Backups > Restore"), "Stop first."),
+            "title: Runbook | text: Section: Backups > Restore\n\nStop first."
         );
     }
 }

--- a/src/embed/hub.rs
+++ b/src/embed/hub.rs
@@ -1,0 +1,41 @@
+//! Hugging Face Hub helpers for the benchmark-only embedders that load their own
+//! assets: the candle models (Qwen3, Nomic v2 MoE) need a tokenizer for
+//! `token_count` because the fastembed candle types don't expose their internal
+//! one, and the Arctic user-defined ONNX model needs its raw ONNX + tokenizer
+//! files. Uses the same `hf-hub` sync API and cache directory FastEmbed uses, so
+//! files fetched here are shared with — not duplicated by — the model loads.
+
+use hf_hub::api::sync::{ApiBuilder, ApiRepo};
+use tokenizers::Tokenizer;
+
+fn repo(repo_id: &str) -> Result<ApiRepo, String> {
+    let api = ApiBuilder::new()
+        .with_progress(false)
+        .build()
+        .map_err(|e| format!("hf-hub api init: {e}"))?;
+    Ok(api.model(repo_id.to_string()))
+}
+
+/// Fetch a single file from a repo into the shared Hugging Face cache and
+/// return its path. Large ONNX files should be passed to ONNX Runtime by path
+/// rather than copied into the process heap first.
+pub fn fetch_path(repo_id: &str, filename: &str) -> Result<std::path::PathBuf, String> {
+    repo(repo_id)?
+        .get(filename)
+        .map_err(|e| format!("hf-hub get {repo_id}/{filename}: {e}"))
+}
+
+/// Fetch a single file from a repo, returning its bytes (cached on disk by hf-hub).
+pub fn fetch_bytes(repo_id: &str, filename: &str) -> Result<Vec<u8>, String> {
+    let path = fetch_path(repo_id, filename)?;
+    std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))
+}
+
+/// Load a `tokenizers::Tokenizer` from a repo's tokenizer.json, for token
+/// counting during chunking. No truncation is configured so counts are exact.
+pub fn fetch_tokenizer(repo_id: &str) -> Result<Tokenizer, String> {
+    let path = repo(repo_id)?
+        .get("tokenizer.json")
+        .map_err(|e| format!("hf-hub get {repo_id}/tokenizer.json: {e}"))?;
+    Tokenizer::from_file(&path).map_err(|e| format!("load tokenizer {repo_id}: {e}"))
+}

--- a/src/embed/matryoshka.rs
+++ b/src/embed/matryoshka.rs
@@ -1,0 +1,114 @@
+//! Matryoshka dimension reduction as an embedder decorator. Wraps a full-size
+//! model and truncates each vector to a shorter prefix, then re-normalises.
+//! Because the cache derives its vector dimension, storage layout, and rebuild
+//! trigger entirely from the embedder, this needs zero changes to the populate
+//! path: `eval build --dim 256` produces a 256-dimensional index.
+
+use std::sync::Arc;
+
+use super::Embedder;
+
+pub struct MatryoshkaEmbedder {
+    inner: Arc<dyn Embedder>,
+    dim: usize,
+}
+
+impl MatryoshkaEmbedder {
+    /// Wrap `inner`, truncating its output to `dim`. Fails if `dim` is zero or
+    /// larger than the model's native dimension (Matryoshka only shortens).
+    pub fn new(inner: Arc<dyn Embedder>, dim: usize) -> Result<Self, String> {
+        let full = inner.embedding_dim();
+        if dim == 0 || dim > full {
+            return Err(format!(
+                "matryoshka dim {dim} must be in 1..={full} (the model's native dimension)"
+            ));
+        }
+        Ok(Self { inner, dim })
+    }
+}
+
+/// Truncate to the first `dim` components and re-normalise to unit length, as
+/// Matryoshka-trained models expect for a reduced representation.
+fn truncate_and_normalize(vector: &[f32], dim: usize) -> Vec<f32> {
+    let mut out = vector[..dim].to_vec();
+    let norm = out.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-12);
+    for x in &mut out {
+        *x /= norm;
+    }
+    out
+}
+
+impl Embedder for MatryoshkaEmbedder {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        let full = self.inner.embed(texts)?;
+        Ok(full
+            .iter()
+            .map(|v| truncate_and_normalize(v, self.dim))
+            .collect())
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Distinct from the inner model so a cache built at a reduced dimension is
+    /// never reused as if it held full-size vectors.
+    fn identity(&self) -> String {
+        format!("{}-mrl{}", self.inner.identity(), self.dim)
+    }
+
+    fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+        self.inner.token_count(text, add_special_tokens)
+    }
+
+    fn doc_prefix(&self) -> &'static str {
+        self.inner.doc_prefix()
+    }
+
+    fn query_prefix(&self) -> &'static str {
+        self.inner.query_prefix()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embed::StubEmbedder;
+
+    #[test]
+    fn rejects_zero_and_oversized_dimensions() {
+        let inner: Arc<dyn Embedder> = Arc::new(StubEmbedder::new(768));
+        assert!(MatryoshkaEmbedder::new(inner.clone(), 0).is_err());
+        assert!(MatryoshkaEmbedder::new(inner.clone(), 769).is_err());
+        assert!(MatryoshkaEmbedder::new(inner, 256).is_ok());
+    }
+
+    #[test]
+    fn reports_reduced_dimension_and_distinct_identity() {
+        let inner: Arc<dyn Embedder> = Arc::new(StubEmbedder::new(768));
+        let mrl = MatryoshkaEmbedder::new(inner.clone(), 256).expect("wrap");
+        assert_eq!(mrl.embedding_dim(), 256);
+        assert_ne!(mrl.identity(), inner.identity());
+        assert!(mrl.identity().ends_with("-mrl256"));
+    }
+
+    #[test]
+    fn embeds_truncated_renormalized_prefix_of_inner() {
+        let inner: Arc<dyn Embedder> = Arc::new(StubEmbedder::new(768));
+        let mrl = MatryoshkaEmbedder::new(inner.clone(), 256).expect("wrap");
+
+        let text = vec!["hello world".to_string()];
+        let reduced = mrl.embed(&text).expect("embed");
+        assert_eq!(reduced.len(), 1);
+        assert_eq!(reduced[0].len(), 256);
+
+        let expected = truncate_and_normalize(&inner.embed(&text).expect("inner")[0], 256);
+        assert_eq!(reduced[0], expected);
+
+        let norm: f32 = reduced[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-5,
+            "reduced vector must be unit length"
+        );
+    }
+}

--- a/src/embed/matryoshka.rs
+++ b/src/embed/matryoshka.rs
@@ -68,6 +68,10 @@ impl Embedder for MatryoshkaEmbedder {
     fn query_prefix(&self) -> &'static str {
         self.inner.query_prefix()
     }
+
+    fn document_input(&self, title: &str, heading_path: Option<&str>, body: &str) -> String {
+        self.inner.document_input(title, heading_path, body)
+    }
 }
 
 #[cfg(test)]

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -7,6 +7,6 @@ pub mod matryoshka;
 
 pub use candle_embedder::{NomicV2Embedder, Qwen3Embedder};
 pub use context::contextual_document;
-pub use embedder::{Embedder, StubEmbedder};
+pub use embedder::{Embedder, RuntimeEmbedder, StubEmbedder};
 pub use fastembed_embedder::FastembedEmbedder;
 pub use matryoshka::MatryoshkaEmbedder;

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,7 +1,9 @@
 pub mod context;
 pub mod embedder;
 pub mod fastembed_embedder;
+pub mod matryoshka;
 
 pub use context::contextual_document;
 pub use embedder::{Embedder, StubEmbedder};
 pub use fastembed_embedder::FastembedEmbedder;
+pub use matryoshka::MatryoshkaEmbedder;

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,5 +1,7 @@
+pub mod context;
 pub mod embedder;
 pub mod fastembed_embedder;
 
+pub use context::contextual_document;
 pub use embedder::{Embedder, StubEmbedder};
 pub use fastembed_embedder::FastembedEmbedder;

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,8 +1,11 @@
+pub mod candle_embedder;
 pub mod context;
 pub mod embedder;
 pub mod fastembed_embedder;
+pub mod hub;
 pub mod matryoshka;
 
+pub use candle_embedder::{NomicV2Embedder, Qwen3Embedder};
 pub use context::contextual_document;
 pub use embedder::{Embedder, StubEmbedder};
 pub use fastembed_embedder::FastembedEmbedder;

--- a/src/eval/hybrid_runner.rs
+++ b/src/eval/hybrid_runner.rs
@@ -133,6 +133,7 @@ mod tests {
             expected_heading_path: None,
             category: None,
             language: None,
+            tier: None,
             anti_expected: vec![],
         }];
 
@@ -177,6 +178,7 @@ mod tests {
             expected_heading_path: None,
             category: None,
             language: None,
+            tier: None,
             anti_expected: vec![],
         }];
         let out = run_hybrid_eval(&cache, embedder.as_ref(), &queries, 5, 60, 10).expect("run");

--- a/src/eval/hybrid_runner.rs
+++ b/src/eval/hybrid_runner.rs
@@ -71,6 +71,9 @@ pub fn run_hybrid_eval(
             query_result: QueryResult {
                 query_id: q.id.clone(),
                 top_k,
+                // Hybrid fusion collapses to note slugs; heading paths aren't
+                // tracked here, so this path scores no correct-heading hits.
+                top_k_headings: Vec::new(),
             },
             latency_ms,
         });
@@ -128,6 +131,8 @@ mod tests {
             query: "flying baby plane".to_string(),
             expected_notes: vec!["gamma".to_string()],
             expected_heading_path: None,
+            category: None,
+            language: None,
             anti_expected: vec![],
         }];
 
@@ -170,6 +175,8 @@ mod tests {
             query: "storage pool layout archive server".to_string(),
             expected_notes: vec!["gamma".to_string()],
             expected_heading_path: None,
+            category: None,
+            language: None,
             anti_expected: vec![],
         }];
         let out = run_hybrid_eval(&cache, embedder.as_ref(), &queries, 5, 60, 10).expect("run");

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -313,7 +313,9 @@ impl LatencyStats {
 pub struct RerankQueryResult {
     pub query_id: String,
     pub top_k_pre: Vec<String>,
+    pub top_k_pre_headings: Vec<Option<String>>,
     pub top_k_post: Vec<String>,
+    pub top_k_post_headings: Vec<Option<String>>,
     pub rerank_latency_ms: f64,
     pub e2e_latency_ms: f64,
 }
@@ -336,11 +338,15 @@ pub fn aggregate_rerank(
     let mut anti_num = 0usize;
     let mut headline_n = 0usize;
     let mut per_query = Vec::with_capacity(queries.len());
+    let mut rows: Vec<GroupRow> = Vec::with_capacity(queries.len());
 
     for q in queries {
         let result = by_id.get(q.id.as_str());
         let top_10_post: Vec<String> = result
             .map(|r| r.top_k_post.iter().take(10).cloned().collect())
+            .unwrap_or_default();
+        let top_10_post_headings: Vec<Option<String>> = result
+            .map(|r| r.top_k_post_headings.iter().take(10).cloned().collect())
             .unwrap_or_default();
         let top_5_post: Vec<String> = top_10_post.iter().take(5).cloned().collect();
 
@@ -350,6 +356,12 @@ pub fn aggregate_rerank(
             .unwrap_or(None);
         let anti_hit = (!q.anti_expected.is_empty())
             .then(|| any_anti_expected_in_top_k(&q.anti_expected, &top_5_post));
+        let heading = heading_hit(
+            &q.expected_notes,
+            q.expected_heading_path.as_deref(),
+            &top_10_post,
+            &top_10_post_headings,
+        );
 
         // Diagnostic queries are excluded from headline numbers, same as the
         // pure-retrieval path, so the two runs stay comparable.
@@ -383,6 +395,15 @@ pub fn aggregate_rerank(
             rank_pre_rerank: rank_pre,
             rank_post_rerank: rank_post,
         });
+        rows.push(GroupRow {
+            category: q.category.clone(),
+            tier: q.tier.clone(),
+            language: q.language.clone(),
+            hit5: recall_at_k_any(&q.expected_notes, &top_5_post),
+            hit10: recall_at_k_any(&q.expected_notes, &top_10_post),
+            rr: rank_post.map(|rank| 1.0 / rank as f64).unwrap_or(0.0),
+            heading,
+        });
     }
 
     let n = headline_n.max(1) as f64;
@@ -398,6 +419,10 @@ pub fn aggregate_rerank(
         (!rerank_samples.is_empty()).then(|| LatencyStats::from_samples(&rerank_samples));
     let e2e_latency_ms =
         (!e2e_samples.is_empty()).then(|| LatencyStats::from_samples(&e2e_samples));
+    let headline_rows: Vec<&GroupRow> = rows
+        .iter()
+        .filter(|r| r.tier.as_deref() != Some("diagnostic"))
+        .collect();
 
     Report {
         model_id: run_id.to_string(),
@@ -408,12 +433,10 @@ pub fn aggregate_rerank(
         recall_at_10_all: sum_all_10 / n,
         mrr: sum_mrr / n,
         fp_rate_at_5,
-        // The rerank path collapses to note slugs and carries no query tags, so
-        // heading and per-group breakdowns don't apply here.
-        correct_heading_rate: None,
-        per_category: Vec::new(),
-        per_tier: Vec::new(),
-        per_language: Vec::new(),
+        correct_heading_rate: heading_rate(&headline_rows),
+        per_category: group_reports(&rows, |r| r.category.as_deref()),
+        per_tier: group_reports(&rows, |r| r.tier.as_deref()),
+        per_language: group_reports(&rows, |r| r.language.as_deref()),
         per_query,
         rerank_latency_ms,
         e2e_latency_ms,
@@ -681,7 +704,9 @@ mod rerank_tests {
         let pre = vec![RerankQueryResult {
             query_id: "Q1".to_string(),
             top_k_pre: top(&["a", "b", "x"]), // expected at rank 3 pre
+            top_k_pre_headings: vec![None; 3],
             top_k_post: top(&["x", "a", "b"]), // expected at rank 1 post
+            top_k_post_headings: vec![None; 3],
             rerank_latency_ms: 12.0,
             e2e_latency_ms: 25.0,
         }];
@@ -722,7 +747,9 @@ mod rerank_tests {
         RerankQueryResult {
             query_id: id.to_string(),
             top_k_pre: top(&["x"]),
+            top_k_pre_headings: vec![None],
             top_k_post: top(&["x"]),
+            top_k_post_headings: vec![None],
             rerank_latency_ms: rerank_ms,
             e2e_latency_ms: e2e_ms,
         }

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -313,9 +313,7 @@ impl LatencyStats {
 pub struct RerankQueryResult {
     pub query_id: String,
     pub top_k_pre: Vec<String>,
-    pub top_k_pre_headings: Vec<Option<String>>,
     pub top_k_post: Vec<String>,
-    pub top_k_post_headings: Vec<Option<String>>,
     pub rerank_latency_ms: f64,
     pub e2e_latency_ms: f64,
 }
@@ -338,15 +336,11 @@ pub fn aggregate_rerank(
     let mut anti_num = 0usize;
     let mut headline_n = 0usize;
     let mut per_query = Vec::with_capacity(queries.len());
-    let mut rows: Vec<GroupRow> = Vec::with_capacity(queries.len());
 
     for q in queries {
         let result = by_id.get(q.id.as_str());
         let top_10_post: Vec<String> = result
             .map(|r| r.top_k_post.iter().take(10).cloned().collect())
-            .unwrap_or_default();
-        let top_10_post_headings: Vec<Option<String>> = result
-            .map(|r| r.top_k_post_headings.iter().take(10).cloned().collect())
             .unwrap_or_default();
         let top_5_post: Vec<String> = top_10_post.iter().take(5).cloned().collect();
 
@@ -356,12 +350,6 @@ pub fn aggregate_rerank(
             .unwrap_or(None);
         let anti_hit = (!q.anti_expected.is_empty())
             .then(|| any_anti_expected_in_top_k(&q.anti_expected, &top_5_post));
-        let heading = heading_hit(
-            &q.expected_notes,
-            q.expected_heading_path.as_deref(),
-            &top_10_post,
-            &top_10_post_headings,
-        );
 
         // Diagnostic queries are excluded from headline numbers, same as the
         // pure-retrieval path, so the two runs stay comparable.
@@ -395,15 +383,6 @@ pub fn aggregate_rerank(
             rank_pre_rerank: rank_pre,
             rank_post_rerank: rank_post,
         });
-        rows.push(GroupRow {
-            category: q.category.clone(),
-            tier: q.tier.clone(),
-            language: q.language.clone(),
-            hit5: recall_at_k_any(&q.expected_notes, &top_5_post),
-            hit10: recall_at_k_any(&q.expected_notes, &top_10_post),
-            rr: rank_post.map(|rank| 1.0 / rank as f64).unwrap_or(0.0),
-            heading,
-        });
     }
 
     let n = headline_n.max(1) as f64;
@@ -419,11 +398,6 @@ pub fn aggregate_rerank(
         (!rerank_samples.is_empty()).then(|| LatencyStats::from_samples(&rerank_samples));
     let e2e_latency_ms =
         (!e2e_samples.is_empty()).then(|| LatencyStats::from_samples(&e2e_samples));
-    let headline_rows: Vec<&GroupRow> = rows
-        .iter()
-        .filter(|r| r.tier.as_deref() != Some("diagnostic"))
-        .collect();
-
     Report {
         model_id: run_id.to_string(),
         reranker_id: Some(reranker_id.to_string()),
@@ -433,10 +407,12 @@ pub fn aggregate_rerank(
         recall_at_10_all: sum_all_10 / n,
         mrr: sum_mrr / n,
         fp_rate_at_5,
-        correct_heading_rate: heading_rate(&headline_rows),
-        per_category: group_reports(&rows, |r| r.category.as_deref()),
-        per_tier: group_reports(&rows, |r| r.tier.as_deref()),
-        per_language: group_reports(&rows, |r| r.language.as_deref()),
+        // The rerank path collapses to note slugs and carries no query tags, so
+        // heading and per-group breakdowns don't apply here.
+        correct_heading_rate: None,
+        per_category: Vec::new(),
+        per_tier: Vec::new(),
+        per_language: Vec::new(),
         per_query,
         rerank_latency_ms,
         e2e_latency_ms,
@@ -704,9 +680,7 @@ mod rerank_tests {
         let pre = vec![RerankQueryResult {
             query_id: "Q1".to_string(),
             top_k_pre: top(&["a", "b", "x"]), // expected at rank 3 pre
-            top_k_pre_headings: vec![None; 3],
             top_k_post: top(&["x", "a", "b"]), // expected at rank 1 post
-            top_k_post_headings: vec![None; 3],
             rerank_latency_ms: 12.0,
             e2e_latency_ms: 25.0,
         }];
@@ -747,9 +721,7 @@ mod rerank_tests {
         RerankQueryResult {
             query_id: id.to_string(),
             top_k_pre: top(&["x"]),
-            top_k_pre_headings: vec![None],
             top_k_post: top(&["x"]),
-            top_k_post_headings: vec![None],
             rerank_latency_ms: rerank_ms,
             e2e_latency_ms: e2e_ms,
         }

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -1,10 +1,14 @@
 use crate::eval::query::Query;
 
-/// Per-query result. `top_k` is the ordered list of note slugs returned.
+/// Per-query result. `top_k` is the ordered list of note slugs returned;
+/// `top_k_headings` is the parallel list of each hit's heading path (used to
+/// score correct-heading rate). Paths may be empty for retrievers that don't
+/// surface headings (e.g. the hybrid path), which simply score no heading hits.
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     pub query_id: String,
     pub top_k: Vec<String>,
+    pub top_k_headings: Vec<Option<String>>,
 }
 
 /// Aggregate metrics for one model over the full query set.
@@ -18,9 +22,29 @@ pub struct Report {
     pub recall_at_10_all: f64,
     pub mrr: f64,
     pub fp_rate_at_5: f64,
+    /// Fraction of heading-scoped queries whose expected note+heading appeared
+    /// in top-10. `None` when no query declares an `expected_heading_path`.
+    pub correct_heading_rate: Option<f64>,
+    /// Metrics broken out per `category` (empty when no query is tagged).
+    pub per_category: Vec<GroupReport>,
+    /// Metrics broken out per `language` (empty when no query is tagged).
+    pub per_language: Vec<GroupReport>,
     pub per_query: Vec<PerQueryMetrics>,
     pub rerank_latency_ms: Option<LatencyStats>,
     pub e2e_latency_ms: Option<LatencyStats>,
+}
+
+/// Metrics for one subset of queries sharing a grouping label (category or
+/// language). Reported alongside the overall numbers so a change that helps on
+/// average but hurts a specific slice is visible rather than hidden.
+#[derive(Debug, Clone)]
+pub struct GroupReport {
+    pub label: String,
+    pub n: usize,
+    pub recall_at_5_any: f64,
+    pub recall_at_10_any: f64,
+    pub mrr: f64,
+    pub correct_heading_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +90,72 @@ pub fn any_anti_expected_in_top_k(anti: &[String], top_k: &[String]) -> bool {
     anti.iter().any(|a| top_k.iter().any(|t| t == a))
 }
 
+/// Whether the query is answered at heading granularity: some hit is both an
+/// expected note AND carries the expected heading path. `None` when the query
+/// declares no `expected_heading_path` (it isn't a heading-scoped query, so it
+/// is excluded from the correct-heading rate rather than counted as a miss).
+pub fn heading_hit(
+    expected_notes: &[String],
+    expected_heading: Option<&str>,
+    top_slugs: &[String],
+    top_headings: &[Option<String>],
+) -> Option<bool> {
+    let wanted = expected_heading?;
+    let hit = top_slugs.iter().zip(top_headings).any(|(slug, heading)| {
+        expected_notes.iter().any(|e| e == slug) && heading.as_deref() == Some(wanted)
+    });
+    Some(hit)
+}
+
+/// Per-query scored data retained for grouping into category/language reports.
+struct GroupRow {
+    category: Option<String>,
+    language: Option<String>,
+    hit5: bool,
+    hit10: bool,
+    rr: f64,
+    heading: Option<bool>,
+}
+
+fn heading_rate(rows: &[&GroupRow]) -> Option<f64> {
+    let scored: Vec<bool> = rows.iter().filter_map(|r| r.heading).collect();
+    if scored.is_empty() {
+        return None;
+    }
+    Some(scored.iter().filter(|h| **h).count() as f64 / scored.len() as f64)
+}
+
+/// Group rows by a label key (category or language), preserving first-seen order
+/// and skipping untagged rows, into one [`GroupReport`] each.
+fn group_reports(rows: &[GroupRow], key: impl Fn(&GroupRow) -> Option<&str>) -> Vec<GroupReport> {
+    let mut labels: Vec<String> = Vec::new();
+    for row in rows {
+        if let Some(label) = key(row)
+            && !labels.iter().any(|seen| seen == label)
+        {
+            labels.push(label.to_string());
+        }
+    }
+    labels
+        .into_iter()
+        .map(|label| {
+            let subset: Vec<&GroupRow> = rows
+                .iter()
+                .filter(|r| key(r) == Some(label.as_str()))
+                .collect();
+            let denom = subset.len().max(1) as f64;
+            GroupReport {
+                recall_at_5_any: subset.iter().filter(|r| r.hit5).count() as f64 / denom,
+                recall_at_10_any: subset.iter().filter(|r| r.hit10).count() as f64 / denom,
+                mrr: subset.iter().map(|r| r.rr).sum::<f64>() / denom,
+                correct_heading_rate: heading_rate(&subset),
+                n: subset.len(),
+                label,
+            }
+        })
+        .collect()
+}
+
 pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> Report {
     let by_id: std::collections::HashMap<&str, &QueryResult> =
         results.iter().map(|r| (r.query_id.as_str(), r)).collect();
@@ -78,27 +168,39 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
     let mut anti_denom = 0usize;
     let mut anti_num = 0usize;
     let mut per_query = Vec::with_capacity(queries.len());
+    let mut rows: Vec<GroupRow> = Vec::with_capacity(queries.len());
 
     for q in queries {
         let result = by_id.get(q.id.as_str());
         let top_10: Vec<String> = result
             .map(|r| r.top_k.iter().take(10).cloned().collect())
             .unwrap_or_default();
+        let top_10_headings: Vec<Option<String>> = result
+            .map(|r| r.top_k_headings.iter().take(10).cloned().collect())
+            .unwrap_or_default();
         let top_5: Vec<String> = top_10.iter().take(5).cloned().collect();
 
-        if recall_at_k_any(&q.expected_notes, &top_5) {
+        let hit5 = recall_at_k_any(&q.expected_notes, &top_5);
+        let hit10 = recall_at_k_any(&q.expected_notes, &top_10);
+        if hit5 {
             sum_any_5 += 1.0;
         }
-        if recall_at_k_any(&q.expected_notes, &top_10) {
+        if hit10 {
             sum_any_10 += 1.0;
         }
         sum_all_5 += recall_at_k_all(&q.expected_notes, &top_5);
         sum_all_10 += recall_at_k_all(&q.expected_notes, &top_10);
 
         let rank = first_expected_rank(&q.expected_notes, &top_10);
-        if let Some(r) = rank {
-            sum_mrr += 1.0 / r as f64;
-        }
+        let rr = rank.map(|r| 1.0 / r as f64).unwrap_or(0.0);
+        sum_mrr += rr;
+
+        let heading = heading_hit(
+            &q.expected_notes,
+            q.expected_heading_path.as_deref(),
+            &top_10,
+            &top_10_headings,
+        );
 
         let anti_hit = if q.anti_expected.is_empty() {
             None
@@ -119,6 +221,14 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
             rank_pre_rerank: None,
             rank_post_rerank: None,
         });
+        rows.push(GroupRow {
+            category: q.category.clone(),
+            language: q.language.clone(),
+            hit5,
+            hit10,
+            rr,
+            heading,
+        });
     }
 
     let n = queries.len().max(1) as f64;
@@ -127,6 +237,10 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
     } else {
         anti_num as f64 / anti_denom as f64
     };
+    let all_rows: Vec<&GroupRow> = rows.iter().collect();
+    let correct_heading_rate = heading_rate(&all_rows);
+    let per_category = group_reports(&rows, |r| r.category.as_deref());
+    let per_language = group_reports(&rows, |r| r.language.as_deref());
 
     Report {
         model_id: model_id.to_string(),
@@ -137,6 +251,9 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
         recall_at_10_all: sum_all_10 / n,
         mrr: sum_mrr / n,
         fp_rate_at_5,
+        correct_heading_rate,
+        per_category,
+        per_language,
         per_query,
         rerank_latency_ms: None,
         e2e_latency_ms: None,
@@ -268,6 +385,11 @@ pub fn aggregate_rerank(
         recall_at_10_all: sum_all_10 / n,
         mrr: sum_mrr / n,
         fp_rate_at_5,
+        // The rerank path collapses to note slugs and carries no query tags, so
+        // heading and per-group breakdowns don't apply here.
+        correct_heading_rate: None,
+        per_category: Vec::new(),
+        per_language: Vec::new(),
         per_query,
         rerank_latency_ms,
         e2e_latency_ms,
@@ -286,6 +408,8 @@ mod aggregate_tests {
             expected_notes: expected.iter().map(|s| s.to_string()).collect(),
             expected_heading_path: None,
             anti_expected: anti.iter().map(|s| s.to_string()).collect(),
+            category: None,
+            language: None,
         }
     }
 
@@ -293,6 +417,16 @@ mod aggregate_tests {
         QueryResult {
             query_id: id.to_string(),
             top_k: top_k.iter().map(|s| s.to_string()).collect(),
+            top_k_headings: vec![None; top_k.len()],
+        }
+    }
+
+    /// Result helper with parallel heading paths, for correct-heading tests.
+    fn r_h(id: &str, hits: &[(&str, Option<&str>)]) -> QueryResult {
+        QueryResult {
+            query_id: id.to_string(),
+            top_k: hits.iter().map(|(s, _)| s.to_string()).collect(),
+            top_k_headings: hits.iter().map(|(_, h)| h.map(|x| x.to_string())).collect(),
         }
     }
 
@@ -319,6 +453,50 @@ mod aggregate_tests {
         let results = vec![r("a", &["n1"])];
         let rep = aggregate("test", &queries, &results);
         assert_eq!(rep.fp_rate_at_5, 0.0);
+    }
+
+    fn q_tagged(id: &str, note: &str, heading: Option<&str>, category: &str) -> Query {
+        Query {
+            id: id.to_string(),
+            query: format!("q-{id}"),
+            expected_notes: vec![note.to_string()],
+            expected_heading_path: heading.map(str::to_string),
+            anti_expected: Vec::new(),
+            category: Some(category.to_string()),
+            language: None,
+        }
+    }
+
+    #[test]
+    fn aggregate_reports_heading_rate_and_per_category() {
+        let queries = vec![
+            q_tagged("a", "n1", Some("Backups > Restoring"), "heading"),
+            q_tagged("b", "n2", Some("Setup"), "heading"),
+            q_tagged("c", "n3", None, "exact-name"),
+        ];
+        let results = vec![
+            r_h("a", &[("n1", Some("Backups > Restoring"))]), // note + heading hit
+            r_h("b", &[("n2", Some("Wrong heading"))]),       // note hit, heading miss
+            r_h("c", &[("n3", None)]),                        // note hit, not heading-scoped
+        ];
+        let rep = aggregate("test", &queries, &results);
+
+        // 2 heading-scoped queries, 1 correct → 0.5; the exact-name query is
+        // excluded from the heading denominator.
+        assert_eq!(rep.correct_heading_rate, Some(0.5));
+
+        // First-seen category order: "heading" (n=2) then "exact-name" (n=1).
+        assert_eq!(rep.per_category.len(), 2);
+        assert_eq!(rep.per_category[0].label, "heading");
+        assert_eq!(rep.per_category[0].n, 2);
+        assert_eq!(rep.per_category[0].correct_heading_rate, Some(0.5));
+        assert_eq!(rep.per_category[0].recall_at_5_any, 1.0);
+        // A category with no heading-scoped query reports no heading rate.
+        assert_eq!(rep.per_category[1].label, "exact-name");
+        assert_eq!(rep.per_category[1].correct_heading_rate, None);
+
+        // No language tags → no per-language rows.
+        assert!(rep.per_language.is_empty());
     }
 }
 
@@ -354,6 +532,34 @@ mod tests {
     }
 
     #[test]
+    fn heading_hit_requires_both_matching_note_and_heading() {
+        let expected = s(&["runbook"]);
+        let slugs = s(&["runbook", "other"]);
+        let headings = vec![Some("Backups".to_string()), None];
+        assert_eq!(
+            heading_hit(&expected, Some("Backups"), &slugs, &headings),
+            Some(true)
+        );
+        // Expected note present but under a different heading.
+        assert_eq!(
+            heading_hit(&expected, Some("Setup"), &slugs, &headings),
+            Some(false)
+        );
+        // Right heading text, but on a non-expected note.
+        assert_eq!(
+            heading_hit(
+                &expected,
+                Some("Backups"),
+                &s(&["other"]),
+                &[Some("Backups".to_string())]
+            ),
+            Some(false)
+        );
+        // Not a heading-scoped query → excluded from scoring.
+        assert_eq!(heading_hit(&expected, None, &slugs, &headings), None);
+    }
+
+    #[test]
     fn first_rank_is_one_indexed() {
         assert_eq!(
             first_expected_rank(&s(&["b"]), &s(&["a", "b", "c"])),
@@ -385,6 +591,8 @@ mod rerank_tests {
             expected_notes: expected.iter().map(|s| s.to_string()).collect(),
             expected_heading_path: None,
             anti_expected: anti.iter().map(|s| s.to_string()).collect(),
+            category: None,
+            language: None,
         }
     }
 

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -27,6 +27,10 @@ pub struct Report {
     pub correct_heading_rate: Option<f64>,
     /// Metrics broken out per `category` (empty when no query is tagged).
     pub per_category: Vec<GroupReport>,
+    /// Metrics broken out per `tier` (empty when no query is tagged). The
+    /// "diagnostic" tier is shown here as its own row even though it is excluded
+    /// from the headline numbers above.
+    pub per_tier: Vec<GroupReport>,
     /// Metrics broken out per `language` (empty when no query is tagged).
     pub per_language: Vec<GroupReport>,
     pub per_query: Vec<PerQueryMetrics>,
@@ -107,9 +111,10 @@ pub fn heading_hit(
     Some(hit)
 }
 
-/// Per-query scored data retained for grouping into category/language reports.
+/// Per-query scored data retained for grouping into category/tier/language reports.
 struct GroupRow {
     category: Option<String>,
+    tier: Option<String>,
     language: Option<String>,
     hit5: bool,
     hit10: bool,
@@ -167,6 +172,7 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
     let mut sum_mrr = 0.0;
     let mut anti_denom = 0usize;
     let mut anti_num = 0usize;
+    let mut headline_n = 0usize;
     let mut per_query = Vec::with_capacity(queries.len());
     let mut rows: Vec<GroupRow> = Vec::with_capacity(queries.len());
 
@@ -182,36 +188,41 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
 
         let hit5 = recall_at_k_any(&q.expected_notes, &top_5);
         let hit10 = recall_at_k_any(&q.expected_notes, &top_10);
-        if hit5 {
-            sum_any_5 += 1.0;
-        }
-        if hit10 {
-            sum_any_10 += 1.0;
-        }
-        sum_all_5 += recall_at_k_all(&q.expected_notes, &top_5);
-        sum_all_10 += recall_at_k_all(&q.expected_notes, &top_10);
-
         let rank = first_expected_rank(&q.expected_notes, &top_10);
         let rr = rank.map(|r| 1.0 / r as f64).unwrap_or(0.0);
-        sum_mrr += rr;
-
         let heading = heading_hit(
             &q.expected_notes,
             q.expected_heading_path.as_deref(),
             &top_10,
             &top_10_headings,
         );
+        // Whether a plausible-wrong note landed in top-5 (for the per-query
+        // display); folded into the headline FP rate only for non-diagnostic
+        // queries below.
+        let anti_hit = (!q.anti_expected.is_empty())
+            .then(|| any_anti_expected_in_top_k(&q.anti_expected, &top_5));
 
-        let anti_hit = if q.anti_expected.is_empty() {
-            None
-        } else {
-            anti_denom += 1;
-            let hit = any_anti_expected_in_top_k(&q.anti_expected, &top_5);
-            if hit {
-                anti_num += 1;
+        // Diagnostic queries (the staleness slice) are reported apart in
+        // per_tier / per_category but excluded from every headline number.
+        let is_diagnostic = q.tier.as_deref() == Some("diagnostic");
+        if !is_diagnostic {
+            headline_n += 1;
+            if hit5 {
+                sum_any_5 += 1.0;
             }
-            Some(hit)
-        };
+            if hit10 {
+                sum_any_10 += 1.0;
+            }
+            sum_all_5 += recall_at_k_all(&q.expected_notes, &top_5);
+            sum_all_10 += recall_at_k_all(&q.expected_notes, &top_10);
+            sum_mrr += rr;
+            if let Some(hit) = anti_hit {
+                anti_denom += 1;
+                if hit {
+                    anti_num += 1;
+                }
+            }
+        }
 
         per_query.push(PerQueryMetrics {
             id: q.id.clone(),
@@ -223,6 +234,7 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
         });
         rows.push(GroupRow {
             category: q.category.clone(),
+            tier: q.tier.clone(),
             language: q.language.clone(),
             hit5,
             hit10,
@@ -231,15 +243,21 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
         });
     }
 
-    let n = queries.len().max(1) as f64;
+    let n = headline_n.max(1) as f64;
     let fp_rate_at_5 = if anti_denom == 0 {
         0.0
     } else {
         anti_num as f64 / anti_denom as f64
     };
-    let all_rows: Vec<&GroupRow> = rows.iter().collect();
-    let correct_heading_rate = heading_rate(&all_rows);
+    // Headline correct-heading rate excludes the diagnostic slice, matching the
+    // other headline metrics; per_tier still surfaces the diagnostic row.
+    let headline_rows: Vec<&GroupRow> = rows
+        .iter()
+        .filter(|r| r.tier.as_deref() != Some("diagnostic"))
+        .collect();
+    let correct_heading_rate = heading_rate(&headline_rows);
     let per_category = group_reports(&rows, |r| r.category.as_deref());
+    let per_tier = group_reports(&rows, |r| r.tier.as_deref());
     let per_language = group_reports(&rows, |r| r.language.as_deref());
 
     Report {
@@ -253,6 +271,7 @@ pub fn aggregate(model_id: &str, queries: &[Query], results: &[QueryResult]) -> 
         fp_rate_at_5,
         correct_heading_rate,
         per_category,
+        per_tier,
         per_language,
         per_query,
         rerank_latency_ms: None,
@@ -315,6 +334,7 @@ pub fn aggregate_rerank(
     let mut sum_mrr = 0.0;
     let mut anti_denom = 0usize;
     let mut anti_num = 0usize;
+    let mut headline_n = 0usize;
     let mut per_query = Vec::with_capacity(queries.len());
 
     for q in queries {
@@ -324,33 +344,36 @@ pub fn aggregate_rerank(
             .unwrap_or_default();
         let top_5_post: Vec<String> = top_10_post.iter().take(5).cloned().collect();
 
-        if recall_at_k_any(&q.expected_notes, &top_5_post) {
-            sum_any_5 += 1.0;
-        }
-        if recall_at_k_any(&q.expected_notes, &top_10_post) {
-            sum_any_10 += 1.0;
-        }
-        sum_all_5 += recall_at_k_all(&q.expected_notes, &top_5_post);
-        sum_all_10 += recall_at_k_all(&q.expected_notes, &top_10_post);
-
         let rank_post = first_expected_rank(&q.expected_notes, &top_10_post);
-        if let Some(r) = rank_post {
-            sum_mrr += 1.0 / r as f64;
-        }
         let rank_pre = result
             .map(|r| first_expected_rank(&q.expected_notes, &r.top_k_pre))
             .unwrap_or(None);
+        let anti_hit = (!q.anti_expected.is_empty())
+            .then(|| any_anti_expected_in_top_k(&q.anti_expected, &top_5_post));
 
-        let anti_hit = if q.anti_expected.is_empty() {
-            None
-        } else {
-            anti_denom += 1;
-            let hit = any_anti_expected_in_top_k(&q.anti_expected, &top_5_post);
-            if hit {
-                anti_num += 1;
+        // Diagnostic queries are excluded from headline numbers, same as the
+        // pure-retrieval path, so the two runs stay comparable.
+        let is_diagnostic = q.tier.as_deref() == Some("diagnostic");
+        if !is_diagnostic {
+            headline_n += 1;
+            if recall_at_k_any(&q.expected_notes, &top_5_post) {
+                sum_any_5 += 1.0;
             }
-            Some(hit)
-        };
+            if recall_at_k_any(&q.expected_notes, &top_10_post) {
+                sum_any_10 += 1.0;
+            }
+            sum_all_5 += recall_at_k_all(&q.expected_notes, &top_5_post);
+            sum_all_10 += recall_at_k_all(&q.expected_notes, &top_10_post);
+            if let Some(r) = rank_post {
+                sum_mrr += 1.0 / r as f64;
+            }
+            if let Some(hit) = anti_hit {
+                anti_denom += 1;
+                if hit {
+                    anti_num += 1;
+                }
+            }
+        }
 
         per_query.push(PerQueryMetrics {
             id: q.id.clone(),
@@ -362,7 +385,7 @@ pub fn aggregate_rerank(
         });
     }
 
-    let n = queries.len().max(1) as f64;
+    let n = headline_n.max(1) as f64;
     let fp_rate_at_5 = if anti_denom == 0 {
         0.0
     } else {
@@ -389,6 +412,7 @@ pub fn aggregate_rerank(
         // heading and per-group breakdowns don't apply here.
         correct_heading_rate: None,
         per_category: Vec::new(),
+        per_tier: Vec::new(),
         per_language: Vec::new(),
         per_query,
         rerank_latency_ms,
@@ -410,6 +434,21 @@ mod aggregate_tests {
             anti_expected: anti.iter().map(|s| s.to_string()).collect(),
             category: None,
             language: None,
+            tier: None,
+        }
+    }
+
+    /// Query with explicit category and tier, for the per-group / diagnostic tests.
+    fn q_full(id: &str, expected: &[&str], category: Option<&str>, tier: Option<&str>) -> Query {
+        Query {
+            id: id.to_string(),
+            query: format!("q-{id}"),
+            expected_notes: expected.iter().map(|s| s.to_string()).collect(),
+            expected_heading_path: None,
+            anti_expected: Vec::new(),
+            category: category.map(str::to_string),
+            language: None,
+            tier: tier.map(str::to_string),
         }
     }
 
@@ -464,6 +503,7 @@ mod aggregate_tests {
             anti_expected: Vec::new(),
             category: Some(category.to_string()),
             language: None,
+            tier: None,
         }
     }
 
@@ -495,8 +535,42 @@ mod aggregate_tests {
         assert_eq!(rep.per_category[1].label, "exact-name");
         assert_eq!(rep.per_category[1].correct_heading_rate, None);
 
-        // No language tags → no per-language rows.
+        // No language or tier tags → no per-language / per-tier rows.
         assert!(rep.per_language.is_empty());
+        assert!(rep.per_tier.is_empty());
+    }
+
+    #[test]
+    fn diagnostic_tier_excluded_from_headline_but_reported_per_tier() {
+        let queries = vec![
+            q_full("a", &["n1"], Some("conceptual"), Some("hard")),
+            q_full("b", &["n2"], Some("conceptual"), Some("realistic")),
+            q_full("s", &["n3"], Some("staleness"), Some("diagnostic")),
+        ];
+        let results = vec![
+            r("a", &["n1"]),  // hit
+            r("b", &["n2"]),  // hit
+            r("s", &["zzz"]), // diagnostic MISS
+        ];
+        let rep = aggregate("test", &queries, &results);
+
+        // Headline is computed over the 2 non-diagnostic queries only (both hit
+        // → 1.0), not 2/3 that including the diagnostic miss would give.
+        assert_eq!(rep.recall_at_5_any, 1.0);
+        assert_eq!(rep.mrr, 1.0);
+
+        // The diagnostic slice is still visible as its own per_tier row.
+        let diag = rep
+            .per_tier
+            .iter()
+            .find(|g| g.label == "diagnostic")
+            .expect("diagnostic tier row present");
+        assert_eq!(diag.n, 1);
+        assert_eq!(diag.recall_at_5_any, 0.0);
+
+        // And the two headline tiers are broken out.
+        assert!(rep.per_tier.iter().any(|g| g.label == "hard"));
+        assert!(rep.per_tier.iter().any(|g| g.label == "realistic"));
     }
 }
 
@@ -593,6 +667,7 @@ mod rerank_tests {
             anti_expected: anti.iter().map(|s| s.to_string()).collect(),
             category: None,
             language: None,
+            tier: None,
         }
     }
 

--- a/src/eval/query.rs
+++ b/src/eval/query.rs
@@ -9,6 +9,14 @@ pub struct Query {
     pub expected_heading_path: Option<String>,
     #[serde(default)]
     pub anti_expected: Vec<String>,
+    /// Optional grouping label (e.g. "exact-name", "conceptual", "heading").
+    /// When present, the report breaks metrics out per category.
+    #[serde(default)]
+    pub category: Option<String>,
+    /// Optional language tag. Dormant on a single-language set; when present,
+    /// the report breaks metrics out per language.
+    #[serde(default)]
+    pub language: Option<String>,
 }
 
 pub fn load_jsonl(path: &std::path::Path) -> Result<Vec<Query>, String> {
@@ -54,6 +62,24 @@ mod tests {
         assert_eq!(qs[0].expected_notes, vec!["n1", "n2"]);
         assert!(qs[0].anti_expected.is_empty());
         assert_eq!(qs[1].anti_expected, vec!["x"]);
+        // category and language default to None when absent.
+        assert!(qs[0].category.is_none());
+        assert!(qs[0].language.is_none());
+    }
+
+    #[test]
+    fn loads_optional_category_and_language() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("q.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"id":"U1","query":"a","expected_notes":["n1"],"category":"exact-name","language":"en"}}"#
+        )
+        .unwrap();
+        let qs = load_jsonl(&path).expect("load");
+        assert_eq!(qs[0].category.as_deref(), Some("exact-name"));
+        assert_eq!(qs[0].language.as_deref(), Some("en"));
     }
 
     #[test]

--- a/src/eval/query.rs
+++ b/src/eval/query.rs
@@ -17,6 +17,11 @@ pub struct Query {
     /// the report breaks metrics out per language.
     #[serde(default)]
     pub language: Option<String>,
+    /// Difficulty tier ("realistic" | "hard" | "diagnostic"). When present, the
+    /// report breaks metrics out per tier alongside the per-category cut.
+    /// Queries tagged "diagnostic" are excluded from the headline numbers.
+    #[serde(default)]
+    pub tier: Option<String>,
 }
 
 pub fn load_jsonl(path: &std::path::Path) -> Result<Vec<Query>, String> {

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -120,12 +120,7 @@ pub fn append_section(path: &Path, report: &Report, build: &BuildInfo) -> Result
     Ok(())
 }
 
-pub fn append_rerank_section(
-    path: &Path,
-    report: &Report,
-    initial_k: usize,
-    max_pair_tokens: usize,
-) -> Result<(), String> {
+pub fn append_rerank_section(path: &Path, report: &Report, initial_k: usize) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create parent: {e}"))?;
     }
@@ -142,7 +137,6 @@ pub fn append_rerank_section(
     writeln!(f).ok();
     writeln!(f, "- Run timestamp: {now}").ok();
     writeln!(f, "- Initial K: {initial_k}").ok();
-    writeln!(f, "- Max query-document pair tokens: {max_pair_tokens}").ok();
     if let Some(stats) = report.rerank_latency_ms {
         writeln!(
             f,
@@ -168,10 +162,6 @@ pub fn append_rerank_section(
     writeln!(f, "| Recall@10 (all) | {:.3} |", report.recall_at_10_all).ok();
     writeln!(f, "| MRR | {:.3} |", report.mrr).ok();
     writeln!(f, "| FP-rate@5 | {:.3} |", report.fp_rate_at_5).ok();
-    match report.correct_heading_rate {
-        Some(rate) => writeln!(f, "| Correct-heading | {rate:.3} |").ok(),
-        None => writeln!(f, "| Correct-heading | n/a |").ok(),
-    };
     writeln!(f).ok();
     writeln!(f, "### Per-query breakdown").ok();
     writeln!(f).ok();
@@ -525,7 +515,7 @@ mod tests {
     fn append_rerank_section_writes_expected_markdown() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("results.md");
-        append_rerank_section(&path, &fake_rerank_report(), 20, 512).expect("append");
+        append_rerank_section(&path, &fake_rerank_report(), 20).expect("append");
         let text = std::fs::read_to_string(&path).expect("read");
         assert!(text.contains("## Rerank — NomicEmbedTextV15 + JINARerankerV2BaseMultilingual"));
         assert!(text.contains("Initial K: 20"));

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -2,7 +2,36 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::eval::compare_runner::{CompareQueryResult, CompareSummary};
-use crate::eval::metrics::Report;
+use crate::eval::metrics::{GroupReport, Report};
+
+/// Write a markdown table for one grouping dimension (category or language),
+/// or nothing when no query carried that tag.
+fn write_group_table(f: &mut impl Write, title: &str, groups: &[GroupReport]) {
+    if groups.is_empty() {
+        return;
+    }
+    writeln!(f, "### {title}").ok();
+    writeln!(f).ok();
+    writeln!(
+        f,
+        "| Group | N | Recall@5 | Recall@10 | MRR | Correct-heading |"
+    )
+    .ok();
+    writeln!(f, "|---|---|---|---|---|---|").ok();
+    for g in groups {
+        let heading = g
+            .correct_heading_rate
+            .map(|r| format!("{r:.3}"))
+            .unwrap_or_else(|| "n/a".to_string());
+        writeln!(
+            f,
+            "| {} | {} | {:.3} | {:.3} | {:.3} | {heading} |",
+            g.label, g.n, g.recall_at_5_any, g.recall_at_10_any, g.mrr
+        )
+        .ok();
+    }
+    writeln!(f).ok();
+}
 
 pub fn append_section(
     path: &Path,
@@ -37,7 +66,13 @@ pub fn append_section(
     writeln!(f, "| Recall@10 (all) | {:.3} |", report.recall_at_10_all).ok();
     writeln!(f, "| MRR | {:.3} |", report.mrr).ok();
     writeln!(f, "| FP-rate@5 | {:.3} |", report.fp_rate_at_5).ok();
+    match report.correct_heading_rate {
+        Some(rate) => writeln!(f, "| Correct-heading | {rate:.3} |").ok(),
+        None => writeln!(f, "| Correct-heading | n/a |").ok(),
+    };
     writeln!(f).ok();
+    write_group_table(&mut f, "Per-category", &report.per_category);
+    write_group_table(&mut f, "Per-language", &report.per_language);
     writeln!(f, "### Per-query breakdown").ok();
     writeln!(f).ok();
     writeln!(
@@ -361,6 +396,9 @@ mod tests {
             recall_at_10_all: 0.78,
             mrr: 0.61,
             fp_rate_at_5: 0.20,
+            correct_heading_rate: Some(0.5),
+            per_category: Vec::new(),
+            per_language: Vec::new(),
             per_query: vec![PerQueryMetrics {
                 id: "U1".to_string(),
                 query: "Where does my Plex media live?".to_string(),
@@ -412,6 +450,9 @@ mod tests {
             recall_at_10_all: 0.99,
             mrr: 0.95,
             fp_rate_at_5: 0.0,
+            correct_heading_rate: None,
+            per_category: Vec::new(),
+            per_language: Vec::new(),
             per_query: vec![
                 PerQueryMetrics {
                     id: "U5".to_string(),

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -33,11 +33,17 @@ fn write_group_table(f: &mut impl Write, title: &str, groups: &[GroupReport]) {
     writeln!(f).ok();
 }
 
-pub fn append_section(
-    path: &Path,
-    report: &Report,
-    build_duration_secs: Option<f64>,
-) -> Result<(), String> {
+/// Build-phase telemetry read back from cache metadata, reported alongside the
+/// retrieval metrics so each results section records how the index was produced.
+#[derive(Debug, Default, Clone)]
+pub struct BuildInfo {
+    pub duration_secs: Option<f64>,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub peak_rss_mb: Option<f64>,
+}
+
+pub fn append_section(path: &Path, report: &Report, build: &BuildInfo) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create parent: {e}"))?;
     }
@@ -48,7 +54,8 @@ pub fn append_section(
         .map_err(|e| format!("open {}: {e}", path.display()))?;
 
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let dur = build_duration_secs
+    let dur = build
+        .duration_secs
         .map(|s| format!("{s:.1} s"))
         .unwrap_or_else(|| "(unknown)".to_string());
 
@@ -57,6 +64,12 @@ pub fn append_section(
     writeln!(f).ok();
     writeln!(f, "- Run timestamp: {now}").ok();
     writeln!(f, "- Build duration: {dur}").ok();
+    if let (Some(start), Some(end)) = (&build.started_at, &build.finished_at) {
+        writeln!(f, "- Build window: {start} → {end}").ok();
+    }
+    if let Some(rss) = build.peak_rss_mb {
+        writeln!(f, "- Build peak RSS: {rss:.1} MB").ok();
+    }
     writeln!(f).ok();
     writeln!(f, "| Metric | Value |").ok();
     writeln!(f, "|---|---|").ok();
@@ -107,7 +120,12 @@ pub fn append_section(
     Ok(())
 }
 
-pub fn append_rerank_section(path: &Path, report: &Report, initial_k: usize) -> Result<(), String> {
+pub fn append_rerank_section(
+    path: &Path,
+    report: &Report,
+    initial_k: usize,
+    max_pair_tokens: usize,
+) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create parent: {e}"))?;
     }
@@ -124,6 +142,7 @@ pub fn append_rerank_section(path: &Path, report: &Report, initial_k: usize) -> 
     writeln!(f).ok();
     writeln!(f, "- Run timestamp: {now}").ok();
     writeln!(f, "- Initial K: {initial_k}").ok();
+    writeln!(f, "- Max query-document pair tokens: {max_pair_tokens}").ok();
     if let Some(stats) = report.rerank_latency_ms {
         writeln!(
             f,
@@ -149,6 +168,10 @@ pub fn append_rerank_section(path: &Path, report: &Report, initial_k: usize) -> 
     writeln!(f, "| Recall@10 (all) | {:.3} |", report.recall_at_10_all).ok();
     writeln!(f, "| MRR | {:.3} |", report.mrr).ok();
     writeln!(f, "| FP-rate@5 | {:.3} |", report.fp_rate_at_5).ok();
+    match report.correct_heading_rate {
+        Some(rate) => writeln!(f, "| Correct-heading | {rate:.3} |").ok(),
+        None => writeln!(f, "| Correct-heading | n/a |").ok(),
+    };
     writeln!(f).ok();
     writeln!(f, "### Per-query breakdown").ok();
     writeln!(f).ok();
@@ -418,12 +441,23 @@ mod tests {
     fn append_section_writes_expected_markdown() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("results.md");
-        append_section(&path, &fake_report(), Some(612.5)).expect("append");
+        let build = BuildInfo {
+            duration_secs: Some(612.5),
+            started_at: Some("2026-07-25T20:00:00Z".to_string()),
+            finished_at: Some("2026-07-25T20:10:12Z".to_string()),
+            peak_rss_mb: Some(2048.0),
+        };
+        append_section(&path, &fake_report(), &build).expect("append");
         let text = std::fs::read_to_string(&path).expect("read");
         assert!(text.contains("## BGESmallENV15"), "header missing");
         assert!(text.contains("Recall@5 (any)"), "metrics table missing");
         assert!(text.contains("0.840"), "recall_at_5_any value missing");
         assert!(text.contains("612.5"), "build duration missing");
+        assert!(
+            text.contains("2026-07-25T20:10:12Z"),
+            "build window missing"
+        );
+        assert!(text.contains("2048.0 MB"), "peak RSS missing");
         assert!(text.contains("U1"), "per-query row missing");
         assert!(
             text.contains("Where does my Plex media live?"),
@@ -435,8 +469,8 @@ mod tests {
     fn append_section_appends_to_existing_file() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("results.md");
-        append_section(&path, &fake_report(), None).expect("first");
-        append_section(&path, &fake_report(), None).expect("second");
+        append_section(&path, &fake_report(), &BuildInfo::default()).expect("first");
+        append_section(&path, &fake_report(), &BuildInfo::default()).expect("second");
         let text = std::fs::read_to_string(&path).expect("read");
         let occurrences = text.matches("## BGESmallENV15").count();
         assert_eq!(occurrences, 2);
@@ -491,7 +525,7 @@ mod tests {
     fn append_rerank_section_writes_expected_markdown() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("results.md");
-        append_rerank_section(&path, &fake_rerank_report(), 20).expect("append");
+        append_rerank_section(&path, &fake_rerank_report(), 20, 512).expect("append");
         let text = std::fs::read_to_string(&path).expect("read");
         assert!(text.contains("## Rerank — NomicEmbedTextV15 + JINARerankerV2BaseMultilingual"));
         assert!(text.contains("Initial K: 20"));

--- a/src/eval/report.rs
+++ b/src/eval/report.rs
@@ -72,6 +72,7 @@ pub fn append_section(
     };
     writeln!(f).ok();
     write_group_table(&mut f, "Per-category", &report.per_category);
+    write_group_table(&mut f, "Per-tier", &report.per_tier);
     write_group_table(&mut f, "Per-language", &report.per_language);
     writeln!(f, "### Per-query breakdown").ok();
     writeln!(f).ok();
@@ -398,6 +399,7 @@ mod tests {
             fp_rate_at_5: 0.20,
             correct_heading_rate: Some(0.5),
             per_category: Vec::new(),
+            per_tier: Vec::new(),
             per_language: Vec::new(),
             per_query: vec![PerQueryMetrics {
                 id: "U1".to_string(),
@@ -452,6 +454,7 @@ mod tests {
             fp_rate_at_5: 0.0,
             correct_heading_rate: None,
             per_category: Vec::new(),
+            per_tier: Vec::new(),
             per_language: Vec::new(),
             per_query: vec![
                 PerQueryMetrics {

--- a/src/eval/rerank_runner.rs
+++ b/src/eval/rerank_runner.rs
@@ -90,6 +90,7 @@ mod tests {
             expected_heading_path: None,
             category: None,
             language: None,
+            tier: None,
             anti_expected: vec![],
         }];
         let out = run_rerank_eval(&cache, embedder.as_ref(), &reranker, &queries, 5).expect("run");

--- a/src/eval/rerank_runner.rs
+++ b/src/eval/rerank_runner.rs
@@ -19,18 +19,24 @@ pub fn run_rerank_eval(
         let e2e_start = Instant::now();
         let candidates = cache.semantic_search(embedder, &q.query, initial_k)?;
         let top_k_pre: Vec<String> = candidates.iter().map(|c| c.note_slug.clone()).collect();
+        let top_k_pre_headings: Vec<Option<String>> =
+            candidates.iter().map(|c| c.heading_path.clone()).collect();
 
         let rerank_start = Instant::now();
         let reranked = reranker.rerank(&q.query, candidates)?;
         let rerank_latency_ms = rerank_start.elapsed().as_secs_f64() * 1000.0;
 
         let top_k_post: Vec<String> = reranked.iter().map(|c| c.note_slug.clone()).collect();
+        let top_k_post_headings: Vec<Option<String>> =
+            reranked.iter().map(|c| c.heading_path.clone()).collect();
         let e2e_latency_ms = e2e_start.elapsed().as_secs_f64() * 1000.0;
 
         out.push(RerankQueryResult {
             query_id: q.id.clone(),
             top_k_pre,
+            top_k_pre_headings,
             top_k_post,
+            top_k_post_headings,
             rerank_latency_ms,
             e2e_latency_ms,
         });

--- a/src/eval/rerank_runner.rs
+++ b/src/eval/rerank_runner.rs
@@ -88,6 +88,8 @@ mod tests {
             query: "flying baby plane".to_string(),
             expected_notes: vec!["gamma".to_string()],
             expected_heading_path: None,
+            category: None,
+            language: None,
             anti_expected: vec![],
         }];
         let out = run_rerank_eval(&cache, embedder.as_ref(), &reranker, &queries, 5).expect("run");

--- a/src/eval/rerank_runner.rs
+++ b/src/eval/rerank_runner.rs
@@ -19,24 +19,18 @@ pub fn run_rerank_eval(
         let e2e_start = Instant::now();
         let candidates = cache.semantic_search(embedder, &q.query, initial_k)?;
         let top_k_pre: Vec<String> = candidates.iter().map(|c| c.note_slug.clone()).collect();
-        let top_k_pre_headings: Vec<Option<String>> =
-            candidates.iter().map(|c| c.heading_path.clone()).collect();
 
         let rerank_start = Instant::now();
         let reranked = reranker.rerank(&q.query, candidates)?;
         let rerank_latency_ms = rerank_start.elapsed().as_secs_f64() * 1000.0;
 
         let top_k_post: Vec<String> = reranked.iter().map(|c| c.note_slug.clone()).collect();
-        let top_k_post_headings: Vec<Option<String>> =
-            reranked.iter().map(|c| c.heading_path.clone()).collect();
         let e2e_latency_ms = e2e_start.elapsed().as_secs_f64() * 1000.0;
 
         out.push(RerankQueryResult {
             query_id: q.id.clone(),
             top_k_pre,
-            top_k_pre_headings,
             top_k_post,
-            top_k_post_headings,
             rerank_latency_ms,
             e2e_latency_ms,
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod eval;
 pub mod git;
 pub mod handlers;
 pub mod mcp;
+pub mod model_setup;
 pub mod rerank;
 pub mod search;
 pub mod server;

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -1559,11 +1559,21 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
-        let result = &body["result"]["structuredContent"]["results"][0];
-        assert_eq!(result["note_slug"], "home");
-        assert!(result.get("chunk_id").is_some());
-        assert!(result.get("content").is_some());
-        assert!(result.get("score").is_some());
+        let results = body["result"]["structuredContent"]["results"]
+            .as_array()
+            .expect("results array");
+        // Ranking is not asserted: the test embedder hashes inputs to vectors, so
+        // semantic order is arbitrary. What matters is that search surfaces the
+        // matching note and every hit carries the compact chunk shape.
+        assert!(
+            results.iter().any(|r| r["note_slug"] == "home"),
+            "search should surface the home note, got: {results:?}"
+        );
+        let first = &results[0];
+        assert!(first.get("note_slug").is_some());
+        assert!(first.get("chunk_id").is_some());
+        assert!(first.get("content").is_some());
+        assert!(first.get("score").is_some());
     }
 
     #[tokio::test]

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -12,7 +12,7 @@ use super::config::{McpConfig, SERVER_INSTRUCTIONS, negotiate_protocol_version};
 use super::protocol::{
     JsonRpcFailure, JsonRpcRequest, jsonrpc_error_response, jsonrpc_success_response,
 };
-use super::tools::{handle_tools_call, tools_list};
+use super::tools::{handle_tools_call, setup_tools_list, tools_list};
 
 pub async fn mcp_get_handler(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let config = state.mcp_config.clone();
@@ -89,13 +89,21 @@ async fn handle_mcp_post(
 
     let result = match request.method.as_str() {
         "initialize" => {
-            let layers = layer_catalog_for(&state).await;
-            Ok(handle_initialize(request.params.as_ref(), &layers))
+            if state.startup.is_ready() {
+                let layers = layer_catalog_for(&state).await;
+                Ok(handle_initialize(request.params.as_ref(), &layers))
+            } else {
+                Ok(handle_setup_initialize(request.params.as_ref()))
+            }
         }
         "ping" => Ok(json!({})),
         "tools/list" => {
-            let layers = layer_catalog_for(&state).await;
-            Ok(json!({ "tools": tools_list(config, &layers) }))
+            if state.startup.is_ready() {
+                let layers = layer_catalog_for(&state).await;
+                Ok(json!({ "tools": tools_list(config, &layers) }))
+            } else {
+                Ok(json!({ "tools": setup_tools_list() }))
+            }
         }
         "tools/call" => handle_tools_call(state, request.params, config).await,
         method => Err(JsonRpcFailure::method_not_found(format!(
@@ -164,6 +172,19 @@ fn handle_initialize(params: Option<&Value>, layers: &[LayerInfo]) -> Value {
     })
 }
 
+fn handle_setup_initialize(params: Option<&Value>) -> Value {
+    let requested = params
+        .and_then(|params| params.get("protocolVersion"))
+        .and_then(Value::as_str);
+    let protocol_version = negotiate_protocol_version(requested);
+    json!({
+        "protocolVersion": protocol_version,
+        "capabilities": { "tools": { "listChanged": true } },
+        "serverInfo": { "name": "hatchdoor", "version": env!("CARGO_PKG_VERSION") },
+        "instructions": "Hatchdoor needs first-run search-model setup before vault tools are available. Call get_model_setup_status, then either accept_gemma_terms for the multilingual default or decline_gemma_terms to use the English-only Nomic fallback. Acceptance stays local and does not change ownership of vault data."
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,11 +237,18 @@ mod tests {
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(crate::embed::RuntimeEmbedder::new()),
+            model_setup: Arc::new(crate::model_setup::ModelSetup::new(
+                tmp.path().join("models"),
+            )),
+            model_setup_started: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -262,11 +290,18 @@ mod tests {
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(crate::embed::RuntimeEmbedder::new()),
+            model_setup: Arc::new(crate::model_setup::ModelSetup::new(
+                tmp.path().join("models"),
+            )),
+            model_setup_started: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -304,6 +339,58 @@ mod tests {
             search["inputSchema"]["properties"].get("layers").is_none(),
             "a vault with no layers must not advertise a layers parameter"
         );
+    }
+
+    #[tokio::test]
+    async fn first_run_mcp_exposes_only_model_setup_tools() {
+        let (state, _tmp) = test_state();
+        state.startup.set_terms_required();
+        let response = post_json(
+            state,
+            json!({"jsonrpc":"2.0","id":69,"method":"tools/list"}),
+            enabled_config(),
+        )
+        .await;
+        let body = response_json(response).await;
+        let tools = body["result"]["tools"].as_array().expect("tools");
+        assert_eq!(tools.len(), 3);
+        assert!(
+            tools
+                .iter()
+                .any(|tool| tool["name"] == "get_model_setup_status")
+        );
+        assert!(
+            tools
+                .iter()
+                .any(|tool| tool["name"] == "accept_gemma_terms")
+        );
+        assert!(
+            tools
+                .iter()
+                .any(|tool| tool["name"] == "decline_gemma_terms")
+        );
+        assert!(!tools.iter().any(|tool| tool["name"] == "search_notes"));
+    }
+
+    #[tokio::test]
+    async fn first_run_initialize_prompts_model_setup() {
+        let (state, _tmp) = test_state();
+        state.startup.set_terms_required();
+        let response = post_json(
+            state,
+            json!({
+                "jsonrpc":"2.0","id":68,"method":"initialize",
+                "params": {"protocolVersion":"2025-11-25","capabilities":{}}
+            }),
+            enabled_config(),
+        )
+        .await;
+        let body = response_json(response).await;
+        let instructions = body["result"]["instructions"]
+            .as_str()
+            .expect("instructions");
+        assert!(instructions.contains("accept_gemma_terms"));
+        assert!(instructions.contains("does not change ownership of vault data"));
     }
 
     #[tokio::test]

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::app_state::AppState;
 
 use super::config::McpConfig;
-use super::protocol::{JsonRpcFailure, tool_error};
+use super::protocol::{JsonRpcFailure, tool_error, tool_success};
 
 pub async fn handle_tools_call(
     state: AppState,
@@ -29,6 +29,53 @@ pub async fn handle_tools_call(
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| json!({}));
+
+    // Before the first index exists, MCP is deliberately a tiny setup surface.
+    // This lets a headless user make the same explicit Gemma terms choice as the
+    // web UI without exposing any vault operation early.
+    if !state.startup.is_ready() {
+        return match name {
+            "get_model_setup_status" => Ok(tool_success(json!({
+                "state": state.startup.status(),
+                "gemma": {
+                    "model": crate::model_setup::GEMMA_MODEL_ID,
+                    "terms_url": crate::model_setup::GEMMA_TERMS_URL,
+                    "policy_url": crate::model_setup::GEMMA_POLICY_URL,
+                    "terms_version": crate::model_setup::GEMMA_TERMS_VERSION,
+                    "repository": crate::model_setup::GEMMA_REPOSITORY,
+                    "revision": crate::model_setup::GEMMA_REVISION,
+                    "data_notice": "Accepting the terms does not change ownership of your vault data. The acceptance record stays on this machine and is not sent anywhere."
+                },
+                "fallback": {
+                    "model": crate::model_setup::NOMIC_MODEL_ID,
+                    "notice": "Nomic is English-only and provides lower retrieval quality for multilingual vaults."
+                }
+            }))),
+            "accept_gemma_terms" => {
+                state
+                    .model_setup
+                    .accept_gemma()
+                    .map_err(JsonRpcFailure::internal)?;
+                crate::server::spawn_model_startup(state, crate::model_setup::SelectedModel::Gemma);
+                Ok(tool_success(
+                    json!({ "accepted": true, "model": crate::model_setup::GEMMA_MODEL_ID }),
+                ))
+            }
+            "decline_gemma_terms" => {
+                state
+                    .model_setup
+                    .decline_gemma()
+                    .map_err(JsonRpcFailure::internal)?;
+                crate::server::spawn_model_startup(state, crate::model_setup::SelectedModel::Nomic);
+                Ok(tool_success(
+                    json!({ "accepted": false, "model": crate::model_setup::NOMIC_MODEL_ID }),
+                ))
+            }
+            _ => Ok(tool_error(
+                "Hatchdoor is still being set up. Use get_model_setup_status, accept_gemma_terms, or decline_gemma_terms first.".to_string(),
+            )),
+        };
+    }
 
     let outcome = match name {
         "search_notes" => read::search_notes_tool(state, arguments).await,
@@ -110,6 +157,32 @@ pub fn tools_list(config: &McpConfig, layers: &[crate::search::LayerInfo]) -> Ve
         tools.extend(write::write_tools_list());
     }
     tools
+}
+
+/// Tools exposed before a model is selected and the initial vault index is
+/// ready. Keep these schemas dependency-free so any MCP client can complete
+/// first-run setup.
+pub fn setup_tools_list() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "get_model_setup_status",
+            "description": "Show Hatchdoor's first-run embedding model setup status, Gemma terms links, and the local-data privacy notice.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false },
+            "annotations": read_only_tool_annotations(),
+        }),
+        json!({
+            "name": "accept_gemma_terms",
+            "description": "Accept the Gemma terms for this local Hatchdoor instance, then download the multilingual default model and begin indexing. The acceptance record stays local and does not change ownership of vault data.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false },
+            "annotations": write_tool_annotations(false, true),
+        }),
+        json!({
+            "name": "decline_gemma_terms",
+            "description": "Decline Gemma terms, remove any Gemma download/cache, then download Nomic Embed Text v1.5 and begin indexing. Nomic is English-only and lower quality for multilingual vaults.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false },
+            "annotations": write_tool_annotations(true, true),
+        }),
+    ]
 }
 
 /// Arguments for the several tools keyed only by a note slug (read and write).

--- a/src/model_setup.rs
+++ b/src/model_setup.rs
@@ -1,0 +1,472 @@
+//! Persistent, local-only selection and acknowledgement state for Hatchdoor's
+//! startup embedding model. Model files live under the same directory, so
+//! moving the bind mount preserves both the weights and their terms receipt.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hf_hub::api::Progress;
+use hf_hub::api::sync::ApiBuilder;
+use hf_hub::{Cache, Repo, RepoType};
+use serde::{Deserialize, Serialize};
+
+pub const GEMMA_MODEL_ID: &str = "EmbeddingGemma 300M Q4";
+pub const NOMIC_MODEL_ID: &str = "Nomic Embed Text v1.5";
+pub const GEMMA_TERMS_URL: &str = "https://ai.google.dev/gemma/terms";
+pub const GEMMA_POLICY_URL: &str = "https://ai.google.dev/gemma/prohibited_use_policy";
+pub const GEMMA_TERMS_VERSION: &str = "2026-04-01";
+pub const GEMMA_REPOSITORY: &str = "onnx-community/embeddinggemma-300m-ONNX";
+pub const GEMMA_REVISION: &str = "5090578d9565bb06545b4552f76e6bc2c93e4a66";
+/// Enough room for either model plus temporary download files and a fresh
+/// index. The cache is persistent, so setup must fail early rather than leave
+/// a half-written model on a full volume.
+pub const MIN_SETUP_FREE_BYTES: u64 = 512 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectedModel {
+    TermsRequired,
+    Gemma,
+    Nomic,
+}
+
+impl SelectedModel {
+    pub fn id(self) -> Option<&'static str> {
+        match self {
+            Self::TermsRequired => None,
+            Self::Gemma => Some(GEMMA_MODEL_ID),
+            Self::Nomic => Some(NOMIC_MODEL_ID),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SelectionRecord {
+    selected: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AcceptanceRecord {
+    terms_version: String,
+    terms_url: String,
+    prohibited_use_policy_url: String,
+    accepted_at: String,
+    model_repository: String,
+    model_revision: String,
+    hatchdoor_version: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IntegrityRecord {
+    artifacts: Vec<IntegrityArtifact>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IntegrityArtifact {
+    path: String,
+    blake3: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheIntegrity {
+    Missing,
+    Valid,
+    Invalid,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelSetup {
+    models_dir: PathBuf,
+}
+
+impl ModelSetup {
+    pub fn new(models_dir: PathBuf) -> Self {
+        Self { models_dir }
+    }
+
+    pub fn default_models_dir() -> PathBuf {
+        if cfg!(target_os = "linux") && Path::new("/models").is_dir() {
+            PathBuf::from("/models")
+        } else {
+            PathBuf::from("models")
+        }
+    }
+
+    pub fn models_dir(&self) -> &Path {
+        &self.models_dir
+    }
+
+    pub fn model_cache_dir(&self, selected: SelectedModel) -> PathBuf {
+        match selected {
+            SelectedModel::Gemma => self
+                .models_dir
+                .join("embeddinggemma-300m-q4")
+                .join(GEMMA_REVISION),
+            SelectedModel::Nomic => self.models_dir.join("nomic-embed-text-v1.5"),
+            SelectedModel::TermsRequired => self.models_dir.join("pending"),
+        }
+    }
+
+    pub fn selected(&self) -> Result<SelectedModel, String> {
+        let selection_path = self.models_dir.join("selection.json");
+        let Ok(bytes) = std::fs::read(selection_path) else {
+            return Ok(SelectedModel::TermsRequired);
+        };
+        let selection: SelectionRecord = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("invalid local model selection: {error}"))?;
+        match selection.selected.as_str() {
+            "gemma" if self.acceptance_is_current()? => Ok(SelectedModel::Gemma),
+            "nomic" => Ok(SelectedModel::Nomic),
+            _ => Ok(SelectedModel::TermsRequired),
+        }
+    }
+
+    pub fn accept_gemma(&self) -> Result<(), String> {
+        let dir = self.model_cache_dir(SelectedModel::Gemma);
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("create model directory: {error}"))?;
+        let receipt = AcceptanceRecord {
+            terms_version: GEMMA_TERMS_VERSION.to_string(),
+            terms_url: GEMMA_TERMS_URL.to_string(),
+            prohibited_use_policy_url: GEMMA_POLICY_URL.to_string(),
+            accepted_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            model_repository: GEMMA_REPOSITORY.to_string(),
+            model_revision: GEMMA_REVISION.to_string(),
+            hatchdoor_version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        write_json_atomic(&dir.join("acceptance.json"), &receipt)?;
+        self.write_selection("gemma")
+    }
+
+    pub fn decline_gemma(&self) -> Result<(), String> {
+        let gemma_root = self.models_dir.join("embeddinggemma-300m-q4");
+        if gemma_root.exists() {
+            std::fs::remove_dir_all(&gemma_root)
+                .map_err(|error| format!("remove declined Gemma model: {error}"))?;
+        }
+        self.write_selection("nomic")
+    }
+
+    /// Prepare a persistent model directory for an interrupted download to
+    /// resume safely. A changed cached artifact is removed before FastEmbed is
+    /// allowed to use it; a missing manifest simply means this is the first
+    /// download.
+    pub fn prepare_download(&self, selected: SelectedModel) -> Result<(), String> {
+        let dir = self.model_cache_dir(selected);
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("create model directory: {error}"))?;
+        let available = available_bytes(&dir)?;
+        if available < MIN_SETUP_FREE_BYTES {
+            return Err(format!(
+                "not enough free space for model setup: {} MB available, at least {} MB required",
+                available / (1024 * 1024),
+                MIN_SETUP_FREE_BYTES / (1024 * 1024)
+            ));
+        }
+        if self.verify_integrity(selected)? == CacheIntegrity::Invalid {
+            self.remove_downloaded_artifacts(selected)?;
+        }
+        Ok(())
+    }
+
+    /// Download every artifact FastEmbed needs through a fixed Gemma revision,
+    /// then point FastEmbed's normal `main` cache lookup at that immutable
+    /// snapshot. FastEmbed itself does not expose a revision option.
+    pub fn fetch_gemma_at_pinned_revision(
+        &self,
+        report: Arc<dyn Fn(u64, u64) + Send + Sync>,
+    ) -> Result<(), String> {
+        let cache_dir = self.model_cache_dir(SelectedModel::Gemma);
+        let api = ApiBuilder::new()
+            .with_cache_dir(cache_dir.clone())
+            .with_progress(false)
+            .build()
+            .map_err(|error| format!("create Hugging Face download client: {error}"))?;
+        let pinned = api.repo(Repo::with_revision(
+            GEMMA_REPOSITORY.to_string(),
+            RepoType::Model,
+            GEMMA_REVISION.to_string(),
+        ));
+        for file in [
+            "onnx/model_q4.onnx",
+            "onnx/model_q4.onnx_data",
+            "config.json",
+            "special_tokens_map.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ] {
+            pinned
+                .get(file)
+                .or_else(|_| {
+                    pinned.download_with_progress(file, ModelDownloadProgress::new(report.clone()))
+                })
+                .map_err(|error| format!("download Gemma artifact {file}: {error}"))?;
+        }
+        // FastEmbed uses Repo::model (revision "main"). Its cache supports a
+        // local ref, so write `main -> <pinned commit>` only after every needed
+        // artifact landed in the snapshot.
+        Cache::new(cache_dir)
+            .repo(Repo::model(GEMMA_REPOSITORY.to_string()))
+            .create_ref(GEMMA_REVISION)
+            .map_err(|error| format!("activate pinned Gemma snapshot: {error}"))
+    }
+
+    /// Record all downloaded regular files after a successful load. The next
+    /// startup verifies these BLAKE3 digests before reusing the local cache.
+    pub fn record_integrity(&self, selected: SelectedModel) -> Result<(), String> {
+        let dir = self.model_cache_dir(selected);
+        let mut artifacts = Vec::new();
+        for entry in walkdir::WalkDir::new(&dir) {
+            let entry = entry.map_err(|error| format!("walk model cache: {error}"))?;
+            if !entry.file_type().is_file() || is_local_metadata(entry.path()) {
+                continue;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(&dir)
+                .map_err(|error| format!("model cache relative path: {error}"))?
+                .to_string_lossy()
+                .into_owned();
+            artifacts.push(IntegrityArtifact {
+                path: relative,
+                blake3: file_blake3(entry.path())?,
+            });
+        }
+        artifacts.sort_by(|left, right| left.path.cmp(&right.path));
+        if artifacts.is_empty() {
+            return Err("model download completed without cache artifacts".to_string());
+        }
+        write_json_atomic(&dir.join("integrity.json"), &IntegrityRecord { artifacts })
+    }
+
+    pub fn verify_integrity(&self, selected: SelectedModel) -> Result<CacheIntegrity, String> {
+        let dir = self.model_cache_dir(selected);
+        let path = dir.join("integrity.json");
+        let Ok(bytes) = std::fs::read(path) else {
+            return Ok(CacheIntegrity::Missing);
+        };
+        let record: IntegrityRecord = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("invalid model integrity record: {error}"))?;
+        if record.artifacts.is_empty() {
+            return Ok(CacheIntegrity::Invalid);
+        }
+        for artifact in record.artifacts {
+            let path = dir.join(&artifact.path);
+            if !path.is_file() || file_blake3(&path)? != artifact.blake3 {
+                return Ok(CacheIntegrity::Invalid);
+            }
+        }
+        Ok(CacheIntegrity::Valid)
+    }
+
+    /// Discard downloaded artifacts while retaining a Gemma acceptance receipt.
+    /// Used after an unrecoverable first attempt before one clean retry.
+    pub fn reset_download_cache(&self, selected: SelectedModel) -> Result<(), String> {
+        self.remove_downloaded_artifacts(selected)
+    }
+
+    fn remove_downloaded_artifacts(&self, selected: SelectedModel) -> Result<(), String> {
+        let dir = self.model_cache_dir(selected);
+        for entry in
+            std::fs::read_dir(&dir).map_err(|error| format!("read corrupt model cache: {error}"))?
+        {
+            let entry =
+                entry.map_err(|error| format!("read corrupt model cache entry: {error}"))?;
+            let path = entry.path();
+            if is_local_metadata(&path) {
+                continue;
+            }
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+                    .map_err(|error| format!("remove corrupt model cache: {error}"))?;
+            } else {
+                std::fs::remove_file(&path)
+                    .map_err(|error| format!("remove corrupt model artifact: {error}"))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn acceptance_is_current(&self) -> Result<bool, String> {
+        let path = self
+            .model_cache_dir(SelectedModel::Gemma)
+            .join("acceptance.json");
+        let Ok(bytes) = std::fs::read(path) else {
+            return Ok(false);
+        };
+        let receipt: AcceptanceRecord = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("invalid Gemma acceptance receipt: {error}"))?;
+        Ok(receipt.terms_version == GEMMA_TERMS_VERSION
+            && receipt.model_repository == GEMMA_REPOSITORY
+            && receipt.model_revision == GEMMA_REVISION)
+    }
+
+    fn write_selection(&self, selected: &str) -> Result<(), String> {
+        std::fs::create_dir_all(&self.models_dir)
+            .map_err(|error| format!("create models directory: {error}"))?;
+        write_json_atomic(
+            &self.models_dir.join("selection.json"),
+            &SelectionRecord {
+                selected: selected.to_string(),
+            },
+        )
+    }
+}
+
+fn is_local_metadata(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("acceptance.json" | "integrity.json")
+    )
+}
+
+fn file_blake3(path: &Path) -> Result<String, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|error| format!("open model artifact {}: {error}", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("read model artifact {}: {error}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn available_bytes(path: &Path) -> Result<u64, String> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        let path = CString::new(path.as_os_str().as_encoded_bytes())
+            .map_err(|_| "model path contains an interior NUL byte".to_string())?;
+        let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+        // SAFETY: `path` is NUL-terminated and `stat` is valid writable storage.
+        let result = unsafe { libc::statvfs(path.as_ptr(), stat.as_mut_ptr()) };
+        if result != 0 {
+            return Err(format!(
+                "check free space for model directory: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: successful statvfs initializes the output structure.
+        let stat = unsafe { stat.assume_init() };
+        return Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(u64::MAX)
+    }
+}
+
+struct ModelDownloadProgress {
+    report: Arc<dyn Fn(u64, u64) + Send + Sync>,
+    downloaded: u64,
+    total: u64,
+}
+
+impl ModelDownloadProgress {
+    fn new(report: Arc<dyn Fn(u64, u64) + Send + Sync>) -> Self {
+        Self {
+            report,
+            downloaded: 0,
+            total: 0,
+        }
+    }
+}
+
+impl Progress for ModelDownloadProgress {
+    fn init(&mut self, size: usize, _filename: &str) {
+        self.total = size as u64;
+        (self.report)(0, self.total);
+    }
+
+    fn update(&mut self, size: usize) {
+        self.downloaded = self.downloaded.saturating_add(size as u64);
+        (self.report)(self.downloaded, self.total);
+    }
+
+    fn finish(&mut self) {
+        (self.report)(self.total, self.total);
+    }
+}
+
+fn write_json_atomic(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let bytes =
+        serde_json::to_vec_pretty(value).map_err(|error| format!("encode json: {error}"))?;
+    let temporary = path.with_extension("tmp");
+    std::fs::write(&temporary, bytes)
+        .map_err(|error| format!("write {}: {error}", temporary.display()))?;
+    std::fs::rename(&temporary, path)
+        .map_err(|error| format!("replace {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_model_directory_requires_gemma_terms() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            ModelSetup::new(temp.path().join("models"))
+                .selected()
+                .unwrap(),
+            SelectedModel::TermsRequired
+        );
+    }
+
+    #[test]
+    fn accepting_gemma_persists_a_local_versioned_receipt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let setup = ModelSetup::new(temp.path().join("models"));
+        setup.accept_gemma().expect("accept");
+        assert_eq!(setup.selected().unwrap(), SelectedModel::Gemma);
+        let receipt = setup
+            .model_cache_dir(SelectedModel::Gemma)
+            .join("acceptance.json");
+        let text = std::fs::read_to_string(receipt).expect("receipt");
+        assert!(text.contains(GEMMA_TERMS_VERSION));
+        assert!(text.contains(GEMMA_REVISION));
+        assert!(!text.contains("vault"));
+    }
+
+    #[test]
+    fn declining_gemma_removes_its_files_and_selects_nomic() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let setup = ModelSetup::new(temp.path().join("models"));
+        setup.accept_gemma().expect("accept");
+        let gemma_root = setup.models_dir().join("embeddinggemma-300m-q4");
+        std::fs::write(gemma_root.join("partial.onnx"), "partial").expect("partial file");
+        setup.decline_gemma().expect("decline");
+        assert!(!gemma_root.exists());
+        assert_eq!(setup.selected().unwrap(), SelectedModel::Nomic);
+    }
+
+    #[test]
+    fn integrity_manifest_detects_a_changed_cached_artifact() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let setup = ModelSetup::new(temp.path().join("models"));
+        let dir = setup.model_cache_dir(SelectedModel::Nomic);
+        std::fs::create_dir_all(&dir).expect("model dir");
+        let artifact = dir.join("model.onnx");
+        std::fs::write(&artifact, "original model bytes").expect("artifact");
+        setup
+            .record_integrity(SelectedModel::Nomic)
+            .expect("integrity record");
+        assert_eq!(
+            setup.verify_integrity(SelectedModel::Nomic).unwrap(),
+            CacheIntegrity::Valid
+        );
+
+        std::fs::write(artifact, "corrupt bytes").expect("corrupt artifact");
+        assert_eq!(
+            setup.verify_integrity(SelectedModel::Nomic).unwrap(),
+            CacheIntegrity::Invalid
+        );
+    }
+}

--- a/src/model_setup.rs
+++ b/src/model_setup.rs
@@ -182,11 +182,13 @@ impl ModelSetup {
             .with_progress(false)
             .build()
             .map_err(|error| format!("create Hugging Face download client: {error}"))?;
-        let pinned = api.repo(Repo::with_revision(
+        let pinned_repo = Repo::with_revision(
             GEMMA_REPOSITORY.to_string(),
             RepoType::Model,
             GEMMA_REVISION.to_string(),
-        ));
+        );
+        let cached = Cache::new(cache_dir.clone()).repo(pinned_repo.clone());
+        let pinned = api.repo(pinned_repo);
         for file in [
             "onnx/model_q4.onnx",
             "onnx/model_q4.onnx_data",
@@ -195,12 +197,11 @@ impl ModelSetup {
             "tokenizer.json",
             "tokenizer_config.json",
         ] {
-            pinned
-                .get(file)
-                .or_else(|_| {
-                    pinned.download_with_progress(file, ModelDownloadProgress::new(report.clone()))
-                })
-                .map_err(|error| format!("download Gemma artifact {file}: {error}"))?;
+            if cached.get(file).is_none() {
+                pinned
+                    .download_with_progress(file, ModelDownloadProgress::new(report.clone()))
+                    .map_err(|error| format!("download Gemma artifact {file}: {error}"))?;
+            }
         }
         // FastEmbed uses Repo::model (revision "main"). Its cache supports a
         // local ref, so write `main -> <pinned commit>` only after every needed

--- a/src/rerank/fastembed_reranker.rs
+++ b/src/rerank/fastembed_reranker.rs
@@ -1,6 +1,9 @@
 use std::sync::Mutex;
 
-use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
+use fastembed::{
+    OnnxSource, RerankInitOptions, RerankInitOptionsUserDefined, RerankerModel, TextRerank,
+    TokenizerFiles, UserDefinedRerankingModel,
+};
 
 use crate::cache::SemanticHit;
 
@@ -16,10 +19,17 @@ pub struct FastembedReranker {
 }
 
 impl FastembedReranker {
-    fn load(model: RerankerModel, id: &'static str) -> Result<Self, String> {
-        let model =
-            TextRerank::try_new(RerankInitOptions::new(model).with_show_download_progress(false))
-                .map_err(|e| format!("failed to load reranker {id}: {e}"))?;
+    fn load(
+        model: RerankerModel,
+        id: &'static str,
+        max_pair_tokens: usize,
+    ) -> Result<Self, String> {
+        let model = TextRerank::try_new(
+            RerankInitOptions::new(model)
+                .with_max_length(max_pair_tokens)
+                .with_show_download_progress(false),
+        )
+        .map_err(|e| format!("failed to load reranker {id}: {e}"))?;
         Ok(Self {
             model: Mutex::new(model),
             id,
@@ -31,9 +41,14 @@ impl FastembedReranker {
     }
 
     pub fn jina_v1_turbo() -> Result<Self, String> {
+        Self::jina_v1_turbo_with_max_pair_tokens(512)
+    }
+
+    pub fn jina_v1_turbo_with_max_pair_tokens(max_pair_tokens: usize) -> Result<Self, String> {
         Self::load(
             RerankerModel::JINARerankerV1TurboEn,
             "JINARerankerV1TurboEn",
+            max_pair_tokens,
         )
     }
 
@@ -41,10 +56,59 @@ impl FastembedReranker {
     /// "Multiligual". We re-expose it under the corrected spelling
     /// for our own callers.
     pub fn jina_v2_multilingual() -> Result<Self, String> {
+        Self::jina_v2_multilingual_with_max_pair_tokens(512)
+    }
+
+    pub fn jina_v2_multilingual_with_max_pair_tokens(
+        max_pair_tokens: usize,
+    ) -> Result<Self, String> {
         Self::load(
             RerankerModel::JINARerankerV2BaseMultiligual,
             "JINARerankerV2BaseMultilingual",
+            max_pair_tokens,
         )
+    }
+
+    /// BGE's Apache-2.0 multilingual cross-encoder. FastEmbed supplies a
+    /// maintained ONNX package for this model, so it follows the native path.
+    pub fn bge_reranker_v2_m3_with_max_pair_tokens(max_pair_tokens: usize) -> Result<Self, String> {
+        Self::load(
+            RerankerModel::BGERerankerV2M3,
+            "BGERerankerV2M3",
+            max_pair_tokens,
+        )
+    }
+
+    /// Apache-2.0 GTE multilingual cross-encoder, loaded from the ONNX
+    /// Community export of Alibaba's official model. The original repository
+    /// does not publish ONNX assets; the export is needed for Hatchdoor's local
+    /// ONNX Runtime backend.
+    pub fn gte_multilingual_base_with_max_pair_tokens(
+        max_pair_tokens: usize,
+    ) -> Result<Self, String> {
+        const REPO: &str = "onnx-community/gte-multilingual-reranker-base";
+
+        let tokenizer_files = TokenizerFiles {
+            tokenizer_file: crate::embed::hub::fetch_bytes(REPO, "tokenizer.json")?,
+            config_file: crate::embed::hub::fetch_bytes(REPO, "config.json")?,
+            special_tokens_map_file: crate::embed::hub::fetch_bytes(
+                REPO,
+                "special_tokens_map.json",
+            )?,
+            tokenizer_config_file: crate::embed::hub::fetch_bytes(REPO, "tokenizer_config.json")?,
+        };
+        let onnx_path = crate::embed::hub::fetch_path(REPO, "onnx/model.onnx")?;
+        let user_model =
+            UserDefinedRerankingModel::new(OnnxSource::File(onnx_path), tokenizer_files);
+        let model = TextRerank::try_new_from_user_defined(
+            user_model,
+            RerankInitOptionsUserDefined::new().with_max_length(max_pair_tokens),
+        )
+        .map_err(|e| format!("failed to load reranker GTEMultilingualRerankerBase: {e}"))?;
+        Ok(Self {
+            model: Mutex::new(model),
+            id: "GTEMultilingualRerankerBase",
+        })
     }
 }
 

--- a/src/rerank/fastembed_reranker.rs
+++ b/src/rerank/fastembed_reranker.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
 
 use crate::cache::SemanticHit;
@@ -6,7 +8,10 @@ use super::reranker::{RerankedHit, Reranker};
 
 /// fastembed-backed cross-encoder reranker.
 pub struct FastembedReranker {
-    model: TextRerank,
+    // FastEmbed 5's `TextRerank::rerank` takes `&mut self` (Rayon dropped);
+    // the `Reranker` trait is `&self` behind a shared `Arc`, so serialize
+    // scoring through a Mutex.
+    model: Mutex<TextRerank>,
     id: &'static str,
 }
 
@@ -15,7 +20,10 @@ impl FastembedReranker {
         let model =
             TextRerank::try_new(RerankInitOptions::new(model).with_show_download_progress(false))
                 .map_err(|e| format!("failed to load reranker {id}: {e}"))?;
-        Ok(Self { model, id })
+        Ok(Self {
+            model: Mutex::new(model),
+            id,
+        })
     }
 
     pub fn id(&self) -> &'static str {
@@ -53,6 +61,8 @@ impl Reranker for FastembedReranker {
         let documents: Vec<&str> = candidates.iter().map(|c| c.content.as_str()).collect();
         let scored = self
             .model
+            .lock()
+            .map_err(|e| format!("reranker mutex poisoned: {e}"))?
             .rerank(query, documents, false, None)
             .map_err(|e| format!("rerank call failed: {e}"))?;
 

--- a/src/rerank/fastembed_reranker.rs
+++ b/src/rerank/fastembed_reranker.rs
@@ -1,9 +1,6 @@
 use std::sync::Mutex;
 
-use fastembed::{
-    OnnxSource, RerankInitOptions, RerankInitOptionsUserDefined, RerankerModel, TextRerank,
-    TokenizerFiles, UserDefinedRerankingModel,
-};
+use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
 
 use crate::cache::SemanticHit;
 
@@ -19,17 +16,10 @@ pub struct FastembedReranker {
 }
 
 impl FastembedReranker {
-    fn load(
-        model: RerankerModel,
-        id: &'static str,
-        max_pair_tokens: usize,
-    ) -> Result<Self, String> {
-        let model = TextRerank::try_new(
-            RerankInitOptions::new(model)
-                .with_max_length(max_pair_tokens)
-                .with_show_download_progress(false),
-        )
-        .map_err(|e| format!("failed to load reranker {id}: {e}"))?;
+    fn load(model: RerankerModel, id: &'static str) -> Result<Self, String> {
+        let model =
+            TextRerank::try_new(RerankInitOptions::new(model).with_show_download_progress(false))
+                .map_err(|e| format!("failed to load reranker {id}: {e}"))?;
         Ok(Self {
             model: Mutex::new(model),
             id,
@@ -41,14 +31,9 @@ impl FastembedReranker {
     }
 
     pub fn jina_v1_turbo() -> Result<Self, String> {
-        Self::jina_v1_turbo_with_max_pair_tokens(512)
-    }
-
-    pub fn jina_v1_turbo_with_max_pair_tokens(max_pair_tokens: usize) -> Result<Self, String> {
         Self::load(
             RerankerModel::JINARerankerV1TurboEn,
             "JINARerankerV1TurboEn",
-            max_pair_tokens,
         )
     }
 
@@ -56,59 +41,10 @@ impl FastembedReranker {
     /// "Multiligual". We re-expose it under the corrected spelling
     /// for our own callers.
     pub fn jina_v2_multilingual() -> Result<Self, String> {
-        Self::jina_v2_multilingual_with_max_pair_tokens(512)
-    }
-
-    pub fn jina_v2_multilingual_with_max_pair_tokens(
-        max_pair_tokens: usize,
-    ) -> Result<Self, String> {
         Self::load(
             RerankerModel::JINARerankerV2BaseMultiligual,
             "JINARerankerV2BaseMultilingual",
-            max_pair_tokens,
         )
-    }
-
-    /// BGE's Apache-2.0 multilingual cross-encoder. FastEmbed supplies a
-    /// maintained ONNX package for this model, so it follows the native path.
-    pub fn bge_reranker_v2_m3_with_max_pair_tokens(max_pair_tokens: usize) -> Result<Self, String> {
-        Self::load(
-            RerankerModel::BGERerankerV2M3,
-            "BGERerankerV2M3",
-            max_pair_tokens,
-        )
-    }
-
-    /// Apache-2.0 GTE multilingual cross-encoder, loaded from the ONNX
-    /// Community export of Alibaba's official model. The original repository
-    /// does not publish ONNX assets; the export is needed for Hatchdoor's local
-    /// ONNX Runtime backend.
-    pub fn gte_multilingual_base_with_max_pair_tokens(
-        max_pair_tokens: usize,
-    ) -> Result<Self, String> {
-        const REPO: &str = "onnx-community/gte-multilingual-reranker-base";
-
-        let tokenizer_files = TokenizerFiles {
-            tokenizer_file: crate::embed::hub::fetch_bytes(REPO, "tokenizer.json")?,
-            config_file: crate::embed::hub::fetch_bytes(REPO, "config.json")?,
-            special_tokens_map_file: crate::embed::hub::fetch_bytes(
-                REPO,
-                "special_tokens_map.json",
-            )?,
-            tokenizer_config_file: crate::embed::hub::fetch_bytes(REPO, "tokenizer_config.json")?,
-        };
-        let onnx_path = crate::embed::hub::fetch_path(REPO, "onnx/model.onnx")?;
-        let user_model =
-            UserDefinedRerankingModel::new(OnnxSource::File(onnx_path), tokenizer_files);
-        let model = TextRerank::try_new_from_user_defined(
-            user_model,
-            RerankInitOptionsUserDefined::new().with_max_length(max_pair_tokens),
-        )
-        .map_err(|e| format!("failed to load reranker GTEMultilingualRerankerBase: {e}"))?;
-        Ok(Self {
-            model: Mutex::new(model),
-            id: "GTEMultilingualRerankerBase",
-        })
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,6 +2,7 @@
 //! checks, and the `serve` run loop. Kept in the library (rather than the binary
 //! root) so the HTTP surface is reachable from integration tests.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use axum::extract::DefaultBodyLimit;
@@ -14,13 +15,13 @@ use axum::{Json, Router};
 use tokio::sync::RwLock;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::app_state::{AppState, VaultCache, build_cache_with_sqlite_and_progress};
 use crate::auth::{WebOrMcpToken, WebToken, require_web_or_mcp_token, require_web_token};
 use crate::cache::SqliteCache;
 use crate::config::AppConfig;
-use crate::embed::{Embedder, FastembedEmbedder};
+use crate::embed::{Embedder, FastembedEmbedder, RuntimeEmbedder};
 use crate::git::{self, GitConfig};
 use crate::handlers::{
     archive_note_handler, create_note_handler, delete_note_handler, diagnostics_handler,
@@ -31,6 +32,7 @@ use crate::handlers::{
     vault_asset_handler, vault_events_handler, write_capabilities_handler,
 };
 use crate::mcp::{McpConfig, mcp_get_handler, mcp_post_handler};
+use crate::model_setup::{ModelSetup, SelectedModel};
 use crate::startup::StartupTracker;
 use crate::vault_watcher::spawn_vault_watcher;
 
@@ -184,18 +186,29 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
         require_vault_ready,
     ));
 
+    let model_setup = Router::new()
+        .route("/api/model/accept-gemma", post(accept_gemma_handler))
+        .route("/api/model/decline-gemma", post(decline_gemma_handler))
+        .route("/api/model/retry", post(retry_model_setup_handler));
+    let model_setup = match web_bearer_token.clone() {
+        Some(token) => model_setup.layer(axum::middleware::from_fn_with_state(
+            WebToken(token),
+            require_web_token,
+        )),
+        None => model_setup,
+    };
+
+    // MCP remains reachable during initial setup: it exposes only the three
+    // model-setup tools until the vault is ready (enforced in tools::dispatch).
     let mcp = Router::new()
         .route("/mcp", get(mcp_get_handler).post(mcp_post_handler))
-        .layer(DefaultBodyLimit::max(mcp_body_limit))
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            require_vault_ready,
-        ));
+        .layer(DefaultBodyLimit::max(mcp_body_limit));
 
     Router::new()
         .route("/health", get(health_handler))
         .route("/ready", get(readiness_handler))
         .route("/api/startup-status", get(startup_status_handler))
+        .merge(model_setup)
         .merge(mcp)
         .merge(protected)
         .merge(attachment)
@@ -253,6 +266,191 @@ async fn readiness_handler(State(state): State<AppState>) -> Response {
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, "not ready").into_response()
     }
+}
+
+async fn accept_gemma_handler(State(state): State<AppState>) -> Response {
+    match state.model_setup.accept_gemma() {
+        Ok(()) => {
+            spawn_model_startup(state, SelectedModel::Gemma);
+            StatusCode::ACCEPTED.into_response()
+        }
+        Err(error) => model_setup_error(error),
+    }
+}
+
+async fn decline_gemma_handler(State(state): State<AppState>) -> Response {
+    match state.model_setup.decline_gemma() {
+        Ok(()) => {
+            spawn_model_startup(state, SelectedModel::Nomic);
+            StatusCode::ACCEPTED.into_response()
+        }
+        Err(error) => model_setup_error(error),
+    }
+}
+
+async fn retry_model_setup_handler(State(state): State<AppState>) -> Response {
+    match state.model_setup.selected() {
+        Ok(selected @ (SelectedModel::Gemma | SelectedModel::Nomic)) => {
+            spawn_model_startup(state, selected);
+            StatusCode::ACCEPTED.into_response()
+        }
+        Ok(SelectedModel::TermsRequired) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": "Gemma terms must be accepted or declined first." })),
+        )
+            .into_response(),
+        Err(error) => model_setup_error(error),
+    }
+}
+
+fn model_setup_error(error: String) -> Response {
+    error!("Model setup error: {error}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "Model setup could not be started." })),
+    )
+        .into_response()
+}
+
+pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
+    if state.model_setup_started.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    let tracker = state.startup.clone();
+    let model_name = selected.id().unwrap_or("search model");
+    tracker.set_downloading(model_name, None, None);
+    info!(
+        model = model_name,
+        "Downloading and loading startup embedding model"
+    );
+
+    tokio::spawn(async move {
+        let model_dir = state.model_setup.model_cache_dir(selected);
+        let runtime = state.runtime_embedder.clone();
+        let model_setup = state.model_setup.clone();
+        let download_tracker = tracker.clone();
+        let load_result = tokio::task::spawn_blocking(move || -> Result<(), String> {
+            model_setup.prepare_download(selected)?;
+            for attempt in 0..=1 {
+                let loaded = (|| -> Result<Arc<dyn Embedder>, String> {
+                    if selected == SelectedModel::Gemma {
+                        let progress = {
+                            let download_tracker = download_tracker.clone();
+                            Arc::new(move |downloaded, total| {
+                                download_tracker.set_downloading(
+                                    model_name,
+                                    Some(downloaded),
+                                    Some(total),
+                                );
+                            })
+                        };
+                        model_setup.fetch_gemma_at_pinned_revision(progress)?;
+                    }
+                    match selected {
+                        SelectedModel::Gemma => Ok(Arc::new(
+                            FastembedEmbedder::embedding_gemma_300m_q4_in(model_dir.clone())?,
+                        )),
+                        SelectedModel::Nomic => Ok(Arc::new(FastembedEmbedder::nomic_v1_5_in(
+                            model_dir.clone(),
+                        )?)),
+                        SelectedModel::TermsRequired => {
+                            Err("model terms have not been accepted".to_string())
+                        }
+                    }
+                })();
+                match loaded.and_then(|embedder| {
+                    model_setup.record_integrity(selected)?;
+                    Ok(embedder)
+                }) {
+                    Ok(embedder) => {
+                        runtime.set(embedder, selected == SelectedModel::Gemma);
+                        return Ok(());
+                    }
+                    Err(error) if attempt == 0 => {
+                        warn!(
+                            model = model_name,
+                            "Model setup attempt failed; retrying once: {error}"
+                        );
+                        model_setup.reset_download_cache(selected)?;
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            unreachable!("the retry loop always returns")
+        })
+        .await;
+
+        match load_result {
+            Ok(Ok(())) => {
+                tracker.set_scanning();
+                let progress_tracker = tracker.clone();
+                let on_progress = Arc::new(move |progress| progress_tracker.set_indexing(progress));
+                let index_state = state.clone();
+                let index_result = tokio::task::spawn_blocking(move || {
+                    let sqlite = index_state.cache.blocking_read().sqlite.clone();
+                    build_cache_with_sqlite_and_progress(
+                        &index_state.vault_path,
+                        sqlite,
+                        index_state.embedder.as_ref(),
+                        Some(on_progress),
+                        &index_state.scan_config,
+                    )
+                })
+                .await;
+                match index_result {
+                    Ok(Ok(_)) => {
+                        tracker.set_ready();
+                        info!(
+                            model = model_name,
+                            "Model setup and vault indexing complete"
+                        );
+                        if let Some(git_config) = state.startup_git_config.as_ref().clone() {
+                            let handle = git::spawn_sync_task(
+                                git_config,
+                                state.vault_write_lock.clone(),
+                                git::SyncOps {
+                                    commit: Box::new(git::commit_local),
+                                    fetch: Box::new(git::fetch_remote),
+                                    integrate: Box::new(git::integrate_fetched),
+                                    push: Box::new(git::push_branch),
+                                },
+                            );
+                            let _ = state.git_sync.set(handle);
+                            info!("Git sync enabled");
+                        }
+                        spawn_vault_watcher(
+                            state.clone(),
+                            state.vault_path.clone(),
+                            state.cache_db_path.clone(),
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        tracker.set_failed();
+                        error!("Failed to index vault after model setup: {error}");
+                        spawn_vault_watcher(
+                            state.clone(),
+                            state.vault_path.clone(),
+                            state.cache_db_path.clone(),
+                        );
+                    }
+                    Err(error) => {
+                        tracker.set_failed();
+                        error!("Vault indexing task failed: {error}");
+                    }
+                }
+            }
+            Ok(Err(error)) => {
+                state.model_setup_started.store(false, Ordering::Release);
+                tracker.set_model_setup_failed();
+                error!(model = model_name, "Model download/load failed: {error}");
+            }
+            Err(error) => {
+                state.model_setup_started.store(false, Ordering::Release);
+                tracker.set_model_setup_failed();
+                error!(model = model_name, "Model setup task failed: {error}");
+            }
+        }
+    });
 }
 
 async fn require_vault_ready(
@@ -343,11 +541,13 @@ pub async fn run_server() {
         }),
     );
 
-    let embedder: Arc<dyn Embedder> =
-        Arc::new(FastembedEmbedder::nomic_v1_5().unwrap_or_else(|e| {
-            error!("Failed to load embedder: {e}");
-            std::process::exit(1);
-        }));
+    let model_setup = Arc::new(ModelSetup::new(ModelSetup::default_models_dir()));
+    let selected_model = model_setup.selected().unwrap_or_else(|error| {
+        error!("Model setup state is invalid: {error}");
+        std::process::exit(1);
+    });
+    let runtime_embedder = Arc::new(RuntimeEmbedder::new());
+    let embedder: Arc<dyn Embedder> = runtime_embedder.clone();
 
     let scan_config = Arc::new(crate::vault::VaultScanConfig {
         exclude: crate::vault::ExcludeMatcher::new(&config.exclude_patterns).unwrap_or_else(|e| {
@@ -373,9 +573,14 @@ pub async fn run_server() {
 
     let (vault_events, _) = tokio::sync::broadcast::channel(64);
     let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
-    let startup = StartupTracker::scanning();
+    let startup = if selected_model == SelectedModel::TermsRequired {
+        StartupTracker::terms_required()
+    } else {
+        StartupTracker::scanning()
+    };
     let state = AppState {
         vault_path: config.vault_path.clone(),
+        cache_db_path: config.cache_db_path.clone(),
         cache: Arc::new(RwLock::new(VaultCache {
             sqlite: sqlite.clone(),
         })),
@@ -383,6 +588,10 @@ pub async fn run_server() {
         vault_events,
         mcp_tools_changed,
         embedder,
+        runtime_embedder,
+        model_setup,
+        model_setup_started: Arc::new(AtomicBool::new(false)),
+        startup_git_config: Arc::new(git_sync_config.clone()),
         web_auth_enabled: config.web_bearer_token.is_some(),
         demo_mode: config.demo_mode,
         vault_write_lock,
@@ -417,73 +626,9 @@ pub async fn run_server() {
             std::process::exit(1);
         });
 
-    let indexing_state = state.clone();
-    let vault_path = config.vault_path.clone();
-    let cache_db_path = config.cache_db_path.clone();
-    let indexing_sqlite = sqlite.clone();
-    let indexing_embedder = state.embedder.clone();
-    tokio::spawn(async move {
-        let tracker = indexing_state.startup.clone();
-        let progress_tracker = tracker.clone();
-        let on_progress = Arc::new(move |progress| {
-            progress_tracker.set_indexing(progress);
-        });
-        let indexing_vault_path = vault_path.clone();
-        let indexing_scan_config = indexing_state.scan_config.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            build_cache_with_sqlite_and_progress(
-                &indexing_vault_path,
-                indexing_sqlite,
-                indexing_embedder.as_ref(),
-                Some(on_progress),
-                &indexing_scan_config,
-            )
-        })
-        .await;
-
-        match result {
-            Ok(Ok(_)) => {
-                tracker.set_ready();
-                if let Some(git_config) = git_sync_config {
-                    // Start sync only after the first consistent index is committed.
-                    let handle = git::spawn_sync_task(
-                        git_config,
-                        indexing_state.vault_write_lock.clone(),
-                        git::SyncOps {
-                            commit: Box::new(git::commit_local),
-                            fetch: Box::new(git::fetch_remote),
-                            integrate: Box::new(git::integrate_fetched),
-                            push: Box::new(git::push_branch),
-                        },
-                    );
-                    let _ = indexing_state.git_sync.set(handle);
-                    info!("Git sync enabled");
-                }
-                spawn_vault_watcher(indexing_state, vault_path, cache_db_path);
-            }
-            Ok(Err(e)) => {
-                tracker.set_failed();
-                error!(
-                    "Failed to index vault at {} into SQLite cache {}: {e}. The vault watcher \
-                     will retry on the next change — correct the error (e.g. a malformed \
-                     .hatchdoor-layer marker) to recover without a restart. Git sync, if \
-                     configured, was not started and requires a restart.",
-                    vault_path.display(),
-                    cache_db_path.display()
-                );
-                // Spawn the watcher even though the first index failed, so a
-                // corrected vault triggers a recovering reindex (run_reindex
-                // clears the failed startup state on success). git_sync_config is
-                // intentionally dropped here: git sync begins only after a clean
-                // startup index.
-                spawn_vault_watcher(indexing_state, vault_path, cache_db_path);
-            }
-            Err(e) => {
-                tracker.set_failed();
-                error!("Vault indexing task failed: {e}");
-            }
-        }
-    });
+    if selected_model != SelectedModel::TermsRequired {
+        spawn_model_startup(state.clone(), selected_model);
+    }
 
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         error!("Server error: {e}");
@@ -564,11 +709,16 @@ mod tests {
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(RuntimeEmbedder::new()),
+            model_setup: Arc::new(ModelSetup::new(tmp.path().join("models"))),
+            model_setup_started: Arc::new(AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: web_bearer_token.is_some(),
             demo_mode,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -603,11 +753,16 @@ mod tests {
         mcp_config.bearer_token = mcp_bearer_token;
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(RuntimeEmbedder::new()),
+            model_setup: Arc::new(ModelSetup::new(tmp.path().join("models"))),
+            model_setup_started: Arc::new(AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: web_bearer_token.is_some(),
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -792,7 +947,7 @@ mod tests {
             .expect("response");
         assert_eq!(readiness.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        for path in ["/api/tree", "/mcp"] {
+        for path in ["/api/tree"] {
             let response = app
                 .clone()
                 .oneshot(
@@ -952,11 +1107,16 @@ mod tests {
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(RuntimeEmbedder::new()),
+            model_setup: Arc::new(ModelSetup::new(tmp.path().join("models"))),
+            model_setup_started: Arc::new(AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: false,
             demo_mode: false,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -1020,6 +1180,19 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(no_token.status(), StatusCode::UNAUTHORIZED);
+
+        let model_setup_without_token = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/model/retry")
+                    .method("POST")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(model_setup_without_token.status(), StatusCode::UNAUTHORIZED);
 
         let with_header = app
             .clone()
@@ -1700,11 +1873,16 @@ mod tests {
         let (mcp_tools_changed, _) = tokio::sync::broadcast::channel(16);
         let state = AppState {
             vault_path: vault_root,
+            cache_db_path: tmp.path().join("cache.sqlite3"),
             cache: Arc::new(RwLock::new(cache)),
             vault_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             vault_events,
             mcp_tools_changed,
             embedder,
+            runtime_embedder: Arc::new(RuntimeEmbedder::new()),
+            model_setup: Arc::new(ModelSetup::new(tmp.path().join("models"))),
+            model_setup_started: Arc::new(AtomicBool::new(true)),
+            startup_git_config: Arc::new(None),
             web_auth_enabled: false,
             demo_mode: true,
             vault_write_lock: Arc::new(tokio::sync::Mutex::new(())),

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,6 +86,17 @@ pub fn check_demo_mode_posture(
     Ok(())
 }
 
+fn initial_model_for_startup(demo_mode: bool, selected: SelectedModel) -> SelectedModel {
+    // A public, read-only demo has no person available to accept Gemma's terms.
+    // It may use an already-selected model, otherwise use the no-terms Nomic
+    // fallback without persisting that choice for a later normal deployment.
+    if demo_mode && selected == SelectedModel::TermsRequired {
+        SelectedModel::Nomic
+    } else {
+        selected
+    }
+}
+
 /// Multipart framing (boundary lines, field headers, the small
 /// `target_relative_path` text field) wrapped around the uploaded file. The
 /// attachment body limit is the configured max file size plus this slack, so a
@@ -197,6 +208,10 @@ pub fn build_router(state: AppState, web_bearer_token: Option<Arc<str>>) -> Rout
         )),
         None => model_setup,
     };
+    let model_setup = model_setup.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        reject_demo_model_setup,
+    ));
 
     // MCP remains reachable during initial setup: it exposes only the three
     // model-setup tools until the vault is ready (enforced in tools::dispatch).
@@ -425,6 +440,7 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                         );
                     }
                     Ok(Err(error)) => {
+                        state.model_setup_started.store(false, Ordering::Release);
                         tracker.set_failed();
                         error!("Failed to index vault after model setup: {error}");
                         spawn_vault_watcher(
@@ -434,6 +450,7 @@ pub(crate) fn spawn_model_startup(state: AppState, selected: SelectedModel) {
                         );
                     }
                     Err(error) => {
+                        state.model_setup_started.store(false, Ordering::Release);
                         tracker.set_failed();
                         error!("Vault indexing task failed: {error}");
                     }
@@ -469,6 +486,17 @@ async fn require_vault_ready(
         })),
     )
         .into_response()
+}
+
+async fn reject_demo_model_setup(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.demo_mode {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    next.run(request).await
 }
 
 /// The HTTP surface is intentionally default-only. In demo mode reject an
@@ -546,6 +574,7 @@ pub async fn run_server() {
         error!("Model setup state is invalid: {error}");
         std::process::exit(1);
     });
+    let selected_model = initial_model_for_startup(config.demo_mode, selected_model);
     let runtime_embedder = Arc::new(RuntimeEmbedder::new());
     let embedder: Arc<dyn Embedder> = runtime_embedder.clone();
 
@@ -670,6 +699,22 @@ mod tests {
 
         let git_error = check_demo_mode_posture(true, false, true).expect_err("git rejected");
         assert!(git_error.contains("HATCHDOOR_GIT_SYNC_ENABLED"));
+    }
+
+    #[test]
+    fn demo_mode_uses_nomic_when_gemma_terms_have_not_been_accepted() {
+        assert_eq!(
+            initial_model_for_startup(true, SelectedModel::TermsRequired),
+            SelectedModel::Nomic
+        );
+        assert_eq!(
+            initial_model_for_startup(true, SelectedModel::Gemma),
+            SelectedModel::Gemma
+        );
+        assert_eq!(
+            initial_model_for_startup(false, SelectedModel::TermsRequired),
+            SelectedModel::TermsRequired
+        );
     }
 
     use axum::body::{Body, to_bytes};
@@ -1391,6 +1436,22 @@ mod tests {
                 .iter()
                 .any(|warning| warning.as_str().unwrap_or("").contains("demo mode"))
         );
+    }
+
+    #[tokio::test]
+    async fn demo_mode_hides_model_selection_endpoints() {
+        let (app, _tmp, _state) = app_for_tests_with_web_auth_and_demo_mode(None, true);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/model/retry")
+                    .method("POST")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -32,16 +32,28 @@ impl IndexingProgressSnapshot {
 
 #[derive(Clone, Debug)]
 enum StartupPhase {
+    TermsRequired,
+    Downloading {
+        model: &'static str,
+        downloaded_bytes: Option<u64>,
+        total_bytes: Option<u64>,
+    },
     Scanning,
     Indexing(IndexingProgressSnapshot),
     Ready,
-    Failed,
+    Failed {
+        message: String,
+    },
 }
 
 #[derive(Clone, Debug)]
 pub struct StartupTracker(Arc<RwLock<StartupPhase>>);
 
 impl StartupTracker {
+    pub fn terms_required() -> Self {
+        Self(Arc::new(RwLock::new(StartupPhase::TermsRequired)))
+    }
+
     pub fn scanning() -> Self {
         Self(Arc::new(RwLock::new(StartupPhase::Scanning)))
     }
@@ -54,6 +66,23 @@ impl StartupTracker {
         *self.0.write().expect("startup tracker poisoned") = StartupPhase::Scanning;
     }
 
+    pub fn set_terms_required(&self) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::TermsRequired;
+    }
+
+    pub fn set_downloading(
+        &self,
+        model: &'static str,
+        downloaded_bytes: Option<u64>,
+        total_bytes: Option<u64>,
+    ) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Downloading {
+            model,
+            downloaded_bytes,
+            total_bytes,
+        };
+    }
+
     pub fn set_indexing(&self, progress: IndexingProgressSnapshot) {
         *self.0.write().expect("startup tracker poisoned") = StartupPhase::Indexing(progress);
     }
@@ -63,7 +92,19 @@ impl StartupTracker {
     }
 
     pub fn set_failed(&self) {
-        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Failed;
+        self.set_failed_with_message("Indexing could not be completed.");
+    }
+
+    pub fn set_model_setup_failed(&self) {
+        self.set_failed_with_message(
+            "The search model could not be downloaded or loaded. Check the Hatchdoor logs, then retry setup.",
+        );
+    }
+
+    fn set_failed_with_message(&self, message: impl Into<String>) {
+        *self.0.write().expect("startup tracker poisoned") = StartupPhase::Failed {
+            message: message.into(),
+        };
     }
 
     pub fn is_ready(&self) -> bool {
@@ -75,9 +116,32 @@ impl StartupTracker {
 
     pub fn status(&self) -> StartupStatusResponse {
         match *self.0.read().expect("startup tracker poisoned") {
+            StartupPhase::TermsRequired => StartupStatusResponse::simple("terms_required", None),
+            StartupPhase::Downloading {
+                model,
+                downloaded_bytes,
+                total_bytes,
+            } => StartupStatusResponse {
+                state: "downloading",
+                model: Some(model),
+                downloaded_bytes,
+                total_bytes,
+                notes_completed: None,
+                notes_total: None,
+                chunks_completed: None,
+                chunks_total: None,
+                tokens_completed: None,
+                tokens_total: None,
+                percent: download_percent(downloaded_bytes, total_bytes),
+                eta_seconds: None,
+                message: None,
+            },
             StartupPhase::Scanning => StartupStatusResponse::simple("scanning", None),
             StartupPhase::Indexing(progress) => StartupStatusResponse {
                 state: "indexing",
+                model: None,
+                downloaded_bytes: None,
+                total_bytes: None,
                 notes_completed: Some(progress.notes_completed),
                 notes_total: Some(progress.notes_total),
                 chunks_completed: Some(progress.chunks_completed),
@@ -89,8 +153,8 @@ impl StartupTracker {
                 message: None,
             },
             StartupPhase::Ready => StartupStatusResponse::simple("ready", None),
-            StartupPhase::Failed => {
-                StartupStatusResponse::simple("failed", Some("Indexing could not be completed."))
+            StartupPhase::Failed { ref message } => {
+                StartupStatusResponse::simple("failed", Some(message.clone()))
             }
         }
     }
@@ -99,6 +163,12 @@ impl StartupTracker {
 #[derive(Clone, Debug, Serialize)]
 pub struct StartupStatusResponse {
     pub state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downloaded_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes_completed: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,13 +186,16 @@ pub struct StartupStatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eta_seconds: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<&'static str>,
+    pub message: Option<String>,
 }
 
 impl StartupStatusResponse {
-    fn simple(state: &'static str, message: Option<&'static str>) -> Self {
+    fn simple(state: &'static str, message: Option<String>) -> Self {
         Self {
             state,
+            model: None,
+            downloaded_bytes: None,
+            total_bytes: None,
             notes_completed: None,
             notes_total: None,
             chunks_completed: None,
@@ -133,5 +206,45 @@ impl StartupStatusResponse {
             eta_seconds: None,
             message,
         }
+    }
+}
+
+fn download_percent(downloaded: Option<u64>, total: Option<u64>) -> Option<u8> {
+    let (Some(downloaded), Some(total)) = (downloaded, total) else {
+        return None;
+    };
+    (total > 0).then(|| ((downloaded.saturating_mul(100) / total).min(100)) as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terms_required_is_not_ready_and_is_exposed_to_the_ui() {
+        let tracker = StartupTracker::terms_required();
+        assert!(!tracker.is_ready());
+        let status = tracker.status();
+        assert_eq!(status.state, "terms_required");
+        assert!(status.percent.is_none());
+    }
+
+    #[test]
+    fn download_status_carries_model_and_byte_progress() {
+        let tracker = StartupTracker::terms_required();
+        tracker.set_downloading("EmbeddingGemma 300M Q4", Some(25), Some(100));
+        let status = tracker.status();
+        assert_eq!(status.state, "downloading");
+        assert_eq!(status.model, Some("EmbeddingGemma 300M Q4"));
+        assert_eq!(status.downloaded_bytes, Some(25));
+        assert_eq!(status.total_bytes, Some(100));
+        assert_eq!(status.percent, Some(25));
+    }
+
+    #[test]
+    fn unknown_download_size_does_not_invent_a_percentage() {
+        let tracker = StartupTracker::terms_required();
+        tracker.set_downloading("Nomic Embed Text v1.5", None, None);
+        assert_eq!(tracker.status().percent, None);
     }
 }


### PR DESCRIPTION
## Summary
- upgrade the embedding stack and record the benchmark decisions
- make multilingual EmbeddingGemma the consent-gated first-run default
- provide persistent model storage, Nomic fallback, progress, and recovery safeguards
- document the model setup and move the UI/UX redesign target to v2.5.0

## Validation
- backend and frontend test suites
- live first-run Gemma download, acceptance, fallback, and Compose permissions checks