### PR TITLE
Simplify persistent model bind mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ HOST_VAULT_PATH=./vault
 # HOST_CACHE_PATH stores Hatchdoor's generated SQLite cache on the host.
 HOST_CACHE_PATH=./data/cache
 # HOST_MODELS_PATH stores downloaded embedding models and Gemma's local terms
-# acceptance receipt. Docker Compose makes this directory writable for Hatchdoor.
+# acceptance receipt.
 HOST_MODELS_PATH=./models
 
 # Container/runtime paths. In Docker, these should match the mounted container paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,6 @@
   surface a created, moved, archived, or uploaded item belongs to.
 
 ### Changed
-- Docker Compose now prepares the persistent `/models` bind mount for the
-  rootless runtime user. Set `HOST_MODELS_PATH` to retain downloaded models and
-  the local Gemma terms receipt across container replacement.
 - The `/mcp` request-body limit is raised to fit base64 attachment inflation so a
   legitimately sized upload is not rejected before the tool's own size check.
 - `POST /api/attachment` now accepts the MCP bearer token as an alternative to

--- a/README.md
+++ b/README.md
@@ -275,8 +275,6 @@ For read-only browsing:
 
 - Mount the vault read-only if you want.
 - Keep the cache directory writable.
-- Keep the models directory writable. The supplied Compose file prepares it for
-  Hatchdoor's unprivileged runtime user automatically.
 
 For browser writes, MCP writes, attachment uploads, or git sync:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,4 @@
 services:
-  model-permissions:
-    # Docker creates a missing bind-mount directory as root. Give the unprivileged
-    # Hatchdoor process ownership before it writes its local acceptance receipt
-    # or downloads model artifacts.
-    image: alpine:3.21
-    volumes:
-      - ${HOST_MODELS_PATH:-./models}:/models
-    command: ["chown", "-R", "65532:65532", "/models"]
-    restart: "no"
-
   hatchdoor:
     image: battermanz/hatchdoor:latest
     container_name: hatchdoor
@@ -26,9 +16,6 @@ services:
       # Model downloads and the local Gemma acceptance record persist across
       # image upgrades. Bind-mount this directory to avoid re-downloading.
       - ${HOST_MODELS_PATH:-./models}:/models
-    depends_on:
-      model-permissions:
-        condition: service_completed_successfully
     restart: unless-stopped
     healthcheck:
       # Distroless runtime has no shell/curl, so the binary probes its own


### PR DESCRIPTION
## Summary
- keep the normal persistent `/models` bind mount
- remove the Alpine ownership helper and startup dependency
- remove documentation claiming Compose manages bind-mount permissions