### PR TITLE
Establish scoped collaboration boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Agent Instructions
+
+## CodeGraph
+
+When a `.codegraph/` directory exists at the repository root, reach for
+CodeGraph before grep, find, or reading source files when locating or
+understanding code:
+
+```bash
+codegraph explore "<symbols or question>"
+```
+
+When the CodeGraph MCP tool is available, prefer `codegraph_explore`. It returns
+relevant source, call paths, and blast-radius information in one query.
+
+If `.codegraph/` is absent, use normal search/read tools and do not initialize an
+index automatically. If the directory exists but neither the MCP tool nor CLI is
+available, fall back to normal search/read tools rather than blocking the task.
+
+## Collaboration boundaries
+
+Before changing code, tests, or project tooling/configuration:
+
+1. Read [`docs/architecture/module-map.md`](docs/architecture/module-map.md).
+2. Read the relevant ADR records in
+   [`docs/adr/README.md`](docs/adr/README.md), including any linked record that
+   contains the full decision.
+3. Identify or create a work packet using
+   [`docs/architecture/work-packet-template.md`](docs/architecture/work-packet-template.md).
+4. State the owned paths, public contract, coordination paths, consumed
+   dependencies, forbidden paths/invariants, and validation commands.
+
+An existing issue or task description counts as the work packet when it includes
+those fields. Otherwise, record them in the agent's working plan or task notes
+before coding. Committing a separate packet document is optional unless the
+task explicitly requests one.
+
+A work packet narrows the user-requested outcome; it never grants authority to
+broaden that outcome or perform opportunistic cleanup. Owned paths are writable
+only within that outcome. Coordination paths are writable only when the packet
+explicitly lists the required integration change. Consuming a module does not
+grant permission to edit it.
+
+If implementation requires an undeclared path:
+
+- stop expanding the diff;
+- determine whether it is an internal, contract, or coordination change;
+- when the path is necessary for the existing requested outcome and does not
+  materially increase risk or authority, declare it in the work packet before
+  editing it;
+- when it would materially broaden the outcome, risk, or required authority,
+  stop and ask the user before proceeding;
+- follow the
+  [`interface-change checklist`](docs/architecture/interface-change-checklist.md)
+  whenever a supported contract crosses its producing module boundary or is
+  externally observable, even when one work packet owns the producer and every
+  in-repository consumer.
+
+Do not treat a directory layout as proof of isolation. Composition files such
+as `src/server.rs`, `src/app_state.rs`, and `frontend/src/App.tsx` are declared
+integration points and have no default feature owner.
+
+## Architecture guardrails
+
+- Keep one binary and one shared core; do not split domains into services.
+- Keep HTTP and MCP mutations routed through `src/vault/write/`.
+- Keep Markdown authoritative and SQLite disposable.
+- Keep runtime search behavior consistent with ADR-05 unless a superseding ADR
+  is part of the task.
+- Prefer Rust privacy, narrow re-exports, existing ESLint rules, and focused
+  tests over new frameworks or speculative abstractions.
+- Do not add traits, packages, state libraries, or code generation solely to
+  make a boundary appear more formal.
+
+## Validation
+
+Run the focused checks named in the work packet while developing. Before
+hand-off, run the full checks appropriate to all changed paths as documented in
+`CONTRIBUTING.md`.
+
+When production source files are added, moved, deleted, or reclassified, update
+the module map and, from the repository root, run:
+
+```bash
+node scripts/check-module-map.mjs
+```
+
+Also update the map when supported contracts, invariants, cross-module
+dependencies/consumers, coordination paths, or focused validation change. The
+checker verifies structural coverage only; semantic accuracy still requires
+review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,62 @@ before the fix, and new behavior with tests that cover it.
 Do not commit real vault content, private eval queries, tokens, generated cache
 databases, or local model caches.
 
+## Claiming scoped work
+
+Hatchdoor uses documented module boundaries so a contributor or coding agent can
+work without taking implicit ownership of unrelated code.
+
+Before implementation:
+
+1. Find the relevant boundary in
+   [`docs/architecture/module-map.md`](docs/architecture/module-map.md).
+2. Read the applicable records in
+   [`docs/adr/`](docs/adr/README.md), including any linked record containing the
+   full decision.
+3. Define the task with the
+   [`work-packet template`](docs/architecture/work-packet-template.md).
+4. List owned paths, any shared coordination paths, stable contracts,
+   dependencies, invariants, and exact validation commands.
+
+A work packet narrows the requested outcome; it does not authorize unrelated
+cleanup or broader work. An import or dependency does not make another module
+writable.
+
+If implementation requires an undeclared path, stop expanding the diff and
+classify it as an internal, contract, or coordination change. A path necessary
+for the existing outcome may be declared before editing when it does not
+materially increase risk or authority. Ask the user before proceeding when it
+would materially broaden the outcome, risk, or required authority.
+
+Any supported contract that crosses its producing module boundary or is
+externally observable must follow the
+[`interface-change checklist`](docs/architecture/interface-change-checklist.md),
+even when one work packet owns the producer and every in-repository consumer.
+The checklist does not grant authority to edit undeclared consumers.
+
+Composition files such as `src/server.rs`, `src/app_state.rs`, and
+`frontend/src/App.tsx` are expected integration points, not feature-owned
+shortcuts. A task may change one when its work packet states the precise
+integration required.
+
+When adding, moving, deleting, or reclassifying production source files, update
+the module map and verify its structural coverage:
+
+```bash
+node scripts/check-module-map.mjs
+```
+
+Also update the map when supported contracts, invariants, cross-module
+dependencies or consumers, coordination paths, or focused validation change.
+The checker verifies path coverage, not whether those descriptions remain
+semantically accurate.
+
+When changing the checker itself, run its isolated regression tests:
+
+```bash
+node --test scripts/check-module-map.test.mjs
+```
+
 ## Architecture decisions
 
 Before a structural change, read [`docs/adr/`](docs/adr/README.md). Those records

--- a/README.md
+++ b/README.md
@@ -741,9 +741,11 @@ docker push battermanz/hatchdoor:latest
 
 ## Project Docs
 
-- [Product roadmap](docs/product-roadmap.md): draft overall product direction
+- [Documentation index](docs/README.md): architecture, collaboration, roadmap,
+  research, maintenance, and historical records.
+- [Product roadmap](docs/roadmap/product-roadmap.md): draft overall product direction
   and the workstreams it breaks into.
-- [Design system](docs/design-system.html): visual tokens, component patterns,
+- [Design system](docs/design/design-system.html): visual tokens, component patterns,
   layout rules, and interaction states used by the frontend.
 - [Semantic search strategy](docs/adr/semantic-search-strategy.md): decision
   record for shipping pure semantic search instead of hybrid retrieval or a

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Hatchdoor Documentation
+
+Use this page as the entry point for project documentation. Documents are
+grouped by purpose so active guidance is easy to distinguish from research and
+historical records.
+
+## Architecture and collaboration
+
+- [`adr/`](adr/README.md) — binding architecture decisions and their history.
+- [`architecture/module-map.md`](architecture/module-map.md) — current module
+  ownership, contracts, dependencies, and validation.
+- [`architecture/work-packet-template.md`](architecture/work-packet-template.md)
+  — scope template for contributor and agent work.
+- [`architecture/interface-change-checklist.md`](architecture/interface-change-checklist.md)
+  — safety checklist for cross-boundary or externally observable contracts.
+- [`architecture/domain-collaboration-plan.md`](architecture/domain-collaboration-plan.md)
+  — implemented collaboration-boundary plan.
+- [`architecture/collaboration-pilot-assessment.md`](architecture/collaboration-pilot-assessment.md)
+  — evidence and limitations from the initial boundary pilots.
+
+## Product direction
+
+- [`roadmap/product-roadmap.md`](roadmap/product-roadmap.md) — overall product
+  direction and workstreams.
+- [`roadmap/vault-lifecycle.md`](roadmap/vault-lifecycle.md) — detailed vault
+  lifecycle and multi-vault workstream.
+
+## Design
+
+- [`design/design-system.html`](design/design-system.html) — frontend visual
+  tokens, component patterns, layouts, and interaction states.
+
+## Maintenance
+
+- [`maintenance/dependency-update-plan.md`](maintenance/dependency-update-plan.md)
+  — completed dependency-update plan and retained upgrade context.
+
+## Research
+
+- [`research/embeddings/`](research/embeddings/) — embedding-model,
+  licensing, evaluation, and FastEmbed feasibility records.
+
+Research records inform decisions but are not binding architecture policy.
+Accepted decisions belong in `adr/`.
+
+## Historical reviews and implementation records
+
+- [`reviews/`](reviews/) — point-in-time pull-request and implementation
+  reviews.
+- [`superpowers/`](superpowers/) — task-specific design, handoff, and
+  implementation records retained for context.
+
+## Runtime-coupled documentation
+
+- [`starter-vault/`](starter-vault/) — documentation and example content
+  compiled into Hatchdoor's seeded starter vault. Moving these files requires
+  updating their `include_str!` or `include_bytes!` paths in `src/vault/seed.rs`.

--- a/docs/architecture/collaboration-pilot-assessment.md
+++ b/docs/architecture/collaboration-pilot-assessment.md
@@ -1,0 +1,103 @@
+# Collaboration Boundary Pilot Assessment
+
+## Verdict
+
+The collaboration model is ready to use for real scoped work. The pilots support
+explicit ownership, declared coordination paths, and lightweight enforcement
+without splitting the application or adding architectural frameworks.
+
+Do not extract another feature solely for consistency. Apply the model to the
+next real collaborator task and improve a boundary only when that task exposes a
+specific problem.
+
+## Bounded Graph dry run
+
+Task: add focused Graph page fetch-error coverage.
+
+Observed scope:
+
+- one Graph-owned test file;
+- one temporary work-packet record, removed after its durable findings were
+  captured in this assessment;
+- zero production changes;
+- zero coordination-file changes;
+- zero undeclared integration points.
+
+The packet provided enough context to test the public behavior. Browser gaps
+were handled locally instead of expanding shared test infrastructure.
+
+## Frontend Search structural pilot
+
+Task: co-locate Search behind a public feature entry point without changing
+behavior.
+
+The temporary work-packet record was removed after its durable findings were
+captured in this assessment.
+
+Resulting boundary:
+
+- one feature directory owns Search state, dialog, types, tests, and styles;
+- one public TypeScript entry point;
+- one production consumer (`App.tsx`) importing the public entry point;
+- zero production imports into Search internals;
+- ESLint enforcement for future external imports;
+- five Search-specific type declarations removed from the shared type file;
+- focused tests for dialog and debounced hook behavior.
+
+Declared coordination files were sufficient except for one source-audit test
+that imported the stylesheet as raw text. Validation found it, work stopped,
+the packet was updated, and then the import was migrated. This is the escalation
+behavior the process was designed to produce.
+
+No backend Search, cache, embedding, ranking, MCP, or HTTP behavior changed.
+
+## Validation evidence
+
+- Module-map coverage audit: every current production Rust and frontend source
+  path is represented.
+- Graph focused test: passed.
+- Search focused tests: passed.
+- Client source-audit contracts: passed.
+- ESLint: passed.
+- TypeScript typecheck: passed.
+- Full frontend tests: 37 test files and 180 tests passed.
+- Frontend production build: passed.
+- `git diff --check`: passed.
+
+The repository-wide Prettier check reports ten pre-existing files outside this
+work's diff. All files changed by the pilots were formatted directly.
+
+## What the pilot proves
+
+- A bounded task can stay entirely inside its owned paths.
+- A structural feature task can use a small, predictable coordination set.
+- Public-entry imports can be enforced with existing tooling.
+- The work-packet escalation rule catches a missed non-symbol dependency such
+  as a raw CSS import.
+- Composition files can remain explicit integration points without moving
+  feature behavior into them.
+
+## What it does not prove
+
+- Every full-stack capability should become a frontend feature directory.
+- `AppState` should be replaced with per-domain service traits.
+- Backend modules need separate crates or additional abstraction layers.
+- Permanent human ownership can be inferred; `CODEOWNERS` still requires named
+  maintainers and agreement.
+- Tokens or context were quantitatively reduced against a controlled baseline.
+  The structural proxies improved, but future real tasks should supply the
+  comparison data.
+
+## Recommendation
+
+Use the work-packet template for the next collaborator request. Record:
+
+- undeclared paths discovered;
+- unrelated implementation files inspected;
+- coordination files changed;
+- focused checks used;
+- public contracts changed.
+
+Revisit the module map after that task. Add another enforced feature boundary
+only if the evidence shows that current layout or imports caused avoidable
+context or blast radius.

--- a/docs/architecture/domain-collaboration-plan.md
+++ b/docs/architecture/domain-collaboration-plan.md
@@ -4,7 +4,7 @@
 
 Implemented and validated. The durable results and remaining evidence gaps are
 recorded in
-[`docs/architecture/collaboration-pilot-assessment.md`](architecture/collaboration-pilot-assessment.md).
+[`collaboration-pilot-assessment.md`](collaboration-pilot-assessment.md).
 
 ## Goal
 

--- a/docs/architecture/interface-change-checklist.md
+++ b/docs/architecture/interface-change-checklist.md
@@ -1,0 +1,90 @@
+# Interface Change Checklist
+
+Use this checklist whenever a supported contract crosses its producing module
+boundary or is externally observable, even when one work packet owns both the
+producer and every in-repository consumer. Internal refactors that preserve the
+contract and its observable behavior do not need it.
+
+Copy or record the applicable checklist items in the work packet, issue, pull
+request, or handoff notes. Do not mark up this canonical file for an individual
+change.
+
+This checklist does not expand the work packet's authority. Declare consumer
+edits as owned or coordination paths before changing them, follow the packet's
+escalation rules, and obtain explicit user approval before materially broadening
+the outcome or making a breaking change.
+
+## Declare the change
+
+- [ ] Name the producing module boundary.
+- [ ] Name the contract: function or Rust type; serialized or persistent
+      format; HTTP route, payload, status, error, header, auth, or origin
+      behavior; MCP tool/schema; CLI argument, output, or exit behavior;
+      frontend export or import path; externally observable UI behavior; CSS
+      selector; event; configuration value; filesystem behavior; or ordering
+      and timing behavior.
+- [ ] Record the old and proposed contract shape or behavior.
+- [ ] Explain why the existing contract cannot support the outcome.
+- [ ] List every discovered consumer and its owning boundary, plus how
+      consumers were searched for.
+- [ ] State whether the change is additive, behavior-changing, or breaking.
+- [ ] State compatibility expectations, including external or unknown
+      consumers.
+- [ ] Describe deployment or migration order and rollback/fallback behavior
+      where relevant.
+
+## Preserve architectural invariants
+
+- [ ] Check the applicable records in `docs/adr/`; changing a binding invariant
+      requires an explicitly scoped superseding ADR.
+- [ ] Keep web and MCP writes routed through `vault/write/`.
+- [ ] Keep Markdown authoritative and SQLite disposable.
+- [ ] Keep auth/token/origin requirements at least as strict.
+- [ ] Keep runtime retrieval behavior consistent with ADR-05 unless an
+      explicitly scoped superseding ADR is part of the change.
+- [ ] Avoid a new abstraction unless the change demonstrates its concrete
+      value.
+
+Record `N/A` with a reason for invariant checks that do not apply.
+
+## Update consumers and evidence
+
+- [ ] Declare each required consumer edit in the work packet before editing it;
+      ask the user first if it materially broadens the outcome, risk, or
+      authority.
+- [ ] Update all declared in-repository consumers or document a compatible
+      migration.
+- [ ] Update Rust and TypeScript wire representations together where relevant.
+- [ ] Add or update focused contract tests.
+- [ ] Update the module map if ownership, dependencies, or integration points
+      changed.
+- [ ] Update user or agent documentation when observable behavior changed.
+
+## Validate
+
+- [ ] Run focused producer tests.
+- [ ] Run focused consumer tests.
+- [ ] Run the full checks for every affected backend/frontend surface.
+- [ ] Record the exact validation commands, their starting directories, and
+      their results.
+- [ ] Run `node scripts/check-module-map.mjs` from the repository root when
+      production source files or module-map classifications changed.
+- [ ] Confirm the final working-tree status contains only owned paths, declared
+      coordination paths, and the optional packet record, including any newly
+      created files.
+
+## Pull-request summary
+
+Include a short block in the pull request:
+
+```markdown
+Interface change: <name>
+Producer boundary: <module>
+Kind: <additive | behavior-changing | breaking>
+Old contract: <shape or behavior>
+New contract: <shape or behavior>
+Consumer boundaries: <list, including external or unknown consumers>
+Compatibility/migration: <summary>
+Rollout/rollback: <order and fallback, or N/A with reason>
+Evidence: <exact validation commands/results and documentation>
+```

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1,0 +1,894 @@
+# Hatchdoor Module Map
+
+## Purpose
+
+This map defines collaboration boundaries for humans and coding agents. It
+describes the repository as it exists today; it does not imply that every
+listed boundary should become a package, crate, or feature directory.
+
+Use this map together with
+[`docs/domain-collaboration-plan.md`](../domain-collaboration-plan.md). A work
+packet narrows this catalog to one task and declares any exceptions before work
+starts.
+
+## Boundary vocabulary
+
+- **Owned paths:** implementation a module owner may change freely within the
+  task.
+- **Public contract:** the supported names, serialized shapes, or behavior that
+  collaborators should rely on outside the module. This is narrower than every
+  symbol that happens to be technically `pub` in Rust; current visibility does
+  not enforce every documented boundary.
+- **Coordination paths:** shared or composition files that may change only when
+  the work packet lists them.
+- **Consumed dependencies:** modules this boundary may call but does not own.
+- **Invariant:** behavior that must remain true, usually backed by an ADR.
+
+“Owner” means the owner of a work packet, not a permanent person or team.
+Shared and composition files have no default task owner.
+
+## Change rules
+
+1. Internal changes may stay inside owned paths when the public contract and
+   invariants do not change.
+2. Public-contract changes must be declared and list affected consumers.
+3. Coordination files are not implicitly writable because a module imports
+   them.
+4. Adapter code must not absorb domain behavior merely to avoid coordinating
+   with the domain.
+5. A full-stack feature can span multiple boundaries, but its work packet must
+   enumerate each boundary and integration point.
+6. When this map and the code disagree, stop and update the map or the work
+   packet before expanding the diff.
+
+## When to update this map
+
+Update this map in the same change when:
+
+- a production file is added, moved, or deleted;
+- a file's owner, boundary kind, or shared/composition status changes;
+- a supported public contract or invariant changes;
+- a cross-module consumer, dependency, or coordination path is added or
+  removed;
+- the focused validation for a boundary changes.
+
+Do not update the map for an ordinary internal edit that preserves all of the
+above. Structural coverage can be checked mechanically, but contract and
+invariant accuracy still require review.
+
+Run the structural check after adding, moving, deleting, or reclassifying
+production source files:
+
+```bash
+node scripts/check-module-map.mjs
+```
+
+The production inventory includes Rust `*.rs` files except standalone
+`tests.rs`, plus frontend `*.ts`, `*.tsx`, and `*.css` files except
+`*.test.ts`, `*.test.tsx`, and `frontend/src/test/**`. Exact assignments outside
+that production inventory are still checked for stale paths and duplicates.
+
+## Backend
+
+### Runtime composition
+
+**Kind:** composition/shared.
+
+**Owned paths:** none by default.
+
+**Paths:**
+
+- `src/lib.rs`
+- `src/main.rs`
+- `src/server.rs`
+- `src/app_state.rs`
+- `src/config.rs`
+- `src/startup.rs`
+- `src/model_setup.rs`
+- `src/vault_watcher.rs`
+
+**Contract and responsibility:**
+
+- `lib.rs` exposes the application modules to the main binary and auxiliary
+  binaries.
+- `main.rs` selects serve, model-prefetch, and container-healthcheck modes.
+- `server.rs` is the HTTP composition root: it validates startup posture,
+  constructs `AppState`, builds routes, and starts background work.
+- `AppState` and `VaultCache` carry shared runtime state; `build_cache*`,
+  `sqlite_cache`, `refresh_coalescing`, and `refresh_now` coordinate reindexing.
+- `AppConfig` is the environment-derived deployment contract.
+- `StartupTracker` exposes startup/model/indexing readiness.
+- `ModelSetup` owns local model selection, terms acceptance, download integrity,
+  and persistent setup records.
+- `spawn_vault_watcher` connects filesystem events to cache refresh.
+
+**Consumed dependencies:** nearly every backend boundary. This is expected for
+a composition boundary and is not a reason to introduce per-domain service
+traits.
+
+**Coordination rule:** any work packet touching these files must name the
+specific field, route, startup phase, or integration being changed. Adding an
+`AppState` field requires identifying every constructing test fixture.
+
+**Invariants:**
+
+- One binary serves HTTP, MCP, and the SPA over one shared core (ADR-02).
+- Unsafe public/auth and demo configurations fail at startup (ADR-07).
+- Model inference remains local and CPU-capable (ADR-04).
+- Cache refresh preserves the disposable-read-model contract (ADR-01/06).
+- The runtime image cannot assume a shell (ADR-12).
+
+**Validation:** `cargo test server`, `cargo test app_state`,
+`cargo test config`, `cargo test startup`, `cargo test model_setup`,
+`cargo test vault_watcher`, followed by the full backend checks.
+
+### Web authentication
+
+**Kind:** infrastructure/security.
+
+**Owned paths:** `src/auth.rs`.
+
+**Public contract:** `WebToken`, `WebOrMcpToken`,
+`require_web_token`, and `require_web_or_mcp_token`.
+
+**Consumers:** `server.rs` and protected HTTP routes.
+
+**Coordination paths:** `src/server.rs`, `src/config.rs`, frontend
+`frontend/src/api/api.ts`, and any route whose authentication requirements
+change.
+
+**Invariants:** constant-time token comparison, no token logging, and deliberate
+query-parameter fallback for browser contexts that cannot set headers (ADR-08).
+
+**Validation:** `cargo test auth` and server/router tests.
+
+### HTTP wire types
+
+**Kind:** shared contract.
+
+**Owned paths:** `src/api_types.rs`.
+
+**Public contract:** the shared serialized request and response structures
+defined here, including note, links, resolve, refresh, recent, stats, graph,
+and search query shapes. Endpoint-local wire types remain owned by their
+handlers, notably write types in `handlers/write_api.rs` and diagnostics types
+in `handlers/diagnostics.rs`.
+
+**Consumers:** `src/handlers/**` and the manually corresponding frontend types
+in `frontend/src/types.ts` or feature-local client types.
+
+**Coordination rule:** serialized field changes are interface changes. The work
+packet must identify backend handlers, frontend consumers, and compatibility
+expectations. Additive response fields are usually compatible but still require
+the frontend contract to be checked.
+
+**Validation:** affected backend handler tests, affected frontend consumer
+tests, and frontend typecheck. Rust and TypeScript wire shapes are manually
+synchronized; no automated cross-language schema check currently exists.
+
+### Vault read model and filesystem interpretation
+
+**Kind:** product capability/domain core.
+
+**Owned paths:**
+
+- `src/vault.rs`
+- `src/vault/exclude.rs`
+- `src/vault/index.rs`
+- `src/vault/layers.rs`
+- `src/vault/links.rs`
+- `src/vault/paths.rs`
+- `src/vault/seed.rs`
+- `src/vault/types.rs`
+- `src/vault/tests.rs`
+
+**Public contract:** the intentional re-exports from `src/vault.rs`, notably
+`VaultIndex`, note/tree/link types, path normalization helpers, layer and
+exclusion types, and `seed_empty_vault`.
+
+**Consumed dependencies:** filesystem traversal and parsing; `cache::parse`
+currently supplies content hashing to the index.
+
+**Consumers:** cache population, handlers, MCP reads, write coordination,
+watching, and application startup.
+
+**Coordination paths:** `src/cache/**`, `src/vault_watcher.rs`,
+`src/api_types.rs`, and adapters when a public vault type changes.
+
+**Invariants:**
+
+- Markdown files remain authoritative (ADR-01).
+- Excluded/noise paths do not enter the index.
+- Layer markers remain visible to classification even under broad exclusions.
+- A note remains addressable while its layer is reported to callers.
+
+**Validation:** `cargo test vault` and the full backend checks.
+
+### Vault mutation
+
+**Kind:** product capability/domain core; safety-critical.
+
+**Owned paths:**
+
+- `src/vault/write.rs`
+- `src/vault/write/assets.rs`
+- `src/vault/write/attachments.rs`
+- `src/vault/write/fs_ops.rs`
+- `src/vault/write/notes.rs`
+- `src/vault/write/paths.rs`
+- `src/vault/write/rewrites.rs`
+- `src/vault/write/types.rs`
+- `src/vault/write/tests.rs`
+
+**Public contract:** write functions and result/error types re-exported from
+`src/vault.rs`, including note CRUD-by-move, section/edit primitives, attachment
+operations, allowed attachment extensions, `WriteOutcome`, and `WriteError`.
+
+**Consumed dependencies:** vault index/types and the local filesystem.
+
+**Consumers:** HTTP write handlers and MCP write tools.
+
+**Coordination paths:** `src/handlers/write_api.rs`,
+`src/mcp/tools/write.rs`, Git write records, frontend write API/types, and
+configuration for archive or upload limits.
+
+**Invariants:**
+
+- All HTTP and MCP mutations use this shared layer (ADR-03).
+- Optimistic concurrency uses the expected content hash.
+- Delete is recoverable trash; archive is move-based (ADR-11).
+- Paths remain within the canonical vault root.
+- Layer marker and excluded/noise writes remain protected at adapter and domain
+  boundaries as applicable.
+
+**Validation:** `cargo test vault::write`, adapter write tests, and the full
+backend checks.
+
+### Cache and query read model
+
+**Kind:** infrastructure/read model.
+
+**Owned paths:**
+
+- `src/cache/mod.rs`
+- `src/cache/chunk_ops.rs`
+- `src/cache/parse.rs`
+- `src/cache/populate.rs`
+- `src/cache/schema.rs`
+- `src/cache/queries/mod.rs`
+- `src/cache/queries/graph.rs`
+- `src/cache/queries/metadata.rs`
+- `src/cache/queries/search.rs`
+
+**Public contract:** `SqliteCache`, `ReadConn`, `BuildOptions`, `SemanticHit`,
+and the methods implemented on `SqliteCache`. `parse` is currently public and
+also supplies parsing/hash behavior to vault indexing.
+
+**Consumed dependencies:** vault index/types, chunking, embeddings, SQLite,
+FTS5, and sqlite-vec.
+
+**Consumers:** application state/reindexing, Search, handlers, MCP reads,
+evaluation tooling, and diagnostics.
+
+**Coordination paths:** `src/app_state.rs`, `src/search/**`,
+`src/vault/index.rs`, `src/chunk/**`, and embedder identity/dimensions.
+
+**Invariants:**
+
+- SQLite is rebuildable and never authoritative (ADR-01).
+- Keep embedded SQLite, FTS5, sqlite-vec, WAL, one writer, and pooled
+  query-only reads (ADR-06).
+- Schema or embedder identity mismatch rebuilds rather than mixing data.
+- A refresh commits a coherent new read snapshot.
+
+**Validation:** `cargo test cache` and full backend checks. Schema/population
+changes require search and application-state tests too.
+
+### Chunking
+
+**Kind:** infrastructure/indexing policy.
+
+**Owned paths:**
+
+- `src/chunk/mod.rs`
+- `src/chunk/chunker.rs`
+- `src/chunk/normalize.rs`
+
+**Public contract:** `Chunk`, `ChunkOptions`, `NoteChunking`, `chunk_note`, and
+normalization behavior re-exported by `src/chunk/mod.rs`.
+
+**Consumed dependencies:** Markdown text and tokenizer-aware splitting.
+
+**Consumers:** cache population and evaluation/index microbench tooling.
+
+**Coordination paths:** cache population, embedder token limits, and evaluation
+baselines.
+
+**Invariants:** chunk boundaries and contextual text changes alter every
+embedding and therefore require deliberate evaluation, not only unit tests.
+
+**Validation:** `cargo test chunk`, cache population tests, and relevant eval
+commands when retrieval behavior may change.
+
+### Runtime Search
+
+**Kind:** product capability/domain service.
+
+**Owned paths:**
+
+- `src/search/mod.rs`
+- `src/search/assemble.rs`
+- `src/search/layer_selection.rs`
+- `src/search/retrieve.rs`
+
+**Public contract:** `SearchMode`, `SearchRequest`, `NoteFilters`,
+`LayerSelection`, `LayerInfo`, `SearchResult`, `SearchResponse`, `run`, and
+`query_notes`.
+
+**Consumed dependencies:** `SqliteCache`, `Embedder`, and vault metadata/types.
+
+**Consumers:** HTTP search handler, MCP search/query tools, and offline
+evaluation runners.
+
+**Coordination paths:** `src/api_types.rs`, `src/handlers/api.rs`,
+`src/mcp/tools/read.rs`, cache query methods, and frontend Search contracts.
+
+**Invariants:**
+
+- Runtime search defaults to pure semantic retrieval; hybrid and reranking stay
+  offline (ADR-05).
+- Layer selection and metadata filters must never widen the eligible result
+  set.
+- A structure-only frontend Search pilot must not modify these paths.
+
+**Validation:** `cargo test search`, relevant cache query tests, and evaluation
+only when retrieval semantics change.
+
+### Embeddings and model implementations
+
+**Kind:** infrastructure/external-model seam.
+
+**Owned paths:**
+
+- `src/embed/mod.rs`
+- `src/embed/candle_embedder.rs`
+- `src/embed/context.rs`
+- `src/embed/embedder.rs`
+- `src/embed/fastembed_embedder.rs`
+- `src/embed/hub.rs`
+- `src/embed/matryoshka.rs`
+
+**Public contract:** `Embedder`, `RuntimeEmbedder`, concrete embedders,
+`MatryoshkaEmbedder`, `StubEmbedder`, and contextual-document formatting.
+
+**Consumed dependencies:** local model runtimes, tokenizers, and Hugging Face
+model files.
+
+**Consumers:** cache building, runtime Search, startup/model setup, auxiliary
+evaluation binaries, and tests.
+
+**Coordination paths:** `src/model_setup.rs`, cache schema/identity handling,
+chunking, Docker model prefetch, and evaluation documentation.
+
+**Invariants:** local inference only (ADR-04); embedder identity must encode
+behavior affecting stored vectors; the `Embedder` trait remains the deliberate
+test seam rather than proliferating model abstractions (ADR-13).
+
+**Validation:** `cargo test embed`; feature-gated or model-loading tests when
+applicable; cache identity/rebuild tests for identity changes.
+
+### Reranking
+
+**Kind:** offline evaluation infrastructure.
+
+**Owned paths:**
+
+- `src/rerank/mod.rs`
+- `src/rerank/fastembed_reranker.rs`
+- `src/rerank/reranker.rs`
+
+**Public contract:** `Reranker`, `FastembedReranker`, `StubReranker`, and
+`RerankedHit`.
+
+**Consumers:** evaluation tooling only.
+
+**Coordination paths:** `src/eval/**` and `src/bin/eval.rs`.
+
+**Invariant:** reranking must not enter the runtime search path without
+superseding ADR-05.
+
+**Validation:** `cargo test rerank` and relevant eval runner tests.
+
+### Git synchronization
+
+**Kind:** infrastructure/background capability.
+
+**Owned paths:**
+
+- `src/git/mod.rs`
+- `src/git/config.rs`
+- `src/git/message.rs`
+- `src/git/status.rs`
+- `src/git/sync.rs`
+- `src/git/task.rs`
+
+**Public contract:** `GitConfig`, write-record/message types, sync outcomes and
+errors, status, repository operations, `GitSyncHandle`, `SyncOps`, and
+`spawn_sync_task`.
+
+**Consumed dependencies:** local Git repository through `git2`.
+
+**Consumers:** server startup, write adapters, status handlers/tools, and
+`AppState`.
+
+**Coordination paths:** `src/app_state.rs`, `src/server.rs`, HTTP/MCP write
+adapters, configuration, and vault watcher Git exclusions.
+
+**Invariants:** optional and debounced; writes do not block on sync; never
+force-checkout over uncommitted manual vault edits (ADR-10).
+
+**Validation:** `cargo test git` and affected adapter/server tests.
+
+### HTTP adapters
+
+**Kind:** adapter.
+
+**Owned paths:**
+
+- `src/handlers/mod.rs`
+- `src/handlers/api.rs`
+- `src/handlers/assets.rs`
+- `src/handlers/diagnostics.rs`
+- `src/handlers/downloads.rs`
+- `src/handlers/spa.rs`
+- `src/handlers/write_api.rs`
+
+**Public contract:** handler functions intentionally re-exported by
+`src/handlers/mod.rs`; their route, authentication, status, and serialized HTTP
+behavior.
+
+**Consumed dependencies:** `AppState`, HTTP wire types, vault reads,
+`vault/write`, Search, cache queries, Git status, and auth.
+
+**Consumers:** route construction in `src/server.rs`.
+
+**Coordination paths:** `src/server.rs`, `src/api_types.rs`, frontend clients,
+and whichever domain a handler adapts.
+
+**Invariants:** handlers stay thin. Write handlers never touch the vault
+filesystem directly (ADR-03). Static and vault asset behavior must retain auth
+and path containment.
+
+**Validation:** `cargo test handlers`, router tests, and affected domain tests.
+
+### MCP adapter
+
+**Kind:** adapter/security surface.
+
+**Owned paths:**
+
+- `src/mcp/mod.rs`
+- `src/mcp/auth.rs`
+- `src/mcp/config.rs`
+- `src/mcp/protocol.rs`
+- `src/mcp/routes.rs`
+- `src/mcp/tools/mod.rs`
+- `src/mcp/tools/read.rs`
+- `src/mcp/tools/write.rs`
+
+**Public contract:** `/mcp` Streamable HTTP behavior, `McpConfig`, protocol
+version negotiation, server instructions, tool names/schemas/results, and
+`mcp_get_handler`/`mcp_post_handler`.
+
+**Consumed dependencies:** `AppState`, Search, vault reads, `vault/write`, Git
+status, model setup, cache refresh, and attachment limits.
+
+**Coordination paths:** `src/server.rs`, domains exposed as tools, and
+documentation describing agent behavior.
+
+**Invariants:** MCP is disabled by default, uses its own token, validates
+Origins, and keeps read-only access credentialed (ADR-09). Write tools use
+`vault/write` and retain optimistic concurrency and path protections (ADR-03).
+
+**Validation:** `cargo test mcp`, vault write tests for mutation changes, and
+server router tests.
+
+### Evaluation and development binaries
+
+**Kind:** offline tooling; not a runtime feature.
+
+**Owned paths:**
+
+- `src/eval/mod.rs`
+- `src/eval/compare_runner.rs`
+- `src/eval/hybrid_runner.rs`
+- `src/eval/metrics.rs`
+- `src/eval/query.rs`
+- `src/eval/report.rs`
+- `src/eval/rerank_runner.rs`
+- `src/bin/eval.rs`
+- `src/bin/index_microbench.rs`
+
+**Public contract:** evaluation query JSONL, metrics/report formats, CLI
+arguments, and reproducible comparison behavior.
+
+**Consumed dependencies:** cache, embeddings, chunking, Search, and Reranking.
+
+**Coordination paths:** `eval/**`, related findings under `docs/`, and model or
+chunking code when experiments become runtime decisions.
+
+**Invariant:** hybrid and rerank experiments remain offline unless ADR-05 is
+superseded.
+
+**Validation:** `cargo test eval`, binary argument tests, and the relevant eval
+command for behavioral changes.
+
+## Frontend
+
+The frontend currently uses technical-layer directories rather than enforced
+feature boundaries. The ownership below assigns each production file to one
+capability or marks it shared. Except for Search's TS/TSX façade rule,
+boundaries are currently documentation-enforced.
+
+### Application shell and navigation
+
+**Kind:** composition/shared.
+
+**Owned paths:** none by default.
+
+**Paths:**
+
+- `frontend/src/main.tsx`
+- `frontend/src/App.tsx`
+- `frontend/src/app/AppTopbar.tsx`
+- `frontend/src/app/ExplorerPane.tsx`
+- `frontend/src/app/constants.ts`
+- `frontend/src/hooks/useIsMobile.ts`
+- `frontend/src/hooks/useTheme.ts`
+- `frontend/src/lib/storage.ts`
+
+**Contract and responsibility:** bootstraps React/router/PWA, composes feature
+hooks and routes, owns responsive shell state, navigation, persistent shell
+preferences, topbar actions, and explorer placement.
+
+**Coordination rule:** feature work may touch `App.tsx` only when the work
+packet names the route, callback, shortcut, or state integration. A large prop
+surface is a coordination seam, not permission to move feature behavior into
+the shell.
+
+**Validation:** the applicable `App.*.test.tsx`, `useTheme.test.tsx`, storage
+tests, then full frontend checks.
+
+### Frontend API, authentication, and shared wire contracts
+
+**Kind:** infrastructure/shared contract.
+
+**Owned paths:**
+
+- `frontend/src/api/api.ts`
+- `frontend/src/api/apiError.ts`
+- `frontend/src/components/TokenPrompt.tsx`
+
+**Shared path:** `frontend/src/types.ts`.
+
+**Contract and responsibility:** authenticated/time-bounded fetch, unauthorized
+notification, tokenized asset/download/SSE URLs, error extraction, login prompt,
+and cross-capability TypeScript representations of backend payloads. A feature
+may own its wire types when all consumers go through that feature's public
+entry point, as Search now does.
+
+**Consumers:** almost every data-backed frontend capability.
+
+**Coordination rule:** `types.ts` is not owned by whichever feature needs one
+new field. Contract changes must list the backend serializer and all frontend
+consumers. New feature-local types should remain local unless genuinely shared.
+
+**Invariants:** preserve bearer/header behavior and the deliberate query-token
+fallback (ADR-08). Never log or render tokens.
+
+**Validation:** API/error tests, affected feature/consumer tests, and typecheck.
+`clientAuditContracts.test.ts` audits UI, PWA, and CSS source contracts; it does
+not verify Rust-to-TypeScript wire compatibility.
+
+### Startup and model setup UI
+
+**Kind:** product capability/adapter.
+
+**Owned paths:**
+
+- `frontend/src/startup/StartupGate.tsx`
+- `frontend/src/styles/startup.css`
+
+**Public contract:** `StartupGate` and the `/api/startup-status` plus model
+accept/decline/retry response shapes it consumes.
+
+**Consumed dependencies:** shared API client and theme hook.
+
+**Coordination paths:** `App.tsx`, backend startup/model setup handlers and
+types, and shell-wide styles.
+
+**Validation:** `StartupGate.test.tsx`, `App.startup-auth.test.tsx`, and full
+frontend checks.
+
+### Vault explorer
+
+**Kind:** product capability.
+
+**Owned paths:**
+
+- `frontend/src/components/Explorer.tsx`
+- `frontend/src/hooks/useVaultTree.ts`
+- `frontend/src/lib/folderPaths.ts`
+- `frontend/src/lib/noteCandidates.ts`
+- `frontend/src/styles/layout-explorer.css`
+
+**Public contract:** `useVaultTree`, explorer tree/list components, derived
+folder paths, and flattened note candidates.
+
+**Consumed dependencies:** shared API/error utilities, shared wire types,
+router links, and shared UI components.
+
+**Coordination paths:** `App.tsx`, `app/ExplorerPane.tsx`, `types.ts`,
+`lib/stateCompare.ts`, responsive CSS, and backend tree/recent/event endpoints.
+
+**Validation:** folder/note-candidate/state comparison tests and affected App
+navigation tests; the hook currently needs focused coverage.
+
+### Search dialog
+
+**Kind:** product capability; established feature boundary.
+
+**Owned paths:**
+
+- `frontend/src/features/search/index.ts`
+- `frontend/src/features/search/types.ts`
+- `frontend/src/features/search/SearchDialog.tsx`
+- `frontend/src/features/search/useSearch.ts`
+- `frontend/src/features/search/search.css`
+
+Feature tests:
+
+- `frontend/src/features/search/SearchDialog.test.tsx`
+- `frontend/src/features/search/useSearch.test.ts`
+
+**Public contract:** `frontend/src/features/search/index.ts` is the only public
+TS/TSX entry point. It exposes `useSearch`, `SearchDialog`, Search wire and
+selection types, and the `/api/search` payload consumed by the hook. Search CSS
+is integrated separately through the `App.css` stylesheet aggregation seam.
+
+**Consumed dependencies:** shared API/error utilities, shared UI components,
+router navigation supplied by the shell, and backend Search.
+
+**Coordination paths:** `App.tsx`, `App.css`, backend search HTTP contract, and
+responsive CSS.
+
+**Pilot constraint:** co-location or façade work is structure-only. It must not
+change backend retrieval, ranking, cache, or MCP behavior.
+
+**Boundary enforcement:** production TS/TSX files outside the feature must
+import the directory entry point rather than its internal files; ESLint
+enforces this with `no-restricted-imports`. The raw source-audit test is
+explicitly exempt, and CSS aggregation remains the declared `App.css` seam.
+
+**Validation:** the feature's `SearchDialog.test.tsx` and `useSearch.test.ts`,
+`App.navigation-search.test.tsx`, and full frontend checks.
+
+### Note reading and rendering
+
+**Kind:** product capability.
+
+**Owned paths:**
+
+- `frontend/src/components/NotePage.tsx`
+- `frontend/src/components/note-page/NotePreview.tsx`
+- `frontend/src/components/note-page/PdfPreview.tsx`
+- `frontend/src/components/note-page/RendererComponents.tsx`
+- `frontend/src/components/note-page/dom.ts`
+- `frontend/src/components/note-page/renderers.tsx`
+- `frontend/src/components/note-page/sections.tsx`
+- `frontend/src/components/note-page/text.ts`
+- `frontend/src/components/note-page/wikilinks.ts`
+- `frontend/src/lib/markdown.ts`
+- `frontend/src/lib/noteHeadings.ts`
+- `frontend/src/lib/noteSearch.ts`
+- `frontend/src/noteEnhancements.css`
+- `frontend/src/styles/note-content.css`
+
+**Public contract:** `NotePage`, note preview/rendering behavior, safe asset and
+wikilink resolution, heading/search-hit navigation, Markdown transformations,
+and note navigation/rendering behavior.
+
+**Consumed dependencies:** API/auth helpers, router state, Markdown/rendering
+libraries, shared types/UI, and note editing.
+
+**Coordination paths:** `App.tsx`, `types.ts`, note/link/resolve/download
+handlers, `NoteEditor.tsx`, Search query navigation, shared and responsive CSS.
+
+**Invariants:** vault Markdown remains the rendered source; vault content is
+data rather than trusted executable instructions; asset URLs retain auth and
+path safety.
+
+**Validation:** note-page unit tests, Markdown/heading/search/state tests,
+`App.content-rendering.test.tsx`, `App.enhancements.test.tsx`,
+`App.links-download.test.tsx`, and full frontend checks.
+
+### Note editing and vault actions
+
+**Kind:** product capability/adapter; safety-sensitive.
+
+**Owned paths:**
+
+- `frontend/src/api/writeApi.ts`
+- `frontend/src/components/NoteEditor.tsx`
+- `frontend/src/components/NoteActionsDialog.tsx`
+- `frontend/src/hooks/useNoteActions.ts`
+- `frontend/src/hooks/useWriteMode.ts`
+- `frontend/src/lib/imageUpload.ts`
+- `frontend/src/lib/writeDrafts.ts`
+- `frontend/src/lib/writePaths.ts`
+- `frontend/src/components/note-page/autocomplete.ts`
+- `frontend/src/components/note-page/conflictDiff.ts`
+- `frontend/src/components/note-page/frontmatter.ts`
+
+**Public contract:** write capability discovery and operations, editor/action
+components, note-action/write-mode hooks, local draft behavior, client path
+validation, upload normalization, frontmatter editing, conflict display, and
+wikilink autocomplete.
+
+**Consumed dependencies:** shared API/types/UI, router navigation, vault tree
+note candidates, and backend HTTP write endpoints.
+
+**Coordination paths:** `App.tsx`, `NotePage.tsx`, `types.ts`,
+`noteEnhancements.css`, backend `handlers/write_api.rs`, and
+`vault/write/**`.
+
+**Invariants:** expected content hashes remain part of update concurrency;
+delete stays recoverable; client validation does not replace backend path
+safety; every mutation continues through backend `vault/write` (ADR-03/11).
+
+**Validation:** write API, editor, action dialog, upload, draft, path,
+frontmatter, conflict, and autocomplete tests plus `App.write-mode.test.tsx`
+and full frontend checks.
+
+### Graph
+
+**Kind:** product capability; suitable bounded dry-run candidate.
+
+**Owned paths:**
+
+- `frontend/src/components/graph/GraphPage.tsx`
+- `frontend/src/components/graph/graphSimulation.ts`
+- `frontend/src/styles/graph.css`
+
+**Public contract:** `GraphPage`, graph simulation helpers, and the `/api/graph`
+payload.
+
+**Consumed dependencies:** shared API/error/types/UI, router navigation, and
+`d3-force`.
+
+**Coordination paths:** `App.tsx`, `types.ts`, backend graph wire types/handler,
+and responsive CSS.
+
+**Validation:** `GraphPage.test.tsx`, `graphSimulation.test.ts`, an App route
+smoke test if routing changes, and full frontend checks.
+
+### Statistics
+
+**Kind:** product capability.
+
+**Owned paths:**
+
+- `frontend/src/components/StatsPage.tsx`
+- `frontend/src/styles/stats.css`
+
+**Public contract:** `StatsPage` and the `/api/stats` payload.
+
+**Consumed dependencies:** shared API/error/types/UI and router links.
+
+**Coordination paths:** `App.tsx`, `types.ts`, backend stats wire types/handler,
+and responsive CSS.
+
+**Validation:** add focused component coverage for behavioral changes, affected
+route tests, and full frontend checks.
+
+### Shared UI and styling
+
+**Kind:** shared infrastructure.
+
+**Owned paths:** none by default.
+
+**Paths:**
+
+- `frontend/src/components/ui.tsx`
+- `frontend/src/index.css`
+- `frontend/src/App.css`
+- `frontend/src/styles/base.css`
+- `frontend/src/styles/topbar.css`
+- `frontend/src/styles/ui-common.css`
+- `frontend/src/styles/responsive.css`
+
+**Contract and responsibility:** shared primitives, global tokens/base rules,
+style aggregation, topbar/shell styles, and cross-feature responsive overrides.
+
+**Coordination rule:** a feature work packet should prefer its owned stylesheet.
+Changes to shared selectors, tokens, or responsive rules must name affected
+features. `App.css` remains an aggregation/composition stylesheet; feature
+styles should migrate only as part of a declared boundary pilot.
+
+**Validation:** affected component/App tests, responsive manual or screenshot
+review when layout changes, and full frontend checks.
+
+### Small shared browser utilities
+
+**Kind:** shared infrastructure.
+
+**Owned paths:**
+
+- `frontend/src/lib/clipboard.ts`
+- `frontend/src/lib/stateCompare.ts`
+
+**Consumers:** shell copy actions and rendered code-block controls consume
+clipboard behavior. Vault Explorer consumes tree comparison, while Note reading
+consumes note and link comparison.
+
+**Coordination rule:** keep these utilities behavior-only. Feature-specific
+copy labels, workflows, or state ownership stay with their feature.
+
+**Validation:** `clipboard.test.ts` and `stateCompare.test.ts`.
+
+### Frontend test infrastructure
+
+**Kind:** test infrastructure, not production ownership.
+
+**Paths:**
+
+- `frontend/src/test/setup.ts`
+- all `frontend/src/**/*.test.ts`
+- all `frontend/src/**/*.test.tsx`
+
+Tests follow the production boundary they cover. Cross-feature `App.*` tests
+belong to composition and must be run when their named integration changes.
+
+## Auxiliary repository paths
+
+These paths are outside the runtime module catalog and require separate work
+packet scope:
+
+- `Dockerfile` and `docker-compose.yml`: packaging/deployment.
+- `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`: Rust build and dependency
+  coordination.
+- `frontend/package.json`, lockfile, TypeScript/Vite/ESLint configuration:
+  frontend build and dependency coordination.
+- `assets/**`: project branding and screenshots.
+- `docs/**`: user, contributor, architecture, research, and roadmap
+  documentation.
+- `eval/**`: evaluation inputs and results coordinated with offline tooling.
+- `scripts/**`: repository validation and maintenance tooling.
+
+Dependency or build configuration is never implicitly owned by the module that
+wants a new dependency.
+
+## Full validation gates
+
+Backend:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm ci
+npm run format:check
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+Use focused tests during development. Run the full gates before merging a
+boundary or interface change.

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -7,7 +7,7 @@ describes the repository as it exists today; it does not imply that every
 listed boundary should become a package, crate, or feature directory.
 
 Use this map together with
-[`docs/domain-collaboration-plan.md`](../domain-collaboration-plan.md). A work
+[`domain-collaboration-plan.md`](domain-collaboration-plan.md). A work
 packet narrows this catalog to one task and declares any exceptions before work
 starts.
 

--- a/docs/architecture/work-packet-template.md
+++ b/docs/architecture/work-packet-template.md
@@ -1,0 +1,136 @@
+# Work Packet Template
+
+A complete issue, task description, or agent working plan can serve as the
+packet; a committed packet file is not required. Copy this template where the
+work is being tracked, delete instructional comments, and replace every
+placeholder before coding. Write `None` for sections that do not apply so small
+tasks stay lightweight without leaving ambiguity.
+
+````markdown
+# <Task title>
+
+## Outcome
+
+<Observable result. Describe behavior, not an implementation preference.>
+
+This packet narrows the user-requested outcome. It does not authorize broader
+work or opportunistic cleanup. Owned paths are writable only as necessary to
+produce the outcome above.
+
+## Boundaries
+
+<!-- Repeat for every module involved in a cross-module or full-stack task. -->
+
+- Module: <exact module name from docs/architecture/module-map.md>
+  Kind: <exact kind from the module map>
+
+## Owned paths
+
+The task may change these paths only as necessary for the stated outcome. This
+is the maximum permitted area, not a suggestion to edit every listed file.
+Include intended tests and module-owned documentation:
+
+- `<exact path or narrowly scoped directory>`
+
+## Public contract
+
+Stable contract:
+
+- `<functions, types, serialized fields, events, routes, or behavior consumers rely on>`
+
+Declared contract changes:
+
+- None.
+
+Any supported contract that crosses its producing module boundary or is
+externally observable triggers
+`docs/architecture/interface-change-checklist.md`, even when this packet owns
+the producer and all in-repository consumers. List every affected consumer when
+the declared changes are not `None`.
+
+## Coordination paths
+
+The task may change these shared integration, test, documentation, tooling, or
+configuration files for the stated reason only:
+
+- `<path>` — <required integration change>
+
+## Packet record
+
+<!-- Use None for an issue/task/working-plan packet that creates no repo file. -->
+
+- `<committed packet path, if any>` — may be updated only to reflect approved
+  scope and evidence
+
+## Consumed dependencies
+
+The task may use, import, read, or call but does not own:
+
+- `<module or contract>`
+
+## Forbidden paths and invariants
+
+The task must not change:
+
+- `<path or behavior>`
+- `<applicable ADR invariant>`
+
+## Acceptance criteria
+
+- <observable behavior or structural property>
+- The diff stays within owned paths, declared coordination paths, and the
+  packet record.
+- Existing behavior outside the stated outcome is unchanged.
+
+## Validation
+
+Run commands from the repository root unless a command explicitly changes
+directory.
+
+Focused:
+
+```bash
+<exact commands>
+```
+
+Full:
+
+```bash
+<gates from CONTRIBUTING.md for every affected surface>
+<node scripts/check-module-map.mjs when production files changed>
+```
+
+## Escalation
+
+If an undeclared path or interface is needed, stop expanding the diff and
+classify the change:
+
+- If it is necessary for the existing outcome and does not materially increase
+  risk or authority, declare the path/change in this packet before editing it.
+- If it would materially broaden the outcome, risk, or required authority, stop
+  and ask the user before proceeding.
+
+List affected consumers and complete the interface-change checklist whenever a
+supported contract crosses its producing module boundary or is externally
+observable.
+````
+
+## Packet review questions
+
+Before assigning the packet to a person or agent:
+
+- Is the outcome testable without prescribing unnecessary internals?
+- Does the packet stand alone in limiting work to the user-requested outcome?
+- Are all involved boundaries named exactly as they appear in the module map?
+- Are writable paths exact enough to prevent opportunistic cleanup?
+- Does every shared/composition edit have a stated reason?
+- Are tests, documentation, tooling/configuration, and any committed packet
+  record accounted for?
+- Are consumed dependencies distinguished from owned implementation?
+- Are safety and ADR invariants expressed as concrete behavior?
+- Do focused checks state their starting directory, and are full gates included
+  for every affected surface?
+- Does `git status --short` show only owned paths, coordination paths, and the
+  optional packet record, including any newly created files?
+- Could someone identify an out-of-scope change without knowing the whole
+  repository?

--- a/docs/design/design-system.html
+++ b/docs/design/design-system.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Hatchdoor — design system (Forge)</title>
+<title>Hatchdoor — Design System (Forge)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,400;500;600;700;800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />

--- a/docs/domain-collaboration-plan.md
+++ b/docs/domain-collaboration-plan.md
@@ -1,0 +1,184 @@
+# Domain Collaboration Boundaries
+
+## Status
+
+Implemented and validated. The durable results and remaining evidence gaps are
+recorded in
+[`docs/architecture/collaboration-pilot-assessment.md`](architecture/collaboration-pilot-assessment.md).
+
+## Goal
+
+Make Hatchdoor easier for a human contributor or coding agent to change
+surgically: one owner, one explicit contract, and a predictable set of
+integration points.
+
+The goal is not to force every feature into one directory. Hatchdoor contains
+different kinds of boundaries, and the collaboration model must represent them
+honestly:
+
+- **Product capabilities** such as search, vault mutation, and note reading.
+- **Infrastructure** such as the cache, embeddings, and Git synchronization.
+- **Adapters** such as HTTP handlers, MCP tools, and React UI.
+- **Composition and shared context** such as `server.rs`, `AppState`, and
+  `App.tsx`.
+
+This work must preserve Hatchdoor as a lean modular monolith. It must not
+introduce services, a Cargo workspace, speculative traits, a frontend state
+library, or a schema framework merely to make the architecture look modular.
+
+## Definition of a surgical work packet
+
+Every claimable piece of work must state:
+
+- **Owned paths:** implementation files the contributor may change freely.
+- **Public contract:** interfaces consumers rely on and that remain stable
+  unless the packet explicitly declares a change.
+- **Coordination paths:** shared or composition files that may be changed only
+  when listed in the packet.
+- **Consumed dependencies:** modules the work may call but does not own.
+- **Forbidden paths and invariants:** areas and behavior that must not change.
+- **Validation:** focused tests and full checks required before completion.
+
+A domain boundary is successful when internal work stays within its owned paths.
+A vertical feature may legitimately touch declared coordination files; this is
+not considered a boundary failure.
+
+## Architectural constraints
+
+The module catalog and every applicable work packet must translate the existing
+ADRs into concrete invariants. In particular:
+
+- **ADR-01:** Markdown remains authoritative; SQLite remains disposable.
+- **ADR-02:** Keep one binary and one shared domain core.
+- **ADR-03:** HTTP and MCP mutations continue to use `vault/write/`.
+- **ADR-05:** Runtime search remains pure semantic retrieval by default.
+- **ADR-06:** Keep the embedded SQLite read model and its concurrency model.
+- **ADR-13:** Add abstractions only when the collaboration pilot demonstrates
+  that they pay for themselves.
+
+## Plan
+
+### Phase 1: Define and inventory
+
+1. Adopt the work-packet vocabulary above as the collaboration contract.
+2. Inventory every production path without moving code.
+3. Classify each path as a product capability, infrastructure, adapter, or
+   shared/composition code.
+4. For each claimable module, record:
+   - purpose and classification;
+   - owned paths;
+   - public interface;
+   - allowed or consumed dependencies;
+   - coordination paths;
+   - forbidden dependencies;
+   - ADR-backed invariants;
+   - focused and full validation commands.
+5. Give every production file one documented owner or an explicit
+   shared/composition classification.
+
+The main deliverable is `docs/architecture/module-map.md`.
+
+### Phase 2: Add collaboration guidance
+
+Add:
+
+- a root `AGENTS.md` with agent scope and escalation rules;
+- a collaboration section in `CONTRIBUTING.md`;
+- a reusable work-packet template;
+- an interface-change checklist for pull requests.
+
+Do not add `CODEOWNERS` until real maintainers and ownership assignments are
+known. Do not promise automated PR checks unless the corresponding GitHub
+configuration is deliberately added.
+
+### Phase 3: Dry-run a bounded module
+
+Use the work-packet format for a small, already bounded, low-risk area such as
+the Graph UI or diagnostics.
+
+The dry run should answer:
+
+- Could the contributor identify all writable files without broad repository
+  exploration?
+- Were the public contract and invariants sufficient?
+- Were any undeclared coordination files required?
+- Were the focused checks adequate?
+- What context did the contributor still need from unrelated modules?
+
+Update the catalog and template from this evidence before restructuring code.
+
+### Phase 4: Pilot a meaningful feature boundary
+
+Use frontend Search as the first structural stress-test, unless an upcoming real
+collaborator task provides a better evidence-based candidate.
+
+The intended Search pilot:
+
+- co-locates feature-owned state, UI, client contract, tests, and styles;
+- exposes one intentional public entry point;
+- treats `App.tsx` as a declared composition file for navigation and keyboard
+  shortcuts;
+- leaves backend retrieval behavior unchanged;
+- does not change cache schemas, ranking, reranking, hybrid search, or MCP
+  behavior.
+
+Backend Search already has useful façade functions and should not be rewritten
+solely for symmetry with the frontend.
+
+### Phase 5: Add lightweight enforcement
+
+Only add enforcement justified by issues observed during the dry run and pilot:
+
+- Rust module privacy and narrow re-exports;
+- ESLint `no-restricted-imports` rules preventing imports into feature
+  internals;
+- focused tests for extracted feature behavior;
+- a small shared JSON contract fixture if cross-language Search types are in
+  scope;
+- the existing Cargo and frontend quality gates.
+
+Avoid new dependency-analysis packages or code-generation frameworks unless a
+specific, demonstrated problem cannot be solved with existing tools.
+
+### Phase 6: Validate and reassess
+
+Run the full backend and frontend checks. Then repeat a scoped contributor task
+using the completed packet and compare:
+
+- context required;
+- number of unrelated files inspected;
+- changed paths;
+- undeclared integration points;
+- test scope;
+- blast radius.
+
+Extract another feature only if the pilot demonstrates a meaningful improvement.
+Create a new ADR only if the result establishes a lasting architectural policy
+that is not already covered by the existing records.
+
+## Acceptance criteria
+
+- Every production file has one documented owner or an explicit
+  shared/composition classification.
+- A work packet states writable paths, coordination paths, contracts,
+  invariants, and exact checks.
+- A contributor can change module internals without examining unrelated
+  implementation code.
+- Interface changes are declared and identify affected consumers.
+- External frontend code cannot import feature internals.
+- Rust exposes only intentional module façades where a boundary benefits from
+  one.
+- Pilot changes remain within owned paths and predeclared coordination files.
+- Existing behavior remains unchanged and all relevant backend and frontend
+  checks pass.
+- ADR-01, ADR-02, ADR-03, ADR-05, ADR-06, and ADR-13 appear as concrete
+  invariants wherever they apply.
+
+## Out of scope
+
+- Splitting Hatchdoor into services or separately deployed components.
+- Creating a Cargo workspace solely to represent domains.
+- Hiding `AppState` behind a set of speculative per-domain service traits.
+- Introducing a frontend state-management framework for module boundaries.
+- Reworking backend search behavior during the frontend Search pilot.
+- Assigning maintainers or code owners without their agreement.

--- a/docs/maintenance/dependency-update-plan.md
+++ b/docs/maintenance/dependency-update-plan.md
@@ -1,5 +1,7 @@
 # Dependency update plan
 
+> Maintenance record.
+
 Status: all seven steps complete. FastEmbed 5 is deferred because it would
 impose an AVX requirement on x86_64 users.
 

--- a/docs/research/embeddings/embedding-sweep-decisions-2026-07-26.md
+++ b/docs/research/embeddings/embedding-sweep-decisions-2026-07-26.md
@@ -1,7 +1,10 @@
 # Embedding sweep decisions — 2026-07-26
 
+> Research record.
+
 This records the decisions taken while the embedding evaluation was in progress.
-The raw, per-query measurements are in [`eval/results.md`](../eval/results.md).
+The raw, per-query measurements are in
+[`eval/results.md`](../../../eval/results.md).
 
 ## What was completed
 

--- a/docs/research/embeddings/embeddinggemma-license-options.md
+++ b/docs/research/embeddings/embeddinggemma-license-options.md
@@ -1,5 +1,7 @@
 # EmbeddingGemma licensing and default-model options
 
+> Research record.
+>
 > Researched: 2026-07-26
 > Scope: Using EmbeddingGemma 300M Q4 as Hatchdoor's default embedding model
 > Status: Product-oriented licensing research, not formal legal advice

--- a/docs/research/embeddings/embeddings-investigation-fastembed-v5.md
+++ b/docs/research/embeddings/embeddings-investigation-fastembed-v5.md
@@ -1,5 +1,7 @@
 # Hatchdoor Embedding & Model Investigation
 
+> Research record.
+>
 > Updated for **FastEmbed v5** and current model options as of **24 July 2026**.
 
 ## Executive recommendation

--- a/docs/research/embeddings/fastembed-v5-upgrade-findings.md
+++ b/docs/research/embeddings/fastembed-v5-upgrade-findings.md
@@ -1,19 +1,23 @@
 # FastEmbed v5 Upgrade — Feasibility Findings
 
+> Research record.
+>
 > Investigation notes captured on 2026-07-24 on branch `feature/fastembed-v5-models`
 > (off `development`). This is the *platform/build feasibility* base for a later
 > v5 implementation. For the model-selection strategy, see the companion doc
-> [`embeddings-investigation-fastembed-v5.md`](./embeddings-investigation-fastembed-v5.md).
+> [`embeddings-investigation-fastembed-v5.md`](embeddings-investigation-fastembed-v5.md).
 
 ## Background: the v4 → v5 → v4 excursion
 
 During the dependency batch on `development` (commits `c7936e7`, `af80a79`,
 2026-07-21), FastEmbed 5 was attempted and reverted. The revert reason recorded
-in `docs/dependency-update-plan.md` was ONNX Runtime's AVX baseline requirement.
+in `docs/maintenance/dependency-update-plan.md` was ONNX Runtime's AVX baseline
+requirement.
 FastEmbed 5 was never committed — `git log -S 'fastembed = "5"'` on `Cargo.toml`
 is empty. The excursion left two residues:
 
-- `docs/dependency-update-plan.md` notes "FastEmbed 5 is deferred … requires AVX here".
+- `docs/maintenance/dependency-update-plan.md` notes "FastEmbed 5 is deferred …
+  requires AVX here".
 - `Cargo.toml` keeps a `tokenizers-v21` alias, because FastEmbed 4 pins tokenizers 0.21
   while the rest of the tree moved to tokenizers 0.23.
 
@@ -102,5 +106,5 @@ one-time full reindex everywhere, and a build-host AVX sanity check.
 
 - pykeio/ort platform matrix — `docs/core/platform.tsx` (`PLATFORMS_WITH_BINARIES`)
 - FastEmbed v5.0.0 release (ort 2.0.0-rc.10 upgrade, Rayon removal)
-- `docs/dependency-update-plan.md` (original v5 deferral rationale)
+- `docs/maintenance/dependency-update-plan.md` (original v5 deferral rationale)
 - Local: `Dockerfile:39`, `src/embed/fastembed_embedder.rs:99`, `src/cache/schema.rs:9,56-63`

--- a/docs/reviews/pr-31-managed-vault-foundation-review.md
+++ b/docs/reviews/pr-31-managed-vault-foundation-review.md
@@ -1,5 +1,7 @@
 # PR #31 Review — Managed Git Vault Lifecycle Foundation
 
+> Historical review record.
+
 - PR: [#31 — Establish managed Git vault lifecycle foundation](https://github.com/BattermanZ/Hatchdoor/pull/31)
 - Reviewed head: `9fe7f77988bbd5243e0e6920b5b3fb445f107906`
 - Target branch: `development`

--- a/docs/roadmap/product-roadmap.md
+++ b/docs/roadmap/product-roadmap.md
@@ -6,7 +6,7 @@
   ordering and intent, not committed release dates.
 - Scope: The overall product direction and the workstreams it breaks into. Each
   workstream is a problem to solve; some are detailed in their own document under
-  [`docs/roadmap/`](roadmap/), the rest are stated here to set direction.
+  [`docs/roadmap/`](./), the rest are stated here to set direction.
 
 ## Vision
 
@@ -103,7 +103,7 @@ single instance serves only one folder. Users need to connect, configure, sync,
 and manage vaults from the product, and eventually run several at once.
 
 Direction: detailed in the
-[vault lifecycle & multi-vault roadmap](roadmap/vault-lifecycle.md). Also includes
+[vault lifecycle & multi-vault roadmap](vault-lifecycle.md). Also includes
 **excluding sub-folders from indexing**
 ([#22](https://github.com/BattermanZ/Hatchdoor/issues/22)) when Hatchdoor points at
 a directory, so parts of a vault can be kept out of the index.

--- a/docs/roadmap/vault-lifecycle.md
+++ b/docs/roadmap/vault-lifecycle.md
@@ -3,7 +3,7 @@
 - Status: Draft for discussion
 - Audience: Hatchdoor maintainers, contributors, and product collaborators
 - Horizon: Product direction; no delivery dates are committed
-- Scope: One workstream of the [Hatchdoor product roadmap](../product-roadmap.md) —
+- Scope: One workstream of the [Hatchdoor product roadmap](product-roadmap.md) —
   how vaults are connected, configured, synchronized, indexed, and searched.
   User-facing outcomes and capabilities, not implementation design.
 
@@ -13,7 +13,7 @@ This document details the **vault lifecycle and multi-vault** workstream: how
 Hatchdoor can grow from a web interface connected to one preconfigured Markdown
 folder into an always-available workspace that manages several independent vaults
 from the product itself. It sits under the broader
-[product roadmap](../product-roadmap.md), which frames the other workstreams
+[product roadmap](product-roadmap.md), which frames the other workstreams
 (editing experience, search and discovery, graph and linking, agent/MCP
 capabilities) alongside this one.
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -27,4 +27,25 @@ export default defineConfig([
       "react-hooks/set-state-in-effect": "off",
     },
   },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/features/search/**/*.{ts,tsx}",
+      "src/clientAuditContracts.test.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/features/search/*", "**/features/search/**/*"],
+              message:
+                "Import Search through the public features/search entry point.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]);

--- a/frontend/src/App.content-rendering.test.tsx
+++ b/frontend/src/App.content-rendering.test.tsx
@@ -171,9 +171,7 @@ const x = 1
       );
     });
 
-    fireEvent.click(
-      document.querySelector(".callout-collapsible > summary")!,
-    );
+    fireEvent.click(document.querySelector(".callout-collapsible > summary")!);
     expect(document.querySelector(".callout-collapsible")).toHaveAttribute(
       "open",
     );

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,7 +3,7 @@
 @import "./styles/layout-explorer.css";
 @import "./styles/note-content.css";
 @import "./styles/ui-common.css";
-@import "./styles/search.css";
+@import "./features/search/search.css";
 @import "./styles/responsive.css";
 @import "./styles/stats.css";
 @import "./styles/graph.css";

--- a/frontend/src/App.links-download.test.tsx
+++ b/frontend/src/App.links-download.test.tsx
@@ -19,8 +19,9 @@ afterEach(() => {
 
 describe("App links/download", () => {
   it("renders a relative Markdown PDF link as a vault asset instead of a note route", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
-      async (input: RequestInfo | URL) => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: RequestInfo | URL) => {
         const url = String(input);
         if (url.includes("/api/tree")) {
           return new Response(
@@ -49,8 +50,7 @@ describe("App links/download", () => {
         }
 
         return new Response("not found", { status: 404 });
-      },
-    );
+      });
 
     render(
       <MemoryRouter initialEntries={["/n/home"]}>

--- a/frontend/src/App.startup-auth.test.tsx
+++ b/frontend/src/App.startup-auth.test.tsx
@@ -14,7 +14,9 @@ afterEach(() => {
 it("prompts for the web token when first-run model setup is unauthorized", async () => {
   vi.spyOn(globalThis, "fetch")
     .mockResolvedValueOnce(
-      new Response(JSON.stringify({ state: "terms_required" }), { status: 200 }),
+      new Response(JSON.stringify({ state: "terms_required" }), {
+        status: 200,
+      }),
     )
     .mockResolvedValueOnce(new Response(null, { status: 401 }));
 
@@ -26,8 +28,12 @@ it("prompts for the web token when first-run model setup is unauthorized", async
 
   await screen.findByRole("button", { name: "Accept terms and set up Gemma" });
   await act(async () => {
-    screen.getByRole("button", { name: "Accept terms and set up Gemma" }).click();
+    screen
+      .getByRole("button", { name: "Accept terms and set up Gemma" })
+      .click();
   });
 
-  expect(await screen.findByRole("dialog", { name: "Access token required" })).toBeVisible();
+  expect(
+    await screen.findByRole("dialog", { name: "Access token required" }),
+  ).toBeVisible();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,18 +35,17 @@ import { onUnauthorized, setToken, withAccessToken } from "./api/api";
 import { copyText } from "./lib/clipboard";
 import { NoteActionsDialog } from "./components/NoteActionsDialog";
 import { NotePage } from "./components/NotePage";
-import { SearchDialog } from "./components/SearchDialog";
 import { TokenPrompt } from "./components/TokenPrompt";
 import { GraphPage } from "./components/graph/GraphPage";
 import { StatsPage } from "./components/StatsPage";
 import { StateBlock } from "./components/ui";
 import { useNoteActions } from "./hooks/useNoteActions";
-import { useSearch } from "./hooks/useSearch";
 import { useVaultTree } from "./hooks/useVaultTree";
 import { useWriteMode } from "./hooks/useWriteMode";
 import { pruneNoteDrafts } from "./lib/writeDrafts";
 import type { ActiveNoteMeta, RecentNote } from "./types";
 import { StartupGate } from "./startup/StartupGate";
+import { SearchDialog, useSearch } from "./features/search";
 
 export function VaultApp() {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(() => {

--- a/frontend/src/clientAuditContracts.test.ts
+++ b/frontend/src/clientAuditContracts.test.ts
@@ -10,7 +10,7 @@ import mainSource from "./main.tsx?raw";
 import graphCss from "./styles/graph.css?raw";
 import explorerCss from "./styles/layout-explorer.css?raw";
 import responsiveCss from "./styles/responsive.css?raw";
-import searchCss from "./styles/search.css?raw";
+import searchCss from "./features/search/search.css?raw";
 import topbarCss from "./styles/topbar.css?raw";
 import uiCss from "./styles/ui-common.css?raw";
 import indexHtml from "../index.html?raw";

--- a/frontend/src/components/graph/GraphPage.test.tsx
+++ b/frontend/src/components/graph/GraphPage.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GraphPage } from "./GraphPage";
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+describe("GraphPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("requests the graph and renders the backend error", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Graph index is unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <GraphPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Mapping your vault…")).toBeVisible();
+    expect(
+      await screen.findByRole("heading", { name: "Graph Unavailable" }),
+    ).toBeVisible();
+    expect(screen.getByText("Graph index is unavailable")).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/graph",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});

--- a/frontend/src/components/note-page/PdfPreview.test.tsx
+++ b/frontend/src/components/note-page/PdfPreview.test.tsx
@@ -83,7 +83,10 @@ describe("PdfPreview", () => {
   });
 
   it("renders at 2x backing resolution on a 1x display", async () => {
-    const renderPage = vi.fn(() => ({ promise: Promise.resolve(), cancel: vi.fn() }));
+    const renderPage = vi.fn(() => ({
+      promise: Promise.resolve(),
+      cancel: vi.fn(),
+    }));
     const page = {
       getViewport: ({ scale }: { scale: number }) => ({
         width: 600 * scale,
@@ -115,12 +118,17 @@ describe("PdfPreview", () => {
       value: 1,
     });
 
-    const { container } = render(<PdfPreview src="/vault-assets/sample.pdf" label="Sample" />);
+    const { container } = render(
+      <PdfPreview src="/vault-assets/sample.pdf" label="Sample" />,
+    );
 
     await waitFor(() => expect(renderPage).toHaveBeenCalledOnce());
 
     const canvas = container.querySelector("canvas");
-    expect(canvas).toHaveAttribute("style", expect.stringContaining("width: 300px"));
+    expect(canvas).toHaveAttribute(
+      "style",
+      expect.stringContaining("width: 300px"),
+    );
     expect(canvas).toHaveProperty("width", 600);
     expect(canvas).toHaveProperty("height", 800);
   });

--- a/frontend/src/components/note-page/RendererComponents.tsx
+++ b/frontend/src/components/note-page/RendererComponents.tsx
@@ -50,9 +50,7 @@ export function CalloutOrQuote({ children }: { children: ReactNode }) {
 
   if (isValidElement<{ children?: ReactNode }>(first) && first.type === "p") {
     const firstText = flattenText(first.props.children).trim();
-    const match = firstText.match(
-      /^\[!([A-Za-z0-9_-]+)\]([+-])?[ \t]*(.*)$/m,
-    );
+    const match = firstText.match(/^\[!([A-Za-z0-9_-]+)\]([+-])?[ \t]*(.*)$/m);
 
     if (match) {
       const kind = match[1].toLowerCase();
@@ -113,9 +111,7 @@ export function CalloutOrQuote({ children }: { children: ReactNode }) {
       return (
         <div className={`callout callout-${kind}`}>
           <div className="callout-title">{title}</div>
-          {allBody.length > 0 && (
-            <div className="callout-body">{allBody}</div>
-          )}
+          {allBody.length > 0 && <div className="callout-body">{allBody}</div>}
         </div>
       );
     }

--- a/frontend/src/components/note-page/renderers.tsx
+++ b/frontend/src/components/note-page/renderers.tsx
@@ -124,22 +124,52 @@ export function createNoteMarkdownComponents(
       );
     },
     h1(props: MarkdownHeadingProps) {
-      return renderHeading("h1", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h1",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
     h2(props: MarkdownHeadingProps) {
-      return renderHeading("h2", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h2",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
     h3(props: MarkdownHeadingProps) {
-      return renderHeading("h3", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h3",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
     h4(props: MarkdownHeadingProps) {
-      return renderHeading("h4", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h4",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
     h5(props: MarkdownHeadingProps) {
-      return renderHeading("h5", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h5",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
     h6(props: MarkdownHeadingProps) {
-      return renderHeading("h6", props.children, headingIdsBySourceLine, props.node);
+      return renderHeading(
+        "h6",
+        props.children,
+        headingIdsBySourceLine,
+        props.node,
+      );
     },
   };
 }

--- a/frontend/src/components/note-page/wikilinks.ts
+++ b/frontend/src/components/note-page/wikilinks.ts
@@ -24,8 +24,7 @@ export function useResolvedWikilinks(
       const rawTargets = matches
         .filter(
           (m) =>
-            m[1] !== "!" &&
-            !isPdfAssetTarget(parseWikilinkTarget(m[2]).target),
+            m[1] !== "!" && !isPdfAssetTarget(parseWikilinkTarget(m[2]).target),
         )
         .map((m) => parseWikilinkTarget(m[2]).target)
         .filter((target) => target.length > 0);

--- a/frontend/src/features/search/SearchDialog.test.tsx
+++ b/frontend/src/features/search/SearchDialog.test.tsx
@@ -2,8 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { SearchResult } from "../types";
-import { SearchDialog } from "./SearchDialog";
+import { SearchDialog, type SearchResult } from ".";
 
 function renderDialog(
   overrides?: Partial<ComponentProps<typeof SearchDialog>>,

--- a/frontend/src/features/search/SearchDialog.tsx
+++ b/frontend/src/features/search/SearchDialog.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type ReactNode, type RefObject } from "react";
 
-import type { SearchResult, SearchSelection } from "../types";
-import { UiButton, UiPanel } from "./ui";
+import { UiButton, UiPanel } from "../../components/ui";
+import type { SearchResult, SearchSelection } from "./types";
 
 type NoteGroup = {
   note_slug: string;

--- a/frontend/src/features/search/index.ts
+++ b/frontend/src/features/search/index.ts
@@ -1,0 +1,9 @@
+export { SearchDialog } from "./SearchDialog";
+export { useSearch } from "./useSearch";
+export type {
+  OutboundLink,
+  SearchMode,
+  SearchResponse,
+  SearchResult,
+  SearchSelection,
+} from "./types";

--- a/frontend/src/features/search/search.css
+++ b/frontend/src/features/search/search.css
@@ -1,3 +1,4 @@
+/* Search feature styles; imported by the application style composition root. */
 .search-overlay {
   position: fixed;
   inset: 0;

--- a/frontend/src/features/search/types.ts
+++ b/frontend/src/features/search/types.ts
@@ -1,0 +1,31 @@
+import type { NoteMetadata } from "../../types";
+
+export type SearchMode = "semantic" | "keyword";
+
+export interface OutboundLink {
+  slug: string;
+  title: string;
+}
+
+export interface SearchResult {
+  chunk_id: number;
+  note_slug: string;
+  note_title: string;
+  note_path: string;
+  heading_path: string | null;
+  content: string;
+  score: number;
+  outbound_links: OutboundLink[];
+  metadata?: NoteMetadata;
+}
+
+export type SearchSelection = {
+  slug: string;
+  query: string;
+  matchKind: string;
+};
+
+export interface SearchResponse {
+  mode: SearchMode;
+  results: SearchResult[];
+}

--- a/frontend/src/features/search/useSearch.test.ts
+++ b/frontend/src/features/search/useSearch.test.ts
@@ -1,0 +1,56 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useSearch } from ".";
+
+describe("useSearch", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("debounces a search request and exposes its results", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          mode: "keyword",
+          results: [
+            {
+              chunk_id: 7,
+              note_slug: "plan",
+              note_title: "Plan",
+              note_path: "Projects/Plan",
+              heading_path: "Next",
+              content: "Plan the next milestone",
+              score: 1,
+              outbound_links: [],
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setSearchQuery("plan");
+      result.current.setSearchIncludeContent(true);
+      result.current.setSearchOpen(true);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/search?q=plan&mode=keyword&limit=30&per_note_cap=2",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.searchResults).toHaveLength(1);
+    });
+    expect(result.current.searchResults[0]?.note_slug).toBe("plan");
+    expect(result.current.searchError).toBeNull();
+  });
+});

--- a/frontend/src/features/search/useSearch.ts
+++ b/frontend/src/features/search/useSearch.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { apiFetch } from "../api/api";
-import { readErrorMessage } from "../api/apiError";
-import type { SearchResponse, SearchResult } from "../types";
+import { apiFetch } from "../../api/api";
+import { readErrorMessage } from "../../api/apiError";
+import type { SearchResponse, SearchResult } from "./types";
 
 /**
  * Command-palette search state: open/query/mode plus the debounced fetch and

--- a/frontend/src/startup/StartupGate.test.tsx
+++ b/frontend/src/startup/StartupGate.test.tsx
@@ -81,9 +81,13 @@ describe("StartupGate", () => {
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Set up multilingual search" }),
+      await screen.findByRole("heading", {
+        name: "Set up multilingual search",
+      }),
     ).toBeVisible();
-    expect(screen.getByText(/does not change ownership of your vault/i)).toBeVisible();
+    expect(
+      screen.getByText(/does not change ownership of your vault/i),
+    ).toBeVisible();
     expect(
       screen.getByText(
         /Nomic is the fallback if you decline Gemma\. It supports English only\./,
@@ -99,13 +103,14 @@ describe("StartupGate", () => {
         /Nomic uses about 1\.3 GB of RAM while indexing; Gemma uses about 0\.5 GB\./,
       ),
     ).toBeVisible();
-    expect(screen.getByRole("link", { name: "Read Gemma Terms" })).toHaveAttribute(
-      "href",
-      "https://ai.google.dev/gemma/terms",
-    );
+    expect(
+      screen.getByRole("link", { name: "Read Gemma Terms" }),
+    ).toHaveAttribute("href", "https://ai.google.dev/gemma/terms");
 
     await act(async () => {
-      screen.getByRole("button", { name: "Accept terms and set up Gemma" }).click();
+      screen
+        .getByRole("button", { name: "Accept terms and set up Gemma" })
+        .click();
     });
     const [path, init] = fetchMock.mock.calls.at(-1) ?? [];
     expect(path).toBe("/api/model/accept-gemma");
@@ -115,7 +120,9 @@ describe("StartupGate", () => {
         headers: expect.any(Headers),
       }),
     );
-    expect((init?.headers as Headers).get("Authorization")).toBe("Bearer setup-token");
+    expect((init?.headers as Headers).get("Authorization")).toBe(
+      "Bearer setup-token",
+    );
   });
 
   it("polls until the backend becomes ready", async () => {

--- a/frontend/src/startup/StartupGate.tsx
+++ b/frontend/src/startup/StartupGate.tsx
@@ -71,14 +71,18 @@ export function StartupGate({ children }: { children: ReactNode }) {
   }, []);
 
   const acceptGemma = async () => {
-    const response = await apiFetch("/api/model/accept-gemma", { method: "POST" });
+    const response = await apiFetch("/api/model/accept-gemma", {
+      method: "POST",
+    });
     if (response.ok) {
       setStatus({ state: "downloading", model: "EmbeddingGemma 300M Q4" });
     }
   };
 
   const declineGemma = async () => {
-    const response = await apiFetch("/api/model/decline-gemma", { method: "POST" });
+    const response = await apiFetch("/api/model/decline-gemma", {
+      method: "POST",
+    });
     if (response.ok) {
       setStatus({ state: "downloading", model: "Nomic Embed Text v1.5" });
     }
@@ -105,7 +109,7 @@ export function StartupGate({ children }: { children: ReactNode }) {
     ? `${percent}% of embedding work complete`
     : downloading?.percent !== undefined
       ? `${percent}% of model download complete`
-    : "Measuring the vault";
+      : "Measuring the vault";
 
   return (
     <div className="startup-shell">
@@ -131,7 +135,9 @@ export function StartupGate({ children }: { children: ReactNode }) {
       </header>
 
       <main className="startup-main">
-        <p className="startup-kicker">{termsRequired ? "SEARCH MODEL" : "SEARCH INDEX"}</p>
+        <p className="startup-kicker">
+          {termsRequired ? "SEARCH MODEL" : "SEARCH INDEX"}
+        </p>
         <h1>
           {termsRequired
             ? "Set up multilingual search"
@@ -142,18 +148,21 @@ export function StartupGate({ children }: { children: ReactNode }) {
         {termsRequired ? (
           <section className="startup-terms" aria-label="Gemma terms">
             <p>
-              Hatchdoor can download EmbeddingGemma, a multilingual search
-              model licensed under Google’s Gemma Terms and Prohibited Use
-              Policy.
+              Hatchdoor can download EmbeddingGemma, a multilingual search model
+              licensed under Google’s Gemma Terms and Prohibited Use Policy.
             </p>
             <p>
               Accepting these terms only allows Hatchdoor to download and use
-              the Gemma model. It does not change ownership of your vault or
-              its contents. Hatchdoor does not send your notes to Google when
+              the Gemma model. It does not change ownership of your vault or its
+              contents. Hatchdoor does not send your notes to Google when
               indexing or searching.
             </p>
             <p>
-              <a href="https://ai.google.dev/gemma/terms" target="_blank" rel="noreferrer">
+              <a
+                href="https://ai.google.dev/gemma/terms"
+                target="_blank"
+                rel="noreferrer"
+              >
                 Read Gemma Terms
               </a>{" "}
               <a
@@ -165,10 +174,18 @@ export function StartupGate({ children }: { children: ReactNode }) {
               </a>
             </p>
             <div className="startup-actions">
-              <button type="button" className="startup-primary" onClick={() => void acceptGemma()}>
+              <button
+                type="button"
+                className="startup-primary"
+                onClick={() => void acceptGemma()}
+              >
                 Accept terms and set up Gemma
               </button>
-              <button type="button" className="startup-secondary" onClick={() => void declineGemma()}>
+              <button
+                type="button"
+                className="startup-secondary"
+                onClick={() => void declineGemma()}
+              >
                 Use Nomic instead
               </button>
             </div>
@@ -182,14 +199,14 @@ export function StartupGate({ children }: { children: ReactNode }) {
         ) : (
           <p className="startup-lede" aria-live="polite">
             {failed
-            ? (status.message ?? "Indexing could not be completed.")
-            : connectionIssue
-              ? "Waiting for Hatchdoor to respond…"
-              : downloading
-                ? `Downloading ${downloading.model ?? "the search model"}. Your vault stays locked until setup is complete.`
-              : indexing
-                ? "Building the search index. Your notes stay locked until it is ready."
-                : "Scanning notes and measuring the work ahead…"}
+              ? (status.message ?? "Indexing could not be completed.")
+              : connectionIssue
+                ? "Waiting for Hatchdoor to respond…"
+                : downloading
+                  ? `Downloading ${downloading.model ?? "the search model"}. Your vault stays locked until setup is complete.`
+                  : indexing
+                    ? "Building the search index. Your notes stay locked until it is ready."
+                    : "Scanning notes and measuring the work ahead…"}
           </p>
         )}
 
@@ -201,14 +218,33 @@ export function StartupGate({ children }: { children: ReactNode }) {
               aria-label={progressLabel}
               aria-valuemin={0}
               aria-valuemax={100}
-              aria-valuenow={indexing || downloading?.percent !== undefined ? percent : undefined}
+              aria-valuenow={
+                indexing || downloading?.percent !== undefined
+                  ? percent
+                  : undefined
+              }
             >
               <span style={{ transform: `scaleX(${percent / 100})` }} />
             </div>
 
             <div className="startup-progress-line" aria-live="polite">
-              <strong>{indexing || downloading?.percent !== undefined ? `${percent}%` : downloading ? "Downloading" : "Scanning"}</strong>
-              <span>{indexing ? formatEta(eta) : downloading ? formatDownload(downloading.downloaded_bytes, downloading.total_bytes) : formatEta(eta)}</span>
+              <strong>
+                {indexing || downloading?.percent !== undefined
+                  ? `${percent}%`
+                  : downloading
+                    ? "Downloading"
+                    : "Scanning"}
+              </strong>
+              <span>
+                {indexing
+                  ? formatEta(eta)
+                  : downloading
+                    ? formatDownload(
+                        downloading.downloaded_bytes,
+                        downloading.total_bytes,
+                      )
+                    : formatEta(eta)}
+              </span>
             </div>
 
             {indexing ? (
@@ -260,7 +296,8 @@ function formatEta(seconds?: number) {
 }
 
 function formatDownload(downloaded?: number, total?: number) {
-  if (downloaded === undefined || total === undefined) return "Connecting to model source";
+  if (downloaded === undefined || total === undefined)
+    return "Connecting to model source";
   return `${formatBytes(downloaded)} of ${formatBytes(total)}`;
 }
 

--- a/frontend/src/styles/startup.css
+++ b/frontend/src/styles/startup.css
@@ -94,7 +94,9 @@
   line-height: 1.55;
 }
 
-.startup-terms p { margin: 0 0 var(--space-4); }
+.startup-terms p {
+  margin: 0 0 var(--space-4);
+}
 
 .startup-terms a {
   color: var(--ink);
@@ -102,7 +104,12 @@
   text-underline-offset: 0.2em;
 }
 
-.startup-actions { display: flex; flex-wrap: wrap; gap: var(--space-3); margin-top: var(--space-6); }
+.startup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
 
 .startup-primary,
 .startup-secondary {
@@ -112,16 +119,37 @@
   font: inherit;
   font-weight: 650;
   cursor: pointer;
-  transition: transform var(--dur-fast) var(--ease), background var(--dur) var(--ease), color var(--dur) var(--ease);
+  transition:
+    transform var(--dur-fast) var(--ease),
+    background var(--dur) var(--ease),
+    color var(--dur) var(--ease);
 }
 
-.startup-primary { background: var(--ink); color: var(--bg); }
-.startup-secondary { background: transparent; color: var(--ink); border-color: var(--rule-strong); }
-.startup-primary:hover { background: var(--hot); border-color: var(--hot); }
-.startup-secondary:hover { border-color: var(--ink); }
-.startup-primary:active, .startup-secondary:active { transform: translateY(1px); }
+.startup-primary {
+  background: var(--ink);
+  color: var(--bg);
+}
+.startup-secondary {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--rule-strong);
+}
+.startup-primary:hover {
+  background: var(--hot);
+  border-color: var(--hot);
+}
+.startup-secondary:hover {
+  border-color: var(--ink);
+}
+.startup-primary:active,
+.startup-secondary:active {
+  transform: translateY(1px);
+}
 
-.startup-fallback-note { font-size: 0.84rem; color: var(--muted); }
+.startup-fallback-note {
+  font-size: 0.84rem;
+  color: var(--muted);
+}
 
 .startup-progress {
   position: relative;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -106,36 +106,6 @@ export type ResolveBatchResponse = {
   }>;
 };
 
-export type SearchMode = "semantic" | "keyword";
-
-export interface OutboundLink {
-  slug: string;
-  title: string;
-}
-
-export interface SearchResult {
-  chunk_id: number;
-  note_slug: string;
-  note_title: string;
-  note_path: string;
-  heading_path: string | null;
-  content: string;
-  score: number;
-  outbound_links: OutboundLink[];
-  metadata?: NoteMetadata;
-}
-
-export type SearchSelection = {
-  slug: string;
-  query: string;
-  matchKind: string;
-};
-
-export interface SearchResponse {
-  mode: SearchMode;
-  results: SearchResult[];
-}
-
 export type TagStat = { tag: string; note_count: number };
 export type NoteRef = { title: string; slug: string };
 export type NoteWordRef = NoteRef & { word_count: number };

--- a/scripts/check-module-map.mjs
+++ b/scripts/check-module-map.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+import { lstat, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const moduleMapPath = path.join(
+  repositoryRoot,
+  "docs",
+  "architecture",
+  "module-map.md",
+);
+
+const toRepositoryPath = (absolutePath) =>
+  path.relative(repositoryRoot, absolutePath).split(path.sep).join("/");
+
+async function walk(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      paths.push(...(await walk(absolutePath)));
+    } else if (entry.isFile()) {
+      paths.push(toRepositoryPath(absolutePath));
+    }
+  }
+
+  return paths;
+}
+
+async function productionSourcePaths() {
+  const backend = (await walk(path.join(repositoryRoot, "src"))).filter(
+    (file) => file.endsWith(".rs") && !file.endsWith("/tests.rs"),
+  );
+  const frontend = (
+    await walk(path.join(repositoryRoot, "frontend", "src"))
+  ).filter(
+    (file) =>
+      /\.(?:ts|tsx|css)$/.test(file) &&
+      !/\.test\.(?:ts|tsx)$/.test(file) &&
+      !file.startsWith("frontend/src/test/"),
+  );
+
+  return [...backend, ...frontend].sort();
+}
+
+function pathsInBackticks(line) {
+  return [...line.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+function ownershipAssignments(markdown) {
+  const assignments = new Map();
+  const errors = [];
+  let section = null;
+  let collection = null;
+  let expectSharedPaths = false;
+
+  const add = (file, kind, lineNumber) => {
+    if (!section) {
+      errors.push(
+        `line ${lineNumber}: ownership path ${file} is outside a module section`,
+      );
+      return;
+    }
+    const normalized = path.posix.normalize(file);
+    const parts = file.split("/");
+    const absolutePath = path.resolve(repositoryRoot, ...parts);
+    const relativePath = path.relative(repositoryRoot, absolutePath);
+    if (
+      !/^(?:src|frontend\/src)\//.test(file) ||
+      /[*?[\]{}]/.test(file) ||
+      path.posix.isAbsolute(file) ||
+      file.includes("\\") ||
+      normalized !== file ||
+      parts.includes(".") ||
+      parts.includes("..") ||
+      relativePath === "" ||
+      relativePath === ".." ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
+      errors.push(
+        `line ${lineNumber}: ownership path ${file} is not a canonical repository-relative path`,
+      );
+      return;
+    }
+    const owners = assignments.get(file) ?? [];
+    owners.push({ section, kind, lineNumber });
+    assignments.set(file, owners);
+  };
+
+  for (const [index, line] of markdown.split(/\r?\n/).entries()) {
+    const lineNumber = index + 1;
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      section = heading[1] === "###" ? heading[2] : null;
+      collection = null;
+      expectSharedPaths = false;
+      continue;
+    }
+
+    if (line.startsWith("**Owned paths:**")) {
+      collection = null;
+      const inlinePaths = pathsInBackticks(line);
+      for (const file of inlinePaths) {
+        add(file, "owned", lineNumber);
+      }
+      expectSharedPaths = line.includes("none by default");
+      if (inlinePaths.length === 0 && !expectSharedPaths) {
+        collection = "owned";
+      }
+      continue;
+    }
+
+    if (line.startsWith("**Shared path:**")) {
+      const inlinePaths = pathsInBackticks(line);
+      for (const file of inlinePaths) {
+        add(file, "shared", lineNumber);
+      }
+      collection = inlinePaths.length === 0 ? "shared" : null;
+      continue;
+    }
+
+    if (line.startsWith("**Paths:**")) {
+      const inlinePaths = pathsInBackticks(line);
+      if (!expectSharedPaths && inlinePaths.length > 0) {
+        errors.push(
+          `line ${lineNumber}: inline Paths ownership is not preceded by "Owned paths: none by default"`,
+        );
+      }
+      if (expectSharedPaths) {
+        for (const file of inlinePaths) {
+          add(file, "shared", lineNumber);
+        }
+      }
+      collection =
+        expectSharedPaths && inlinePaths.length === 0 ? "shared" : null;
+      expectSharedPaths = false;
+      continue;
+    }
+
+    if (!collection) {
+      continue;
+    }
+    if (line.trim() === "") {
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      for (const file of pathsInBackticks(line)) {
+        add(file, collection, lineNumber);
+      }
+      continue;
+    }
+    collection = null;
+  }
+
+  return { assignments, errors };
+}
+
+async function invalidAssignedPaths(assignments) {
+  const stale = [];
+  await Promise.all(
+    [...assignments.keys()].map(async (file) => {
+      try {
+        const stat = await lstat(path.join(repositoryRoot, file));
+        if (!stat.isFile()) {
+          stale.push(file);
+        }
+      } catch {
+        stale.push(file);
+      }
+    }),
+  );
+  return stale.sort();
+}
+
+function printGroup(title, values, format = (value) => `  ${value}`) {
+  if (values.length === 0) {
+    return;
+  }
+  console.error(`\n${title}`);
+  for (const value of values) {
+    console.error(format(value));
+  }
+}
+
+const markdown = await readFile(moduleMapPath, "utf8");
+const productionFiles = await productionSourcePaths();
+const { assignments, errors } = ownershipAssignments(markdown);
+
+const unowned = productionFiles.filter((file) => !assignments.has(file));
+const duplicates = [...assignments.entries()]
+  .filter(([, owners]) => owners.length !== 1)
+  .sort(([left], [right]) => left.localeCompare(right));
+const stale = await invalidAssignedPaths(assignments);
+
+if (
+  errors.length > 0 ||
+  unowned.length > 0 ||
+  duplicates.length > 0 ||
+  stale.length > 0
+) {
+  console.error("Module map check failed.");
+  printGroup("INVALID OWNERSHIP MARKUP", errors);
+  printGroup("UNOWNED PRODUCTION FILES", unowned);
+  printGroup("STALE ASSIGNED PATHS", stale);
+  printGroup("DUPLICATE ASSIGNMENTS", duplicates, ([file, owners]) => {
+    const details = owners
+      .map(
+        ({ section, kind, lineNumber }) =>
+          `${section} (${kind}, line ${lineNumber})`,
+      )
+      .join("; ");
+    return `  ${file}\n    ${details}`;
+  });
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Module map OK: ${productionFiles.length} production source files have exactly one assignment.`,
+  );
+}

--- a/scripts/check-module-map.test.mjs
+++ b/scripts/check-module-map.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const sourceScript = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "check-module-map.mjs",
+);
+const temporaryRepositories = [];
+
+const baselineMap = `# Module map
+
+## Backend
+
+### Runtime
+
+**Owned paths:** none by default.
+
+**Paths:**
+
+- \`src/lib.rs\`
+
+## Frontend
+
+### Shell
+
+**Owned paths:** none by default.
+
+**Paths:** \`frontend/src/App.tsx\`
+`;
+
+async function fixture(moduleMap = baselineMap) {
+  const root = await mkdtemp(path.join(tmpdir(), "hatchdoor-module-map-"));
+  temporaryRepositories.push(root);
+  await Promise.all([
+    mkdir(path.join(root, "scripts"), { recursive: true }),
+    mkdir(path.join(root, "docs", "architecture"), { recursive: true }),
+    mkdir(path.join(root, "src"), { recursive: true }),
+    mkdir(path.join(root, "frontend", "src"), { recursive: true }),
+  ]);
+  await Promise.all([
+    copyFile(sourceScript, path.join(root, "scripts", "check-module-map.mjs")),
+    writeFile(
+      path.join(root, "docs", "architecture", "module-map.md"),
+      moduleMap,
+    ),
+    writeFile(path.join(root, "src", "lib.rs"), ""),
+    writeFile(path.join(root, "frontend", "src", "App.tsx"), ""),
+  ]);
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, ["scripts/check-module-map.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRepositories
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+test("accepts list and inline shared Paths assignments", async () => {
+  const result = run(await fixture());
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /2 production source files/);
+});
+
+test("reports an unowned production file", async () => {
+  const root = await fixture();
+  await writeFile(path.join(root, "src", "new_feature.rs"), "");
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /UNOWNED PRODUCTION FILES/);
+  assert.match(result.stderr, /src\/new_feature\.rs/);
+});
+
+test("reports a stale assigned path", async () => {
+  const root = await fixture(
+    baselineMap.replace("- `src/lib.rs`", "- `src/lib.rs`\n- `src/missing.rs`"),
+  );
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /STALE ASSIGNED PATHS/);
+  assert.match(result.stderr, /src\/missing\.rs/);
+});
+
+test("reports duplicate assignments with both module sections", async () => {
+  const root = await fixture(
+    baselineMap.replace(
+      "## Frontend",
+      `### Duplicate owner
+
+**Owned paths:** \`src/lib.rs\`
+
+## Frontend`,
+    ),
+  );
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /DUPLICATE ASSIGNMENTS/);
+  assert.match(result.stderr, /Runtime/);
+  assert.match(result.stderr, /Duplicate owner/);
+});
+
+test("rejects non-canonical and escaping ownership paths", async () => {
+  const root = await fixture(
+    baselineMap.replace(
+      "- `src/lib.rs`",
+      "- `src/lib.rs`\n- `src/../src/lib.rs`\n- `/etc/passwd`",
+    ),
+  );
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /INVALID OWNERSHIP MARKUP/);
+  assert.match(result.stderr, /not a canonical repository-relative path/);
+  assert.match(result.stderr, /\/etc\/passwd/);
+});
+
+test("only H3 headings establish module ownership", async () => {
+  for (const marker of ["#", "##", "####", "#####", "######"]) {
+    const root = await fixture(
+      baselineMap.replace(
+        "## Frontend",
+        `${marker} Detail
+
+**Owned paths:** \`src/lib.rs\`
+
+## Frontend`,
+      ),
+    );
+
+    const result = run(root);
+    assert.equal(result.status, 1, `heading marker ${marker}`);
+    assert.match(result.stderr, /INVALID OWNERSHIP MARKUP/);
+    assert.match(result.stderr, /outside a module section/);
+  }
+});
+
+test("rejects an assigned path that is not a regular file", async () => {
+  const root = await fixture(
+    baselineMap.replace("- `src/lib.rs`", "- `src/lib.rs`\n- `src/generated`"),
+  );
+  await mkdir(path.join(root, "src", "generated"));
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /STALE ASSIGNED PATHS/);
+  assert.match(result.stderr, /src\/generated/);
+});
+
+test("supports inline Owned paths and Shared path fields", async () => {
+  const moduleMap = baselineMap
+    .replace(
+      "**Owned paths:** none by default.\n\n**Paths:**\n\n- `src/lib.rs`",
+      "**Owned paths:** `src/lib.rs`.",
+    )
+    .replace(
+      "**Owned paths:** none by default.\n\n**Paths:** `frontend/src/App.tsx`",
+      "**Shared path:** `frontend/src/App.tsx`.",
+    );
+
+  const result = run(await fixture(moduleMap));
+  assert.equal(result.status, 0, result.stderr);
+});

--- a/src/model_setup.rs
+++ b/src/model_setup.rs
@@ -355,7 +355,7 @@ fn available_bytes(path: &Path) -> Result<u64, String> {
         }
         // SAFETY: successful statvfs initializes the output structure.
         let stat = unsafe { stat.assume_init() };
-        return Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64));
+        Ok(stat.f_bavail.saturating_mul(stat.f_frsize))
     }
     #[cfg(not(unix))]
     {


### PR DESCRIPTION
## Summary

- document module ownership, public contracts, coordination paths, invariants, and validation for all production source files
- add contributor and agent work-packet guidance plus an interface-change checklist
- add a structural module-map checker with regression coverage
- co-locate frontend Search behind a public feature entry point and enforce the boundary with ESLint
- add focused Search and Graph coverage
- organize project documentation behind a categorized `docs/README.md` index
- clear the existing Clippy and Prettier baseline without changing behavior

## Why

Collaborators and coding agents need a predictable way to claim scoped work and change one domain surgically without taking implicit ownership of unrelated modules or shared composition files.

## Compatibility

No backend HTTP/MCP contract or runtime Search behavior changes. Search TypeScript types move behind `frontend/src/features/search/index.ts` with existing shapes preserved.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all` — 443 tests passed
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 37 files / 180 tests passed
- `npm run build`
- `node scripts/check-module-map.mjs` — 145 production files assigned exactly once
- `node --test scripts/check-module-map.test.mjs` — 8 tests passed
- relative Markdown-link audit across project documentation
- `git diff --check`
