### PR TITLE
Expand public documentation Vault and add multi-vault demo tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ frontend/dist
 /data
 /models
 /vault
-/demo-vault
+/demo-vaults
 /.fastembed_cache
 .claude/
 .superpowers/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,6 @@ Do not open a public issue for a vulnerability. Follow the process in
 gitignored — it is not committed. You do not need to create it: on first boot
 the app runs `seed_empty_vault`, which creates the directory and, if it has no
 Markdown yet, populates it with the starter vault from `docs/starter-vault/`.
-Everything else vault-shaped is gitignored too: `demo-vault/` (read-only demo
-content), `data/` (generated cache), and `.fastembed_cache/` (downloaded model
-weights).
+Everything else vault-shaped is gitignored too: `demo-vaults/` (read-only demo
+content — one folder per vault, e.g. `demo-vaults/para/`), `data/` (generated
+cache), and `.fastembed_cache/` (downloaded model weights).

--- a/docs/research/karpathy-llm-wiki/karpathy-llm-wiki-overview.md
+++ b/docs/research/karpathy-llm-wiki/karpathy-llm-wiki-overview.md
@@ -1,0 +1,236 @@
+# Andrej Karpathy's "LLM Wiki" pattern
+
+> Research record.
+>
+> Researched: 2026-08-18
+> Scope: What Karpathy's "LLM Wiki" is, how it works, when it was published,
+> its current status, and its relationship to his other public projects
+> Status: Findings from primary sources only (his own tweet and gist);
+> secondary/SEO write-ups were used only to locate those sources, never cited
+> as evidence
+
+## Executive answer
+
+"LLM Wiki" is not a piece of software Karpathy shipped — it is a **workflow
+pattern** he described in a tweet and then wrote up as a standalone idea
+document (a GitHub Gist). The pattern: instead of doing RAG over a pile of
+raw documents, you have an LLM agent **incrementally compile a persistent,
+interlinked Markdown wiki** from your sources, keep it updated as you add
+more sources, and use it (with Obsidian as a viewer/"IDE") as the thing you
+actually query. Karpathy calls this "manipulating knowledge" the way he
+otherwise manipulates code, and pitches it as an alternative to classic
+RAG/NotebookLM-style retrieval, where "nothing accumulates."
+
+Primary sources confirm:
+
+- **Announcement tweet**: [@karpathy, April 2, 2026](https://x.com/karpathy/status/2039805659525644595)
+  (verified via the `fxtwitter.com` mirror after `x.com` itself returned an
+  HTTP 402 to automated fetch — mirror content matches the tweet id, author,
+  and timestamp fields exactly, so treated as primary).
+- **Follow-up idea doc / Gist**: [gist.github.com/karpathy/442a6bf555914893e9891c11519de94f](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f),
+  titled `llm-wiki.md`, created **April 4, 2026** (confirmed via the raw gist
+  HTML's `datetime="2026-04-04T16:25:13Z"` timestamp and by fetching the raw
+  gist content directly with `curl`, bypassing any AI-summarization step).
+
+There is **no GitHub repository** named `llmwiki`, `llm-wiki`, or similar
+under [github.com/karpathy](https://github.com/karpathy) — his repositories
+are things like `nanochat`, `nanoGPT`, `llm.c`, `LLM101n`, `minbpe`,
+`micrograd`, etc. (confirmed by fetching his repositories page directly).
+"LLM Wiki" is a written pattern/idea file, explicitly described in the gist
+itself as "intentionally abstract... not a specific implementation" — the
+actual code (wiki directory structure, ingest/query/lint tooling) is meant to
+be built by whoever adopts the pattern, in collaboration with their own LLM
+agent. Numerous third parties have since built concrete implementations
+(`karpathy-llm-wiki`, `llmwiki`, `llm-wiki-compiler`, `llm_wiki`, Obsidian
+plugins, etc.), but **none of those are Karpathy's own code** — they are
+community projects inspired by his gist.
+
+## What it actually is (item 1 of the brief)
+
+It is a **workflow/pattern description**, not:
+- not a wiki generated once by an LLM and left static,
+- not a wiki *about* LLMs as a subject,
+- not a dataset,
+- not a course/curriculum artifact (it is unrelated to `LLM101n` beyond both
+  being Karpathy publications).
+
+It is closest to "a documented methodology for using an LLM agent as a
+continuously-operating knowledge-base maintainer," with Obsidian as the
+human-facing viewer.
+
+## Stated purpose/motivation, in Karpathy's own words
+
+From the [announcement tweet](https://x.com/karpathy/status/2039805659525644595)
+(April 2, 2026):
+
+> "Something I'm finding very useful recently: using LLMs to build personal
+> knowledge bases for various topics of research interest. In this way, a
+> large fraction of my recent token throughput is going less into
+> manipulating code, and more into manipulating knowledge (stored as
+> markdown and images)."
+
+And, describing scale he had personally reached:
+
+> "...once your wiki is big enough (e.g. mine on some recent research is
+> ~100 articles and ~400K words), you can ask your LLM agent all kinds of
+> complex questions against the wiki, and it will go off, research the
+> answers, etc. I thought I had to reach for fancy RAG, but the LLM has been
+> pretty good about auto-maintaining index files..."
+
+The gist restates and extends the motivation with a more explicit critique
+of retrieval-only tooling:
+
+> "Most people's experience with LLMs and documents looks like RAG: you
+> upload a collection of files, the LLM retrieves relevant chunks at query
+> time, and generates an answer. This works, but the LLM is rediscovering
+> knowledge from scratch on every question. There's no accumulation... This
+> is the key difference: the wiki is a persistent, compounding artifact."
+
+and closes on the maintenance-burden argument for why this wasn't already
+common practice:
+
+> "The tedious part of maintaining a knowledge base is not the reading or
+> the thinking — it's the bookkeeping... Humans abandon wikis because the
+> maintenance burden grows faster than the value. LLMs don't get bored,
+> don't forget to update a cross-reference, and can touch 15 files in one
+> pass."
+
+He also frames it historically, tying it to Vannevar Bush's Memex (the gist,
+["Why this works" section](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)):
+
+> "The idea is related in spirit to Vannevar Bush's Memex (1945)... The part
+> he couldn't solve was who does the maintenance. The LLM handles that."
+
+## How it technically works (item 3)
+
+Per both the tweet and the gist, the pipeline has three layers and three
+operations.
+
+**Layers** (per the gist):
+1. **Raw sources** — an immutable `raw/` directory of source documents
+   (articles, papers, repos, datasets, images). The LLM reads but never
+   modifies these.
+2. **The wiki** — a directory of Markdown files (summaries, entity pages,
+   concept pages, an index) that the LLM generates and owns entirely. Two
+   files play a special role: `index.md` (a content catalog, updated on
+   every ingest) and `log.md` (an append-only chronological record, with a
+   suggested consistent line prefix like `## [2026-04-02] ingest | Article
+   Title` so it's `grep`-able).
+3. **The schema** — a `CLAUDE.md`/`AGENTS.md`-style configuration document
+   telling the agent the wiki's conventions and workflows; co-evolved by the
+   human and the LLM over time.
+
+**Operations**:
+- **Ingest** — drop a new source in `raw/`, have the agent read it, write a
+  summary page, update the index, update affected entity/concept pages
+  (Karpathy notes "a single source might touch 10-15 wiki pages"), and log
+  the event.
+- **Query** — ask questions against the wiki; the agent reads the index,
+  drills into relevant pages, and synthesizes a cited answer, optionally
+  filing the answer itself back into the wiki as a new page so explorations
+  compound too.
+- **Lint** — periodic LLM-driven health checks for contradictions, stale
+  claims, orphan pages, missing cross-references, and gaps (which can be
+  backfilled via web search).
+
+**Tooling mentioned by name** (from the tweet and gist): Obsidian as the
+viewing "IDE" (plus its Web Clipper extension for converting web articles to
+Markdown, and a hotkey workflow for pulling images down locally), Marp for
+generating slide decks from wiki content, matplotlib for chart output,
+Dataview for frontmatter-driven queries, and — once a wiki outgrows a plain
+index file — [`qmd`](https://github.com/tobi/qmd), a third-party local
+hybrid BM25/vector search engine with both a CLI and an MCP server, which
+Karpathy names as "a good option." He also mentions personally having "vibe
+coded a small and naive search engine over the wiki."
+
+**Model(s) used**: Karpathy does not name a specific model in either the
+tweet or the gist — the pattern is described model-agnostically ("your own
+LLM Agent, e.g. OpenAI Codex, Claude Code, OpenCode / Pi, or etc."), i.e. it
+is a way of using any sufficiently capable coding/agentic LLM against a local
+filesystem, not a wrapper around one particular model.
+
+**Automated vs. human-curated**: The human is responsible for sourcing
+(deciding what goes into `raw/`), directing analysis, and asking questions.
+The LLM is responsible for essentially all of the wiki's *content* — writing
+and maintaining every page, cross-references, and the index/log. Karpathy is
+explicit about this division: "You rarely ever write or edit the wiki
+manually, it's the domain of the LLM."
+
+## When announced/released (item 4)
+
+- **April 2, 2026** — initial tweet, [@karpathy status
+  2039805659525644595](https://x.com/karpathy/status/2039805659525644595),
+  titled "LLM Knowledge Bases" (confirmed `created_at: "Thu Apr 02 20:42:21
+  +0000 2026"` in the tweet's own metadata).
+- **April 4, 2026** — the standalone `llm-wiki.md` gist, a more polished,
+  reusable write-up of the same idea (confirmed by the gist's own
+  `datetime` attribute).
+
+## Current status (item 5)
+
+- **Karpathy's own artifacts**: the tweet and the gist are the only two
+  primary-source documents; there is no dedicated Karpathy repository, no
+  released code, and no dataset. The gist itself says the pattern is
+  "intentionally abstract... not a specific implementation," so by design
+  there is nothing further to "release" from Karpathy directly.
+- **Engagement**: the gist page and tweet do show large engagement counts,
+  but this report does not cite specific star/fork/like numbers as settled
+  fact, because independent checks were inconsistent — two separate WebFetch
+  passes over the same gist page returned conflicting figures ("5,000+
+  stars/forks" in one pass vs. "46,082 stars, 9,486 forks, 1,061 comments"
+  in another), and a direct `curl` of the rendered gist HTML could not
+  extract a reliable numeric star/fork count (GitHub renders those counters
+  client-side). Third-party tweets (not treated as authoritative, only as
+  color) mention figures like "5,000 stars in 48 hours," but that number is
+  unverified against a primary source and should not be repeated as fact.
+  What is independently verifiable: the tweet's own engagement fields at
+  fetch time, via the `fxtwitter.com` mirror of the live tweet, showed
+  21,787,028 views, 60,793 likes, 7,383 retweets, 2,924 replies, and 2,192
+  quotes — these numbers came from the tweet object itself, not a
+  secondary summary, but will have grown further since this fetch.
+- **Third-party implementations** (community projects, not Karpathy's own,
+  found via GitHub search and explicitly excluded from being treated as
+  primary evidence about Karpathy's project itself): `Astro-Han/karpathy-llm-wiki`,
+  `lucasastorian/llmwiki`, `nashsu/llm_wiki`, `atomicstrata/llm-wiki-compiler`,
+  `Ss1024sS/LLM-wiki`, `balukosuri/llm-wiki-karpathy`, and an Obsidian
+  community plugin ("Karpathy LLM Wiki"). These confirm the pattern was
+  picked up and re-implemented widely, but say nothing authoritative about
+  Karpathy's own usage or plans.
+- **Scale Karpathy personally reported**: "~100 articles and ~400K words"
+  for one of his own research wikis, as of the April 2, 2026 tweet — this is
+  the only concrete size figure attributable to Karpathy himself; no later
+  update from him on this figure was found.
+
+## Relationship to Karpathy's other recent work (item 6)
+
+- **nanochat / llm.c**: no direct technical connection found. Both are
+  training/inference codebases; "LLM Wiki" is purely a knowledge-management
+  workflow. The only link is thematic — his tweet frames LLM Wiki as a shift
+  in where his own "token throughput" goes ("less into manipulating code,
+  and more into manipulating knowledge"), implicitly contrasting it with the
+  code-heavy nature of projects like nanochat/llm.c, but he does not say the
+  wiki was used to build either of those repos.
+- **Eureka Labs / LLM101n**: no explicit link in either primary source. Both
+  are separate Karpathy initiatives (Eureka Labs announced July 2024 per
+  search results, not verified first-hand in this pass since it was outside
+  this task's date window); nothing in the tweet or gist mentions Eureka
+  Labs or LLM101n.
+- **"Software 2.0"/"Software 3.0"**: no explicit link found in either
+  primary source. Secondary sources loosely associate the LLM Wiki pattern
+  with his "Software 3.0" framing (LLMs as a new way of directing computers,
+  in English rather than code), but Karpathy does not use that terminology
+  or cite that essay in the tweet or the gist. Any such connection is
+  interpretive, not something he stated.
+
+## Note on secondary-source noise
+
+A first-pass web search turned up a large number of SEO/content-mill
+articles (`datasciencedojo.com`, `medium.com`, `aibuilderclub.com`,
+`kunalganglani.com`, `starmorph.com`, `theaioperator.io`, `hjarni.com`,
+`agentpedia.codes`, etc.) that describe "Karpathy's LLM Wiki" in ways that
+sometimes disagree with each other on hard numbers (e.g. wildly different
+star counts, some describing it as a shipped "tool" rather than a pattern).
+None of these were used as a cited source for any claim above; they were
+used only to locate the real primary URLs (the tweet ID and the gist ID),
+which were then independently verified via direct `curl` fetches of the raw
+gist content and the `fxtwitter.com` mirror of the live tweet object.

--- a/docs/roadmap/product-roadmap.md
+++ b/docs/roadmap/product-roadmap.md
@@ -55,6 +55,30 @@ Direction:
 _Horizon: unversioned ("at some point"), but high-value for trust and safety.
 Some conflict-diff scaffolding already exists in the frontend._
 
+### Vault integrity checks for agent-maintained wikis (lint)
+
+**Problem:** the layer system was built for the agent-wiki pattern — raw
+material demoted into its own layer, an agent ingesting into it and querying
+the curated surface (see the "LLM wiki" research note under
+[`docs/research/karpathy-llm-wiki/`](../research/karpathy-llm-wiki/)) — but
+that pattern's third leg, **lint**, has no home in Hatchdoor today. Nothing
+surfaces orphaned notes, broken wikilinks, or a layer whose marker vanished
+while its notes are still tagged with it; a Vault an agent maintains
+unattended can silently drift out of shape. The building blocks partially
+exist (`build_layer_diagnostics` in `src/handlers/diagnostics.rs`), but the
+route and MCP tool that once exposed it (`/api/diagnostics`,
+`layer_diagnostics`) were both retired in the multi-vault rewrite with no
+Vault-scoped replacement.
+
+Direction: design and ship a Vault-scoped integrity surface — an MCP tool and
+matching HTTP endpoint — covering at minimum: orphaned notes (no backlinks in
+or out), broken wikilinks, layer markers with vanished declarations (notes
+still tagged with a layer no marker claims), and disagreeing layer
+descriptions. Read-only to start; whether it becomes agent-callable as
+routine wiki maintenance, a Web UI diagnostics panel, or both is still open.
+
+_Horizon: unversioned ("at some point"). No implementation started._
+
 ### Onboarding experience
 
 **Problem:** a first-time user lands in Hatchdoor with no onboarding.

--- a/docs/user-documentation-handover.md
+++ b/docs/user-documentation-handover.md
@@ -69,13 +69,14 @@ The current Vault is only the getting-started foundation. It still needs a broad
 ## Release and deployment work still required
 
 - Review every page against the final v2.5.0 behavior and terminology before publication.
-- Provision the dedicated read-only documentation instance.
-- Mount or deploy `docs/user-vault` into that instance.
-- Preserve its Vault registry and stable Vault UUID.
-- Configure the root-to-Home reverse-proxy redirect.
+- ~~Provision the dedicated read-only documentation instance.~~ Done: a `HATCHDOOR_DEMO_MODE=true` instance is deployed and public. (Infra specifics — host, deploy stack, internal domain — deliberately kept out of this repo; see private ops notes.)
+- ~~Mount or deploy `docs/user-vault` into that instance.~~ Done, and syncs itself: the Vault is registered as **`managed_git`**, `pull_only`, pointed at this repo's public GitHub URL (branch `main`, `vault_subdirectory: docs/user-vault`), polling every **15 minutes** (deliberately short for now, while the doc set is still being iterated on; revisit once it stabilizes). Hatchdoor clones and refreshes it itself — no rsync, no filesystem watcher (that's disabled for git-backed Vaults; freshness comes from the poll instead).
+- Preserve its Vault registry and stable Vault UUID so the root redirect and any direct note links keep working across future config changes.
+- ~~Configure the root-to-Home reverse-proxy redirect.~~ Done: `/` redirects to `/v/<vault-id>/n/home`.
 - Confirm public navigation, direct note links, mobile rendering, search, and read-only behavior.
-- Define and document the initial manual publication checklist.
-- Later, automate publication without allowing the deployed instance to overwrite the canonical repository files.
+- **Publishing is now push-and-wait, not a manual step**: merge/push to `main` and the site picks it up within the poll interval. `HATCHDOOR_DEMO_MODE=true` blocks the Sync/Retry API and the Settings UI's Vault controls (`403 demo_read_only`), so there is currently no way to force an immediate pull short of restarting the instance out-of-band.
+- **Changing the Vault's `branch` field requires a full re-clone, not just editing the registry**: the managed-checkout validator checks the existing local checkout against the configured branch and fails closed if they disagree, silently falling back to a stale local-style read (`git: unavailable`, `watcher: running`) instead of failing loudly. After changing `branch`, the existing checkout must also be discarded so it clones fresh.
+- Later, automate publication (e.g. a low-privilege endpoint or webhook that triggers a pull) without allowing the deployed instance to overwrite the canonical repository files — mutation stays impossible either way since `capabilities.mutate` is false for a git-sourced Vault.
 - Decide how documentation for older Hatchdoor versions will be retained once releases move beyond v2.5.0.
 
 ## Important constraints

--- a/docs/user-vault/01 Get started/Connect your first Vault.md
+++ b/docs/user-vault/01 Get started/Connect your first Vault.md
@@ -28,6 +28,8 @@ reason to copy your real notes into the container.
 
 To connect another local Vault later, open **Settings** → **Add a Vault** →
 **A folder on this server** and enter the already-mounted container path.
+Want version history, or a Vault backed by a remote repository instead? See
+[[How to set up a Git-backed Vault]].
 
 With the first Vault ready, keep its contents read-only to agents while you
 make the first connection in [[Connect your agent]].

--- a/docs/user-vault/02 Guides/How to deploy Hatchdoor with an agent.md
+++ b/docs/user-vault/02 Guides/How to deploy Hatchdoor with an agent.md
@@ -1,0 +1,172 @@
+---
+tags: [type/how-to, topic/deployment, topic/mcp]
+---
+
+# How to deploy Hatchdoor with an agent
+
+Use this guide when an agent with shell and HTTP access should stand up Hatchdoor on a machine it controls, without a human clicking through the first-run screen. It assumes Docker Compose and produces a running instance with MCP enabled and one Vault ready to search.
+
+> [!note]
+> This is the unattended path. If a person is doing the deployment by hand, follow [[Install Hatchdoor with Docker Compose]], [[Connect your first Vault]], and [[Connect your agent]] instead — they cover the same ground with screenshots and explanation.
+
+## Before you start
+
+Decide the Vault source:
+
+
+
+- **Local** — Markdown already sits in a folder Docker can mount.
+- **Managed Git** — Hatchdoor should clone and keep a remote repository's Markdown in sync (`pull_only`) or also push local commits back (`two_way`).
+
+Both are covered in step 5; pick one before you begin.
+
+## 1. Write the deployment files
+
+Create an empty deployment directory and, inside it, `compose.yaml`:
+
+```yaml
+services:
+  hatchdoor:
+    image: battermanz/hatchdoor:2.5.0
+    container_name: hatchdoor
+    env_file:
+      - .env
+    environment:
+      HOST: 0.0.0.0
+      PORT: "42824"
+      VAULT_PATH: /data/vault
+      HATCHDOOR_CACHE_DB: /data/cache/hatchdoor-cache.sqlite3
+    ports:
+      - "127.0.0.1:42824:42824"
+    volumes:
+      - ${HOST_VAULT_PATH:-./vault}:/data/vault
+      - ${HOST_CACHE_PATH:-./data/cache}:/data/cache
+      - ${HOST_STATE_PATH:-./data/state}:/data/state
+      - ${HOST_MODELS_PATH:-./models}:/models
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/app/hatchdoor", "--healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+```
+
+> [!warning]
+> `HOST: 0.0.0.0` is required — it is the container's own listener, not a public exposure setting. From Hatchdoor's point of view this is **never** a loopback address, regardless of whether the `ports` mapping above is restricted to `127.0.0.1`. That has one consequence you cannot skip: see step 2.
+
+Generate a web token and a Vault directory before the first start, so the container does not need a fail-then-restart cycle:
+
+```bash
+mkdir -p data/cache data/state models vault
+chmod 700 data/cache data/state models
+sudo chown -R 65532:65532 data models vault
+
+WEB_TOKEN=$(openssl rand -hex 32)
+cat > .env <<EOF
+HATCHDOOR_WEB_BEARER_TOKEN=${WEB_TOKEN}
+HOST_VAULT_PATH=$(pwd)/vault
+EOF
+```
+
+If you are pointing at a Local Vault that already has Markdown, set `HOST_VAULT_PATH` to that folder instead of the empty one created above.
+
+## 2. Start Hatchdoor
+
+```bash
+docker compose up -d
+```
+
+Wait for the health check:
+
+```bash
+until docker compose ps --format json | grep -q '"Health":"healthy"'; do sleep 2; done
+```
+
+> [!warning]
+> Because `HOST` can never be loopback inside the container (step 1), Hatchdoor's own startup check (`check_web_auth`) treats this as a public bind and refuses to run without `HATCHDOOR_WEB_BEARER_TOKEN` set. Pre-generating the token, as above, means the first start already succeeds. If you skip that step, the container exits immediately and prints a freshly generated token to its logs (`docker compose logs hatchdoor`) for you to add to `.env` before starting again.
+
+## 3. Turn on MCP, without a restart
+
+MCP is off by default and is read live from settings on every request — no restart is needed once it is turned on. Generate a separate MCP token (never reuse the web token) and patch it in:
+
+```bash
+MCP_TOKEN=$(openssl rand -hex 32)
+
+curl -sf -X PATCH http://127.0.0.1:42824/api/settings \
+  -H "Authorization: Bearer ${WEB_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "updates": {
+      "HATCHDOOR_MCP_ENABLED": "true",
+      "HATCHDOOR_MCP_WRITE_ENABLED": "true",
+      "HATCHDOOR_MCP_BEARER_TOKEN": "'"${MCP_TOKEN}"'"
+    }
+  }'
+```
+
+> [!warning]
+> Do not set `HATCHDOOR_DEMO_MODE=true` on a deployment an agent needs to manage. Hatchdoor refuses to start at all with demo mode and MCP enabled together — demo mode is for a public, read-only instance nobody configures further, never for this flow.
+
+From here on, address `http://127.0.0.1:42824/mcp` with `Authorization: Bearer ${MCP_TOKEN}` as an MCP Streamable HTTP client.
+
+## 4. Finish first-run model setup
+
+Call `get_model_setup_status`. If setup is still pending, call `accept_gemma_terms` (recommended, multilingual) or `decline_gemma_terms` (English-only, lower memory). Poll `get_model_setup_status` until the model has finished downloading.
+
+## 5. Create the Vault
+
+Call `list_vaults` first — every write below needs its `expected_registry_revision`.
+
+**Local Vault**, for Markdown already mounted into the container:
+
+```json
+{
+  "name": "create_vault",
+  "arguments": {
+    "expected_registry_revision": 0,
+    "name": "Primary",
+    "source": {
+      "type": "local",
+      "path": "/data/vault"
+    }
+  }
+}
+```
+
+**Managed Git Vault**, for a remote repository Hatchdoor should clone and keep in sync:
+
+```json
+{
+  "name": "create_vault",
+  "arguments": {
+    "expected_registry_revision": 0,
+    "name": "Primary",
+    "source": {
+      "type": "managed_git",
+      "repository_url": "https://github.com/<owner>/<repo>.git",
+      "branch": "main",
+      "vault_subdirectory": "notes",
+      "mode": "pull_only",
+      "poll_interval_secs": 900
+    }
+  }
+}
+```
+
+Add `https_credentials` alongside `source` if the repository is private; omit it for a public repository. Use `mode: "two_way"` only if this Vault should also push the agent's own commits back to the remote.
+
+## 6. Confirm it is ready
+
+Poll `list_vaults` or `get_stats` until the Vault's phase reaches `ready`. Then run one read to prove the path works end to end:
+
+```text
+search_notes with a term you expect to match, then get_note on the best result.
+```
+
+> [!success]
+> Hatchdoor is deployed, MCP is live, and the Vault is searchable — all without a human opening the browser. Keep the Web UI available anyway: `http://127.0.0.1:42824` with the web token from step 1 is how a person audits what the agent has done.
+
+---
+
+Related: [[Install Hatchdoor with Docker Compose]] · [[Connect your first Vault]] · [[Connect your agent]]

--- a/docs/user-vault/02 Guides/How to organize a Vault with layers.md
+++ b/docs/user-vault/02 Guides/How to organize a Vault with layers.md
@@ -1,0 +1,83 @@
+---
+tags: [type/how-to, topic/layers]
+---
+
+# How to organize a Vault with layers
+
+Use this when a folder's content should stay in the Vault and stay reachable on request, but should stop showing up in default search and stop competing for attention. See [[The layer system]] first if you want the concepts before the steps.
+
+## 1. Add the marker
+
+Create a `.hatchdoor-layer` file directly inside the folder you want to demote — through your usual filesystem/Git access, or the Web UI's file tools if it exposes raw-file creation. **No MCP or HTTP write tool can create, rename, or move this file**: every write path refuses a target named `.hatchdoor-layer` outright, specifically so a marker that reclassifies a whole folder can't be planted or moved by an agent's ordinary write access.
+
+The simplest marker is just the layer name:
+
+```yaml
+sources
+```
+
+Add a description if it will help an agent decide when to ask for this layer:
+
+```yaml
+name: sources
+description: Raw source material, kept for reference but not for browsing.
+```
+
+Naming rules: letters, digits, and hyphens only, starting with a letter or digit, 32 characters or fewer. `default`, `all`, `noise`, and `none` are reserved.
+
+> [!warning]
+> Don't put a named-layer marker at the Vault root — it would demote the entire Vault and leave nothing on the default surface. Hatchdoor refuses to build the index while that's true.
+
+## 2. Let it index
+
+No manual step needed: the marker file is picked up by the same file watcher that notices note edits, the same way as any other Vault change. Give it a moment, then confirm with `get_stats` (HTTP `GET /api/v1/vaults/{scope}/stats` or the MCP `get_stats` tool) or by checking the note's own `layer` field after reading it.
+
+## 3. Confirm the demotion took effect
+
+Search for something that only exists under the marked folder, without any layer selector — it should **not** appear:
+
+```text
+search_notes with scope=<vault_id>, query="<something only in that folder>"
+```
+
+Now ask for it explicitly, either by naming the layer or by asking for everything:
+
+```json
+{ "name": "search_notes", "arguments": { "scope": "<vault_id>", "query": "...", "layers": ["sources"] } }
+```
+
+```json
+{ "name": "search_notes", "arguments": { "scope": "<vault_id>", "query": "...", "layers": ["all"] } }
+```
+
+Browsing is unaffected either way — the explorer tree, the graph, and `get_note` by slug all still show the note on an ordinary (non-demo) deployment. Only default search changed.
+
+> [!note]
+> There is no "list every layer" tool. If you need to discover what layer names already exist in a Vault, search with `layers: ["all"]` and read the `layer` field off the hits, or look at the marker files while browsing.
+
+## 4. Re-promote a subfolder if needed
+
+A folder nested inside a demoted one can opt back onto the default surface with its own marker:
+
+```yaml
+default
+```
+
+This does not create a layer — a note under it always reports `layer: null` — it just overrides the inherited demotion from its parent.
+
+## 5. Decide whether demoted content should be semantically searchable
+
+By default (`HATCHDOOR_EMBED_LAYERS=true`), a note found through an explicit layer request is searchable by meaning, same as the default surface. Turn it off in **Settings → Meaning search in demoted layers** (or `PATCH /api/settings` with `HATCHDOOR_MCP_ENABLED`'s neighbor, `HATCHDOOR_EMBED_LAYERS`) if the Vault has a lot of demoted content and you would rather trade semantic recall there for a smaller, faster index — exact-word search over demoted notes keeps working either way.
+
+> [!warning]
+> Flipping `HATCHDOOR_EMBED_LAYERS` triggers a background reindex (its settings class is `reindex`, not `instant`) — expect a delay proportional to Vault size before the change is fully applied.
+
+## 6. Retiring a layer
+
+Delete the `.hatchdoor-layer` file (or edit it to `default`) to stop demoting a folder — its notes rejoin the default surface on the next index turn. If you remove a marker while notes are still tagged with its old layer name for some other reason (e.g. only some of them reindexed yet), they stay on that layer rather than being silently promoted; they remain reachable via `layers: ["all"]` until they're fully reclassified.
+
+---
+
+Related: [[The layer system]] · [[MCP tools reference]] · [[Search and change notes with your agent]]
+
+

--- a/docs/user-vault/02 Guides/How to run an LLM wiki in Hatchdoor.md
+++ b/docs/user-vault/02 Guides/How to run an LLM wiki in Hatchdoor.md
@@ -1,0 +1,65 @@
+---
+tags: [type/how-to, topic/agent-workflow, topic/layers]
+---
+
+# How to run an LLM wiki in Hatchdoor
+
+An **LLM wiki** is a pattern popularized by Andrej Karpathy: instead of an agent re-researching the same ground on every question (per-query RAG), it incrementally builds and maintains a persistent, interlinked Markdown wiki — a compounding artifact that gets more useful over time, not a cache that gets thrown away after each answer. Hatchdoor's Vault model, wikilinks, and layer system fit this almost exactly. This guide sets one up.
+
+The pattern has three operations: **ingest** raw material, **query** the wiki, and **lint** it for drift. The first two map cleanly onto Hatchdoor's existing tools; the third is partly manual today — see the note at the end.
+
+## 1. Shape the Vault into two zones
+
+Keep raw material and the curated wiki in the same Vault, separated by a [[The layer system|layer]]: a `raw` (or similarly named) layer for source dumps — transcripts, pasted articles, scraped pages — and the Vault's **default surface** for the curated wiki pages themselves.
+
+Follow [[How to organize a Vault with layers]] to create the marker:
+
+```yaml
+name: raw
+description: Unprocessed source material an agent ingests from, not the curated wiki.
+```
+
+This keeps raw material fully in the Vault, versioned and linkable, without it cluttering default search or the first thing a person sees browsing.
+
+## 2. Connect an agent with write access
+
+Follow [[Connect your agent]] and [[Search and change notes with your agent]] to get a read-then-write connection working. An LLM wiki needs write access — turn on **Let assistants change notes** once you trust the read path.
+
+## 3. Ingest
+
+Give the agent raw material and a clear instruction to file it under the `raw` layer first, before writing anything to the curated wiki:
+
+```text
+Use Hatchdoor MCP. Create a note under the "raw" layer folder containing this material verbatim: [paste source text]. Use a short, dated filename. Do not touch any other note yet.
+```
+
+Then have it turn that into (or fold it into) a curated wiki page — this is where the "compounding artifact" idea matters: prefer extending an existing page over creating a new one for the same topic.
+
+```text
+Search the wiki (default surface) for an existing page about [topic]. If one exists, read it and use append_to_note or replace_section to add what's new from [[raw source note]], with a wikilink back to the source. If none exists, create a new wiki page, link it from any obviously related pages you already found, and link it back to the raw source.
+```
+
+> [!tip]
+> Small, well-linked pages beat one giant page. The wiki's value is in the link graph as much as the content — an agent that queries it later benefits from being able to follow `[[wikilinks]]` between related pages, not just semantic search hits.
+
+## 4. Query
+
+Before answering a question, an agent should search the wiki, not just its own memory or a fresh web search:
+
+```text
+Before answering, search the Hatchdoor wiki for [topic]. Read the most relevant page(s) and any pages they link to. Answer using what the wiki already says; only research further if the wiki doesn't cover it — and if you do, ingest what you learn back into the wiki afterward.
+```
+
+This closes the loop: query first, ingest what's missing, so the next query is faster and doesn't repeat the same research.
+
+## 5. Lint
+
+Hatchdoor has no dedicated wiki-integrity tool yet — it's a known gap, not yet implemented. Until then, approximate it manually:
+
+- Periodically `search_notes` with `layers: ["all"]` to check nothing landed on the wrong surface.
+- Use `recently_modified` and [[Browse and review through the Web UI]] to spot-check what the agent has been writing.
+- Ask the agent directly: *"Search the wiki for pages with no incoming or outgoing wikilinks — those are candidates for linking in or archiving."* This is a manual substitute for the automated check that doesn't exist yet.
+
+---
+
+Related: [[The LLM wiki pattern (external reference)]] · [[The layer system]] · [[How to organize a Vault with layers]] · [[Search and change notes with your agent]] · [[MCP tools reference]]

--- a/docs/user-vault/02 Guides/How to set up a Git-backed Vault.md
+++ b/docs/user-vault/02 Guides/How to set up a Git-backed Vault.md
@@ -1,0 +1,71 @@
+---
+tags: [type/how-to, topic/vaults, topic/git]
+---
+
+# How to set up a Git-backed Vault
+
+This covers adding or editing a Vault's Git behaviour from the Web UI's **Settings** screen — not the MCP/API path, which [[How to deploy Hatchdoor with an agent]] and [[HTTP API reference]] already cover. If you only want a plain folder with no Git at all, [[Connect your first Vault]] is the shorter path.
+
+## Pick the right starting point first
+
+Three questions decide which option you want, before you open the form:
+
+- **Does this Vault need version history or a remote at all?** If not, choose **A folder on this server** and leave its Git behaviour at **No Git** — a plain folder, nothing else.
+- **Do you already keep this folder in Git yourself, on the same machine Hatchdoor runs on?** Choose **A folder on this server**, then pick a Git behaviour (**Local history**, **Pull-only**, or **Two-way**) — Hatchdoor uses your existing working copy in place. It never clones it.
+- **Is the source of truth a remote repository you don't have checked out locally?** Choose **A managed Git checkout** — Hatchdoor clones the repository itself and owns that checkout.
+
+## Create the Vault
+
+Open **Settings** → **Add a Vault**, then:
+
+1. Enter a **Name**.
+2. Optionally fill **Ignore these files and folders** with comma-separated patterns to leave out of this Vault's search.
+3. Under **Where is this Vault?**, choose **A folder on this server** or **A managed Git checkout**.
+4. If you chose **A folder on this server**, enter its **Folder path** — the path as the Hatchdoor container sees it, not your host machine's path (see [[Connect your first Vault]] if that distinction is new).
+5. Under **Git behaviour**, choose one of the options below. A managed checkout only offers **Pull-only** and **Two-way** — a managed Vault exists specifically to track a remote, so there's no "no remote" option for it.
+6. If the behaviour you chose talks to a remote, fill in the fields that appear: **Repository URL**, optionally **Branch** and **Folder within the repository**, **Sign-in**, and the **Sync schedule**.
+7. Select **Create Vault**.
+
+## The four Git behaviours
+
+| Behaviour | What it does | Available on |
+| --- | --- | --- |
+| **No Git** | Nothing — a plain folder, no history, no remote. | A folder on this server |
+| **Local history** | Hatchdoor commits every change locally. Never contacts a remote. | A folder on this server |
+| **Pull-only** | Also fetches from the remote on the sync schedule. Content flows in; Hatchdoor's own commits stay local and are never pushed. | Either |
+| **Two-way** | Also pushes Hatchdoor's own commits back to the remote. | Either |
+
+> [!warning]
+> Local history creates a hidden `.git` folder inside the Vault's own notes folder to hold its history, and that folder grows permanently: every image and PDF ever attached stays in it, even after you delete the file from the Vault. Don't reach for Local history on a Vault with large attachments unless you're prepared for that growth.
+
+## The shared remote fields
+
+These appear whenever the chosen behaviour talks to a remote (**Pull-only** or **Two-way**, on either source):
+
+- **Repository URL** — required for Pull-only/Two-way; not shown for Local history, which has nothing to fetch or push.
+- **Branch** (optional) — leave blank to track the remote's default branch.
+- **Folder within the repository** (optional) — leave blank to use the repository root as the Vault.
+- **Sign-in** — **No sign-in** for a public repository, or **Access token** for a private one. The token is HTTPS-only, write-only (never shown again once saved), and stored separately from every other credential Hatchdoor holds.
+- **Sync schedule** — how often Hatchdoor checks the remote absent a manual sync, since "Hatchdoor has no way to be told when something is pushed." Anywhere from 1 minute to 1440 minutes (24 hours); the default is the slowest setting, once a day, so a Vault you want to stay current sooner needs a shorter interval set deliberately.
+
+## Editing an existing Vault's Git settings
+
+Open the Vault from **Settings** and its own page has a **Save Vault** button in the header, plus a **Sync** console (when Git applies) showing whether the last sync was healthy and a **Sync now** (or **Try again**, if something failed) button.
+
+Two kinds of edit behave differently:
+
+- **Ordinary edits** — name, ignored patterns, archive folder, commit identity, sync schedule, or switching between Pull-only and Two-way on the *same* repository — save immediately with **Save Vault**.
+- **Identity changes** — a different folder path, repository URL, branch, or subdirectory — change what the Vault actually points at. For a local folder these fields are always editable directly; for a Git-sourced Vault they're read-only until you select **Edit** to unlock them. Saving one of these shows a confirmation first:
+
+> [!note]
+> "This runs as one step: the Vault pauses, the change saves, and the Vault starts back up. It stays out of the sidebar and All Vaults for that moment." Confirming also clears any stored sign-in token, even if you didn't touch it — sign in again afterward if the Vault still needs one. If you're moving into Local history, the disk-growth warning above appears again in the same confirmation.
+
+If the final restart step ever fails, the Vault is left paused and hidden rather than silently broken — a banner appears with a **Try to bring this Vault back** button to retry just that step.
+
+## If a sync fails
+
+The Sync console reports what happened in plain language rather than a code — things like a rejected sign-in, an unreachable remote, local edits Hatchdoor isn't sure how to reconcile, or unpushed commits sitting on a Pull-only Vault it isn't allowed to push. Every failure sentence says what happened, confirms nothing was lost, and states the one thing that clears it, ending in **Try again**.
+
+---
+
+Related: [[Connect your first Vault]] · [[Install Hatchdoor with Docker Compose]] · [[HTTP API reference]]

--- a/docs/user-vault/02 Guides/How to troubleshoot common problems.md
+++ b/docs/user-vault/02 Guides/How to troubleshoot common problems.md
@@ -1,0 +1,80 @@
+---
+tags: [type/how-to, topic/troubleshooting]
+---
+
+# How to troubleshoot common problems
+
+Find your symptom below. Each entry gives the real cause, grounded in what Hatchdoor actually checks, and the fix.
+
+## Hatchdoor won't start
+
+The container exits immediately and the logs show a line like `HOST=0.0.0.0 is non-loopback but HATCHDOOR_WEB_BEARER_TOKEN is unset: refusing to start unauthenticated on a public interface`, followed by a freshly generated token and the exact line to paste into `.env`. This is deliberate: the container's own listener is never loopback (`HOST: 0.0.0.0` is fixed in `compose.yaml` so Docker's port publishing can reach it at all), so Hatchdoor refuses to serve mutating routes unauthenticated the moment it isn't bound to `127.0.0.1`/`localhost`.
+
+Fix: `docker compose logs hatchdoor | grep HATCHDOOR_WEB_BEARER_TOKEN | tail -1` — grab the **most recent** one, since `restart: unless-stopped` means a crash loop generates a new token on every attempt. Paste the assignment into `.env`, then `docker compose up -d` again.
+
+> [!warning]
+> If you don't catch this within a few restarts, older tokens in the log are stale and won't match what a later attempt actually needs — always take the last one, not the first you see.
+
+A second, rarer startup failure: `HATCHDOOR_MCP_ENABLED is set but HATCHDOOR_MCP_BEARER_TOKEN is missing`. This only happens if you set `HATCHDOOR_MCP_ENABLED=true` directly in `.env` before ever starting — the normal path is to enable MCP live from **Settings** after the container is already running (see [[Connect your agent]]), which doesn't hit this check at all. Fix: either also set `HATCHDOOR_MCP_BEARER_TOKEN` in `.env`, or remove `HATCHDOOR_MCP_ENABLED` from `.env` and enable MCP from Settings instead.
+
+## Browser asks for a token you don't have
+
+You bound Hatchdoor to a non-loopback host and it generated one on first start (see above) — it isn't something you chose, it's printed once to the container logs. Fix: `docker compose logs hatchdoor | grep HATCHDOOR_WEB_BEARER_TOKEN | tail -1`, or if you already saved it to `.env` and just forgot it, read the value straight out of that file — Hatchdoor never displays it back to you once set, by design (revealing an already-known credential grants no new access, but Hatchdoor still won't show a browser session a token it hasn't already proven it holds).
+
+## An agent can't connect over MCP
+
+Three distinct failures, distinguishable by the response:
+
+- **`404 Not Found` on `/mcp`** — MCP is disabled. Turn on **Let assistants connect (MCP)** in **Settings** → **Agent access (MCP)**.
+- **`401`, JSON-RPC error `-32001`, "Missing or invalid MCP bearer token"** — the client's `Authorization: Bearer <token>` header doesn't match the current MCP password. Regenerate or re-copy it from Settings; the client and Settings must hold the exact same value.
+- **A write tool (`create_note`, `edit_vault`, etc.) returns "MCP write tools are disabled by HATCHDOOR_MCP_WRITE_ENABLED"** — MCP is connected and reading fine, but **Let assistants change notes** is off. This is a separate toggle from connecting at all; see [[Search and change notes with your agent]] for why that separation exists.
+
+A fourth, less common one: **`403 Forbidden`, "Forbidden MCP origin"** — an `Origin` header was sent that isn't on the allow-list (`HATCHDOOR_MCP_ALLOWED_ORIGINS`). This normally only matters for a browser-based MCP client, not a CLI agent.
+
+## Model download is stuck or failed
+
+Check `get_model_setup_status` (MCP) or `GET /api/startup-status` — a failed download reports `"failed"` with a message describing exactly what broke, e.g. a Hugging Face fetch error for a specific model file. Fix: `POST /api/model/retry` (or ask the agent to call `get_model_setup_status` again and retry) once whatever blocked the download — usually network access to Hugging Face — is resolved.
+
+Two related, more specific errors:
+
+- **`409`, "Gemma terms must be accepted or declined first."** — you tried to retry before choosing a model at all. Accept or decline Gemma first.
+- **`409`, "The running search model cannot be changed until Hatchdoor restarts."`** — a model is already active; Hatchdoor doesn't support switching models live. This is expected, not a bug — restart the instance if you genuinely need a different model.
+
+## A Vault won't index or stays in a bad state
+
+`list_vaults` (or the Vault's own Settings page) reports five independent status axes, not one health flag — a Vault can be broken in one dimension while working fine in every other:
+
+| Axis | Values | What it means |
+| --- | --- | --- |
+| `activation` | `active`, `disabled`, `unavailable` | Whether the Vault definition itself is usable |
+| `local_content` | `read_write`, `read_only`, `unavailable` | Whether the authoritative Markdown folder can be read/written |
+| `search` | `unavailable`, `indexing`, `browsable`, `ready`, `stale` | Whether search/browse actually work right now |
+| `git` | `disabled`, `pending`, `ready`, `unavailable` | Only meaningful for a Git-backed Vault |
+| `watcher` | `running`, `disabled`, `unavailable` | Whether file-change detection is active |
+
+`browsable` (not `ready`) right after connecting a Vault isn't broken — it means structural indexing finished but the semantic embedding pass hasn't yet, which happens once per Vault's first successful index. `stale` means content changed and a reindex hasn't completed yet; give it a moment. Anything reporting `unavailable` carries a matching `*_error` field (`activation_error`, `search_error`, `git_error`, `watcher_error`) with a real error code and message — read that field before guessing at a cause.
+
+## Permission denied reading or writing the Vault
+
+`local_content` reports `unavailable` with an error code of `vault_path_unreadable` or `vault_path_unavailable`, and the message includes the underlying OS error (e.g. `Permission denied (os error 13)`). This is almost always the container's UID: the image runs as the numeric `nonroot` user (UID `65532`), and the host folder mounted as the Vault needs to be readable — and writable, if agents or the Web UI should change notes — by that UID specifically, not just by your own host user. See [[Install Hatchdoor with Docker Compose]] for the exact `chown`/`chmod` commands.
+
+A softer variant: `local_content` reports `read_only` rather than `unavailable` — the folder is readable but not writable by UID `65532`. This isn't an error state; it just means Hatchdoor can browse and search the Vault but not write to it. Fix the same way if write access is what you actually wanted.
+
+## Git sync is failing
+
+Check the Vault's Sync console for the specific failure rather than assuming — these need different fixes:
+
+- **Authentication failed** — the stored HTTPS token was rejected by the remote. Re-enter it under **Sign-in** on the Vault's own page; see [[How to set up a Git-backed Vault]].
+- **Clone/fetch failed, or the remote is unreachable** — a network or DNS problem, or the repository URL itself is wrong. Confirm the URL resolves from wherever the container runs, not just from your own machine.
+- **Local commits ahead on a Pull-only Vault** — Hatchdoor made local commits (from note edits) that a Pull-only Vault is configured never to push. This isn't a failure exactly — it's Hatchdoor accurately reporting that local history and the remote have diverged and staying pull-only rather than silently discarding your local commits. Switch the Vault to **Two-way** if you want those commits pushed, or accept that Pull-only Vaults are meant to be read-mostly.
+
+> [!note]
+> A Vault reporting `git: pending` isn't stuck by default — that's the normal state while a clone or fetch is in flight. Only treat it as a problem if it stays `pending` well past the configured sync interval.
+
+## Search returns nothing, or not what you expected
+
+Before assuming something's broken: search only considers the **default surface** unless you explicitly ask for more. If the note you expected lives under a [[The layer system|layer]], it won't appear in an ordinary search — see [[How to organize a Vault with layers]] for how to search across layers deliberately. If a Vault's `search` status is `browsable` rather than `ready` (see above), semantic search over it isn't available yet, but keyword search and browsing already work.
+
+---
+
+Related: [[Connect your agent]] · [[How to set up a Git-backed Vault]] · [[Install Hatchdoor with Docker Compose]] · [[HTTP API reference]]

--- a/docs/user-vault/03 Reference/HTTP API reference.md
+++ b/docs/user-vault/03 Reference/HTTP API reference.md
@@ -1,0 +1,189 @@
+---
+tags: [type/reference, topic/http-api]
+---
+
+# HTTP API reference
+
+Every HTTP endpoint Hatchdoor exposes, grouped by area. This is a dictionary, not a walkthrough — see [[How to deploy Hatchdoor with an agent]] or [[Install Hatchdoor with Docker Compose]] for task-oriented setup steps.
+
+All request and response bodies are JSON unless noted. Errors from the `/api/v1/vaults/...` group share one shape:
+
+```json
+{ "code": "vault_not_found", "message": "...", "vault_id": "...", "retryable": false }
+```
+
+`vault_id` is omitted when an error is not about one specific Vault.
+
+## Auth model
+
+| Surface | Auth |
+| --- | --- |
+| `/health`, `/ready`, `/api/startup-status`, `/api/vault-status` | None, always |
+| `/api/model/*` | Web bearer token (if configured); **absent entirely (`404`) in demo mode** |
+| `/api/settings*`, `/api/index-status`, `/api/git-status` | Web bearer token (if configured); **absent entirely (`404`) in demo mode** |
+| `/mcp` | Its own MCP bearer token — see [[Connect your agent]] |
+| `/api/v1/vaults/...` reads (`GET`) | Web bearer token if configured, **unauthenticated in demo mode** |
+| `/api/v1/vaults/...` writes and Vault control | Web bearer token if configured; **refused with `403 demo_read_only` in demo mode** (not `404` — the route exists, it just declines) |
+| `/api/v1/vaults/{vault_id}/attachments` (upload) | Web bearer token **or** a live MCP bearer token; same demo-mode refusal as other writes |
+
+> [!warning]
+> Demo mode treats settings and model setup as operator-only surfaces that don't exist (`404`), but treats every Vault-scoped route as present — reads are public, writes/control answer `403 demo_read_only`. Don't infer "not implemented" from a `404` on a `/api/v1/vaults/...` path; check the method and current mode first.
+
+The web bearer token is sent as `Authorization: Bearer <token>`, or as an `access_token` query parameter.
+
+## Health & startup
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/health` | Liveness probe; also used by the container's own `--healthcheck`. Returns `200 ok` plaintext. |
+| GET | `/ready` | `200 ready` once legacy single-Vault startup (model + first index) is complete, else `503 not ready`. |
+| GET | `/api/startup-status` | JSON legacy startup-progress snapshot (model download/index progress). `Cache-Control: no-store`. |
+| GET | `/api/vault-status` | JSON snapshot of the legacy startup Vault's state. `Cache-Control: no-store`. |
+
+## Model setup
+
+First-run embedding model selection. Not present in demo mode.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| POST | `/api/model/accept-gemma` | Accept Gemma terms and start downloading/indexing with it. `202` on success, `409` if a model is already active. |
+| POST | `/api/model/decline-gemma` | Decline Gemma and use Nomic Embed Text v1.5 instead. Same status codes. |
+| POST | `/api/model/retry` | Retry startup with the already-selected model. `409` if terms are still pending, `500` on an internal persist failure. |
+
+## Settings
+
+Server-wide instance configuration. Not present in demo mode (routes don't exist, rather than existing and refusing).
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/settings` | Every known setting: `key`, current `value` (secrets redacted), `configured`, `source`, `locked`, `class` (`instant`/`reindex`), `kind` (text/switch/secret/number/mode). |
+| PATCH | `/api/settings` | Update one or more settings. Body: `{"updates": {"KEY": "value", ...}, "confirm": ["reindex", ...]}`. |
+| GET | `/api/index-status` | Background reindex status — whether the live settings document has drifted from the built index. `no-store`. |
+| GET | `/api/git-status` | Legacy single-Vault Git sync task status (mode, running/stopping, last error). `no-store`. |
+| POST | `/api/settings/web-token/reveal` | Returns the current web bearer token, `{"value": "..."}`. `404` if none is set. |
+| POST | `/api/settings/mcp-token/generate` | Returns a freshly generated candidate token, `{"value": "..."}`. Not saved or made live by this call alone. |
+| POST | `/api/settings/mcp-token/reveal` | Returns the live MCP bearer token — only if it equals the caller's own web token (seeing it grants no new access). `404` otherwise. |
+
+**`PATCH /api/settings` consequences.** A save that would reindex, initialize a fresh local Git repo, or downgrade remote versioning off a Vault that is no longer a Git repository returns `409` with a machine-readable consequence (`reindex` | `git_init` | `git_downgrade`) instead of applying. Resend the same request with that value added to `confirm` to proceed. Consequences accumulate across retries rather than one-at-a-time.
+
+**Setting keys**, with change class (`instant` applies immediately; `reindex` triggers a background reindex) and kind:
+
+| Key | Class | Kind |
+| --- | --- | --- |
+| `HATCHDOOR_ARCHIVE_PREFIX` | instant | text |
+| `HATCHDOOR_EXCLUDE` | reindex | text |
+| `HATCHDOOR_EMBED_LAYERS` | reindex | switch |
+| `HATCHDOOR_MCP_ENABLED` | instant | switch |
+| `HATCHDOOR_MCP_WRITE_ENABLED` | instant | switch |
+| `HATCHDOOR_MCP_BEARER_TOKEN` | instant | secret |
+| `HATCHDOOR_MCP_ALLOWED_ORIGINS` | instant | text |
+| `HATCHDOOR_MAX_ATTACHMENT_BYTES` | instant | number |
+| `HATCHDOOR_MCP_MAX_BASE64_BYTES` | instant | number |
+| `HATCHDOOR_GIT_SYNC_ENABLED` | instant | mode |
+| `HATCHDOOR_GIT_HTTPS_USERNAME` | instant | text |
+| `HATCHDOOR_GIT_HTTPS_TOKEN` | instant | secret |
+| `HATCHDOOR_GIT_DEBOUNCE_SECONDS` | instant | number |
+| `HATCHDOOR_GIT_AUTHOR_NAME` | instant | text |
+| `HATCHDOOR_GIT_AUTHOR_EMAIL` | instant | text |
+| `HATCHDOOR_GIT_BRANCH` | instant | text |
+
+> [!note]
+> The six `HATCHDOOR_GIT_*`/`HATCHDOOR_EXCLUDE` keys and `HATCHDOOR_ARCHIVE_PREFIX` are legacy: they exist to import a pre-registry single-Vault deployment's `.env` once. For a Vault created directly in the registry (via `POST /api/v1/vaults` or `create_vault`), the equivalent per-Vault fields — `source` (branch/mode/poll interval), `https_credentials`, `commit_identity`, `archive_folder`, `exclude_patterns` — are the only place that setting lives; nothing here overrides them.
+
+## MCP transport
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/mcp` | Always `405`; MCP is POST-only. |
+| POST | `/mcp` | JSON-RPC 2.0 Streamable HTTP MCP endpoint. See [[MCP tools reference]] for every tool, and [[Connect your agent]] for client setup. |
+
+## Vault collection management
+
+`/api/v1/vaults` and Vault-control routes. Every mutation here uses optimistic concurrency: read `registry_revision` from `GET /api/v1/vaults` first, and pass it back as `expected_registry_revision` — a stale value is rejected rather than silently overwriting a concurrent change.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/v1/vaults` | List every Vault definition plus `registry_revision`/`collection_revision`. In demo mode, only enabled Vaults, and each `source` is omitted (never exposes host paths or remote URLs to a public visitor). |
+| POST | `/api/v1/vaults` | Create a Vault. Body: `CreateVaultRequest` (below). `201` with the new definition. |
+| GET | `/api/v1/vaults/events` | Server-Sent Events stream of collection-revision changes (`vault-collection-revision` events carrying `collection_revision`, affected `vault_ids`, and a change `category`). Carries no Note content. |
+| POST | `/api/v1/vaults/start-with-no-vaults` | One-shot recovery action, reachable only when a failed legacy `.env` import left the instance pending recovery. Body: `{"confirm": true}`. |
+| PATCH | `/api/v1/vaults/{vault_id}` | Replace a Vault's definition wholesale (not a partial patch — resend every field you want to keep). Body: `EditVaultRequest`. |
+| DELETE | `/api/v1/vaults/{vault_id}` | Disconnect a Vault from the registry. Deletes no files, checkout, Git history, or credentials outside the registry record itself. |
+| POST | `/api/v1/vaults/{vault_id}/enable` | Enable a disabled Vault. Query: `expected_registry_revision`. |
+| POST | `/api/v1/vaults/{vault_id}/disable` | Disable a Vault. Same query param. |
+| POST | `/api/v1/vaults/{vault_id}/sync` | Request an immediate managed-Git turn, bypassing the poll schedule. `202` with `{"schedule": "queued"\|"coalesced"}`, or `409`/`503` if the Vault has no remote or isn't accepting work. |
+| POST | `/api/v1/vaults/{vault_id}/retry` | Same as `sync`, distinct name for a post-failure retry. |
+| POST | `/api/v1/vaults/{vault_id}/refresh` | Request the Vault's next Index turn (re-scan local Markdown). `202`/`409`/`503` as above. |
+
+**`CreateVaultRequest` body:**
+
+```json
+{
+  "expected_registry_revision": 0,
+  "name": "Primary",
+  "enabled": true,
+  "source": { "type": "local", "path": "/data/vault" },
+  "exclude_patterns": [],
+  "https_credentials": { "username": "x-access-token", "token": "..." },
+  "archive_folder": "90-archive/",
+  "commit_identity": { "name": "Hatchdoor", "email": "hatchdoor@example.com" }
+}
+```
+
+`source` is one of three shapes (`type` discriminates):
+
+- **`local`** — `{ "type": "local", "path": "<absolute container path>" }`. Hatchdoor never runs Git for it.
+- **`existing_git`** — `{ "type": "existing_git", "repository_path": "...", "repository_url": "...|null", "branch": "...|null", "vault_subdirectory": "...|null", "mode": "local_history"|"pull_only"|"two_way", "poll_interval_secs": 86400 }`. A Git working copy that already exists on disk; Hatchdoor uses it in place and never clones it. `repository_url` is required for `pull_only`/`two_way`, may be null only for `local_history`.
+- **`managed_git`** — `{ "type": "managed_git", "repository_url": "...", "branch": "...|null", "vault_subdirectory": "...|null", "mode": "pull_only"|"two_way", "poll_interval_secs": 900 }`. Hatchdoor clones and owns the checkout; no `local_history` mode (there is always a remote to track). `poll_interval_secs` minimum 60, default 86400.
+
+`https_credentials`, `archive_folder`, and `commit_identity` are all optional; omitted, the server-wide defaults apply (`HATCHDOOR_GIT_HTTPS_*`, `HATCHDOOR_ARCHIVE_PREFIX`, `HATCHDOOR_GIT_AUTHOR_*`). Embedded credentials in `repository_url` are rejected — supply them via `https_credentials` instead.
+
+`EditVaultRequest` is the same shape, plus `vault_id` in the path and `confirm_identity_change: bool`. It replaces the definition wholesale: `name` and `source` are required on every edit, and omitting `exclude_patterns`, `archive_folder`, or `commit_identity` clears the stored value rather than preserving it. The one exception is `https_credentials`, which takes an explicit `{"action": "keep"}` / `{"action": "remove"}` / `{"action": "replace", "username": "...", "token": "..."}` so a secret never has to be resent just to survive an edit.
+
+## Vault-scoped content — one Vault
+
+Every route below is a read and stays reachable unauthenticated in demo mode (subject to the collection-wide token gate above). Exact reads always inspect the Vault's live Markdown directory, never the disposable cache, so indexing lag never applies to them.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/v1/vaults/{vault_id}/notes/{slug}` | Full note by slug: content, frontmatter, content hash. `404` if absent. |
+| GET | `/api/v1/vaults/{vault_id}/notes/{slug}/links` | Outgoing/incoming links for one note. |
+| GET | `/api/v1/vaults/{vault_id}/notes/{slug}/download` | Download the note as a file (`Content-Disposition: attachment`). `413` if the export exceeds the server's download size limit. |
+| GET | `/api/v1/vaults/{vault_id}/resolve?target=...` | Resolve one wikilink target to a slug. `{"vault_id": "...", "slug": "...|null"}`. |
+| POST | `/api/v1/vaults/{vault_id}/resolve-batch` | Resolve many targets at once. Body: `{"targets": [...], "asset_targets": [...], "note_path": "...|null"}` (targets + asset_targets capped at 200 combined). `note_path` anchors asset resolution to that note's folder. |
+| GET | `/api/v1/vaults/{vault_id}/assets/{*path}` | Serve one contained asset or attachment file, with extension allowlisting and traversal containment. |
+| GET | `/api/v1/vaults/{vault_id}/write-capabilities` | `{"vault_id", "enabled", "warnings": [...]}` — whether the Web UI's write controls should be shown, and why not if disabled (unwritable path, non-mutable source, or missing web auth on a mutable one). |
+| GET | `/api/v1/vaults/{vault_id}/stats/detail` | Rich exact statistics for this one Vault (richer than the collection projection below), including layer diagnostics. |
+
+## Vault-scoped content — one-or-all
+
+`{scope}` is either one canonical Vault ID or the literal `all`. Also reads, also demo-safe.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/v1/vaults/{scope}/tree` | Folder/note tree, grouped per Vault. |
+| GET | `/api/v1/vaults/{scope}/recent?limit=` | Recently modified notes, flattened across Vaults. `limit` clamped 1–25, default 5. |
+| GET | `/api/v1/vaults/{scope}/stats` | Lean per-Vault statistics projection (for the exact/rich version, see `stats/detail` above). |
+| GET | `/api/v1/vaults/{scope}/graph` | Note-link graph, grouped per Vault; edges never cross a Vault boundary. |
+| GET | `/api/v1/vaults/{scope}/search?q=&mode=&limit=&per_note_cap=&layers=` | One global ranking flattened across every usable participant. `mode` is `semantic` (default) or `keyword`. `limit` clamped 1–50 (default 10), `per_note_cap` clamped 1–10 (default 2). `layers` is a comma-separated list of layer names, or `all`/`default`; a demo instance always sees the default surface regardless of this parameter. |
+
+## Vault-scoped mutations
+
+Content-changing routes. Web bearer token (if configured); refused with `403 demo_read_only` in demo mode rather than a bare `401`. Every mutation except create takes `expected_content_hash`, read from a prior `GET .../notes/{slug}` — a stale hash is rejected rather than overwriting a concurrent edit.
+
+| Method | Path | Body | Purpose |
+| --- | --- | --- | --- |
+| POST | `/api/v1/vaults/{vault_id}/notes` | `{"relative_path", "content"}` | Create a note. |
+| PUT | `/api/v1/vaults/{vault_id}/notes/{slug}` | `{"content", "expected_content_hash"}` | Replace a note's content. |
+| PATCH | `/api/v1/vaults/{vault_id}/notes/{slug}/rename` | `{"new_title", "expected_content_hash"}` | Rename a note (keeps its folder). |
+| PATCH | `/api/v1/vaults/{vault_id}/notes/{slug}/move` | `{"target_folder", "expected_content_hash"}` | Move a note to another folder (keeps its title). |
+| PATCH | `/api/v1/vaults/{vault_id}/notes/{slug}/move-rename` | `{"target_relative_path", "expected_content_hash"}` | Move and rename in one step. |
+| PATCH | `/api/v1/vaults/{vault_id}/notes/{slug}/archive` | `{"expected_content_hash"}` | Move a note under the Vault's archive folder. |
+| DELETE | `/api/v1/vaults/{vault_id}/notes/{slug}` | `{"expected_content_hash"}` | Delete a note. |
+| POST | `/api/v1/vaults/{vault_id}/attachments` | `multipart/form-data`: `target_relative_path`, `file` | Import an attachment file. Accepts the web token **or** a live MCP bearer token, unlike other mutations — an MCP agent can use it directly without provisioning a separate web token. |
+
+All of the above (except attachment upload) return `VaultWriteOutcomeResponse`: `{"vault_id", "ok", "slug", "relative_path", "content_hash", "quality_warnings": [...], "rewritten_notes", "moved_assets", "trashed_path", "layer"}`. `rewritten_notes` counts other notes whose wikilinks were rewritten to follow a rename/move; `quality_warnings` flags things like a missing heading, not hard failures. Attachment upload returns `VaultAttachmentOutcomeResponse`: `{"vault_id", "ok", "attachment", "rewritten_notes", "trashed_path", "cleanup_warning"}`.
+
+---
+
+Related: [[MCP tools reference]] · [[Connect your agent]] · [[Understand where your data lives]]

--- a/docs/user-vault/03 Reference/MCP tools reference.md
+++ b/docs/user-vault/03 Reference/MCP tools reference.md
@@ -1,0 +1,186 @@
+---
+tags: [type/reference, topic/mcp]
+---
+
+# MCP tools reference
+
+Every tool Hatchdoor's MCP endpoint (`/mcp`) advertises, once [[Connect your agent|MCP is connected]]. This is a lookup reference, not a tutorial — for the first read-only connection, start with [[Connect your agent]].
+
+## Permission model
+
+Two independent gates decide what a call can do:
+
+- **`HATCHDOOR_MCP_ENABLED`** — MCP as a whole. Off by default. A disabled instance answers no MCP calls at all.
+- **`HATCHDOOR_MCP_WRITE_ENABLED`** — write tools specifically. Off by default even when MCP is on. A write tool called while this is off returns the JSON-RPC error `MCP write tools are disabled by HATCHDOOR_MCP_WRITE_ENABLED`.
+
+A third, per-Vault gate sits underneath write mode: a Vault's own `capabilities.mutate` (from its source type and lifecycle phase — a `pull_only` Git Vault, or one not yet `ready`, refuses writes even with `HATCHDOOR_MCP_WRITE_ENABLED=true`). Check `list_vaults` for a Vault's current capabilities before writing to it.
+
+> [!note]
+> The full tool catalogue is always advertised, even before the model-setup completes and even at zero Vaults, so a client that caches tools at connection time never needs to reconnect. Before setup finishes, only `get_model_setup_status`, `accept_gemma_terms`, `decline_gemma_terms`, and the Vault collection discovery/management tools (`list_vaults` and friends) actually run; every other tool returns "Hatchdoor is still being set up." until a model is selected.
+
+There is no selected, sole, or default Vault. Every tool below that touches content takes an explicit `vault_id`; every collection-level tool takes an explicit `scope` (a Vault ID or the literal `all`).
+
+## Model setup
+
+Always available, regardless of `HATCHDOOR_MCP_ENABLED`'s write posture — these are the only tools that run before first-run setup completes.
+
+| Tool | Purpose |
+| --- | --- |
+| `get_model_setup_status` | Report setup state, the Gemma terms/policy links, and the Nomic fallback notice. No parameters. |
+| `accept_gemma_terms` | Accept Gemma's terms, then download it and begin indexing. No parameters. |
+| `decline_gemma_terms` | Decline Gemma, remove any partial Gemma download, download Nomic Embed Text v1.5 instead, and begin indexing. No parameters. |
+
+> [!warning]
+> Once a model is selected, calling either `accept_gemma_terms` or `decline_gemma_terms` again returns an error — changing models after setup is not supported.
+
+## Vault collection: discovery and management
+
+`list_vaults` is always available. The other six require `HATCHDOOR_MCP_WRITE_ENABLED`; without it they return the same "MCP write tools are disabled" error as content write tools.
+
+| Tool | Gating | Purpose |
+| --- | --- | --- |
+| `list_vaults` | Always | Every Vault's ID, name, status, redacted source, and capabilities, plus the registry's `registry_revision`. Call this first — every write below needs a fresh `expected_registry_revision`. |
+| `create_vault` | Write mode | Create a Vault definition. The registry assigns the Vault ID; read it back from `list_vaults`. |
+| `edit_vault` | Write mode | Replace one Vault definition wholesale (not a patch — send back every field you want to keep). |
+| `enable_vault` | Write mode | Enable a disabled Vault definition. |
+| `disable_vault` | Write mode | Disable a Vault without deleting its files. |
+| `disconnect_vault` | Write mode | Remove a Vault from the registry without deleting local files, checkouts, Git history, or credentials outside the registry record. |
+| `sync_vault` | Write mode | Request immediate managed-Git synchronization for one eligible Vault. |
+| `retry_vault` | Write mode | Retry an admitted managed-Git operation for one eligible Vault. |
+
+### `create_vault`
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `expected_registry_revision` | Yes | Most recent `registry_revision` from `list_vaults`. A stale value rejects the create rather than racing another writer. |
+| `name` | Yes | |
+| `enabled` | No | Default `true`. |
+| `source` | Yes | See [[#Vault source shapes]]. |
+| `exclude_patterns` | No | Glob patterns, in gitignore syntax, this Vault's index ignores. Default `[]`. |
+| `https_credentials` | No | `{ "username"?: string, "token": string }`. Write-only — never echoed back; `list_vaults` reports only whether one is configured. |
+| `archive_folder` | No | Per-Vault override of the instance-wide archive folder used by `archive_note`. Absent inherits the instance default. |
+| `commit_identity` | No | `{ "name": string, "email": string }`. Per-Vault override of the instance-wide Git author identity. Absent inherits the instance default. |
+
+### `edit_vault`
+
+Same fields as `create_vault`, plus `vault_id` (the Vault to edit) in place of `enabled`. This is a **wholesale replace**, not a patch: read the Vault from `list_vaults`, change what you mean to change, and send the rest back unchanged. Leaving `exclude_patterns`, `archive_folder`, or `commit_identity` absent *clears* the stored value rather than preserving it.
+
+`https_credentials` is the one exception — it takes a three-state action instead of a plain value, so a stored secret never has to be resent just to survive an edit:
+
+| `action` | Effect |
+| --- | --- |
+| `keep` | Leave the stored credential untouched. Default if the field is omitted. |
+| `remove` | Delete the stored credential — a remote that needs auth will then fail to sync. |
+| `replace` | Set a new `{ "username"?, "token" }`. |
+
+> [!warning]
+> Changing a Vault's `source` path, repository URL, branch, or subdirectory is an **identity change** — it repoints the Vault at different content. It is refused unless `confirm_identity_change: true` **and** the Vault is already disabled (`disable_vault` first); an identity change on an enabled Vault is refused regardless of the confirm flag. Changing `mode`, `poll_interval_secs`, `name`, credentials, exclusions, archive folder, or commit identity is not an identity change and needs neither.
+
+### `enable_vault` / `disable_vault` / `disconnect_vault`
+
+All three take just `vault_id` and `expected_registry_revision`.
+
+### `sync_vault` / `retry_vault`
+
+Both take just `vault_id`. `sync_vault` requests an immediate poll for a managed-Git Vault instead of waiting for `poll_interval_secs`. `retry_vault` retries an operation the scheduler admitted but that failed (e.g. a transient network error), rather than waiting for its own backoff.
+
+## Vault source shapes
+
+`source` on `create_vault`/`edit_vault` is tagged on `type`; each shape rejects unknown fields (`additionalProperties: false`), so a guessed field name fails loudly rather than being silently ignored.
+
+**`local`** — a plain directory on this machine. Hatchdoor never runs Git for it.
+
+```json
+{ "type": "local", "path": "/data/vault" }
+```
+
+**`existing_git`** — a Git working copy that already exists on this machine; Hatchdoor uses it in place and never clones it.
+
+```json
+{
+  "type": "existing_git",
+  "repository_path": "/data/vault",
+  "repository_url": "https://example.com/notes.git",
+  "branch": null,
+  "vault_subdirectory": null,
+  "mode": "pull_only",
+  "poll_interval_secs": 900
+}
+```
+
+`mode` is one of `local_history` (commits locally, never contacts a remote), `pull_only` (also fetches), or `two_way` (also pushes). `repository_url` is required for `pull_only`/`two_way`; it may be `null` only for `local_history`.
+
+**`managed_git`** — a remote repository Hatchdoor clones and owns the checkout of. No `local_history` mode — a managed Vault exists specifically to track a remote.
+
+```json
+{
+  "type": "managed_git",
+  "repository_url": "https://example.com/notes.git",
+  "branch": "main",
+  "vault_subdirectory": "notes",
+  "mode": "pull_only",
+  "poll_interval_secs": 900
+}
+```
+
+`mode` is `pull_only` or `two_way`. `repository_url` must be a credential-free HTTPS URL — embedded credentials are rejected; supply a token through `https_credentials` instead.
+
+`branch` and `vault_subdirectory` are `null`/absent-able on every Git shape: `null` tracks the remote's default branch, or uses the repository root, respectively. `poll_interval_secs` has a floor of `60` and defaults to `86400`; it is ignored for `local_history`, which has no remote to poll.
+
+## Read-only content tools
+
+Available whenever MCP is enabled, independent of write mode.
+
+| Tool | Required parameters | Purpose |
+| --- | --- | --- |
+| `search_notes` | `scope`, `query` | Search one Vault or all enabled Vaults. Optional: `mode` (`semantic` default or `keyword`), `limit` (1–50, default 10), `per_note_cap` (1–10, default 2), `layers` (array of layer names to include). |
+| `get_note` | `vault_id`, `slug` | Read one exact note's authoritative Markdown. |
+| `get_note_links` | `vault_id`, `slug` | Outgoing links and backlinks for one exact note. |
+| `resolve_wikilink` | `vault_id`, `target` | Resolve a wikilink target within one Vault. |
+| `get_tree` | `scope` | Grouped explorer tree for one Vault or all enabled Vaults. |
+| `get_stats` | `scope` | Grouped statistics for one Vault or all enabled Vaults. |
+| `get_graph` | `scope` | Grouped link graph for one Vault or all enabled Vaults. |
+| `recently_modified` | `scope` | Recently modified notes. Optional `limit` (1–25, default 5). |
+| `list_note_attachments` | `vault_id`, `slug` | List the attachments one note references, without the note's full content. |
+| `get_attachment_import_config` | `vault_id` | Report whether uploads are currently possible for this Vault, the available methods, their byte limits, and the allowed file extensions. Call this before uploading. |
+
+Collection-scoped results (`search_notes`, `get_tree`, `get_stats`, `get_graph`, `recently_modified` with `scope: "all"`) carry `scope`, `collection_revision`, `partial`, and `participants` — an agent should branch on the structured error `code`, never on message text, and should treat `partial: true` as "some enabled Vaults did not answer in time," not as an error.
+
+> [!note]
+> `get_attachment_import_config`'s `enabled` field is the AND of two independent gates: `HATCHDOOR_MCP_WRITE_ENABLED` (instance-wide) and the target Vault's own `capabilities.mutate` (source mode and lifecycle phase). The response explains which one is currently false when `enabled` is `false`.
+
+## Write content tools
+
+Every tool below requires `HATCHDOOR_MCP_WRITE_ENABLED=true` and takes `vault_id` in addition to the parameters listed. Every mutating tool that targets an existing note also requires `expected_content_hash` — the hash most recently read from `get_note` — for optimistic concurrency: a stale hash means someone else changed the note since you read it, and the write is rejected rather than silently overwriting.
+
+| Tool | Required parameters (beyond `vault_id`) | Purpose |
+| --- | --- | --- |
+| `create_note` | `relative_path`, `content` | Create a Markdown note. Parent folders are created automatically. Fails if the note exists unless `overwrite: true`. |
+| `update_note` | `slug`, `content`, `expected_content_hash` | Replace a note's full content. |
+| `append_to_note` | `slug`, `content`, `expected_content_hash` | Append content to a note. |
+| `edit_note` | `slug`, `old_string`, `new_string`, `expected_content_hash` | Surgical string replacement. `old_string` must match exactly and be unique unless `replace_all: true`; otherwise the edit is rejected without writing. Prefer this over `update_note` for small changes. |
+| `replace_section` | `slug`, `heading`, `mode`, `content`, `expected_content_hash` | Replace or insert around a Markdown section identified by its heading. `mode` is `replace` (overwrite the section — `content` should include the heading), `before`, or `after`. The section spans the heading through the next same-or-higher heading; headings inside fenced code blocks are ignored, and the heading must match exactly and be unique. |
+| `rename_note` | `slug`, `new_title`, `expected_content_hash` | Rename within the current folder; rewrites wikilink backlinks and moves/rewrites referenced assets. |
+| `move_note` | `slug`, `target_folder`, `expected_content_hash` | Move to a target folder; same backlink/asset handling as rename. |
+| `move_rename_note` | `slug`, `target_relative_path`, `expected_content_hash` | Move and rename in one operation. |
+| `archive_note` | `slug`, `expected_content_hash` | Move to the configured archive folder (the Vault's own `archive_folder`, set via `create_vault`/`edit_vault` above, or the instance default). |
+| `delete_note` | `slug`, `expected_content_hash` | Trash a note under `.hatchdoor-trash`; removes backlinks to it and moves/rewrites its assets. |
+| `import_attachment` | `content` (base64), `target_relative_path` | Upload an attachment by sending its bytes base64-encoded. This is the **fallback** for clients that cannot make an out-of-band HTTP request — size-limited (`HATCHDOOR_MCP_MAX_BASE64_BYTES`, default 5 MiB decoded). Prefer `POST /api/v1/vaults/{vault_id}/attachments` when possible; call `get_attachment_import_config` first to see current limits. |
+| `move_attachment` | `source_relative_path`, `target_relative_path` | Move an attachment and rewrite every note reference to it. |
+| `rename_attachment` | `source_relative_path`, `new_filename` | Rename an attachment in place and rewrite every note reference to it. |
+| `delete_attachment` | `source_relative_path` | Trash an attachment under `.hatchdoor-trash` and rewrite every note reference to it. |
+
+Every write tool accepts an optional `commit_summary` (a one-line string) used in the Git commit body for Vaults with versioning enabled.
+
+> [!warning]
+> No write tool can create, rename, or move a file named `.hatchdoor-layer` (the layer marker) — that call is rejected outright, since a marker silently changes how a whole folder is classified and is meant to be edited directly in the Vault. Writes are also rejected if the target path matches the Vault's own noise-exclusion patterns, since such a file would be written to disk but stay invisible to every read surface.
+
+### Response shape
+
+A successful note write returns `vault_id`, `slug`, `relative_path`, `content_hash` (use this for the next write), `layer`, `quality_warnings`, `rewritten_notes` (backlinks updated), `moved_assets`, and `trashed_path` (set only by `delete_note`). A successful attachment write returns `vault_id`, `attachment`, `rewritten_notes`, `trashed_path`, and `cleanup_warning`.
+
+A write conflict (stale `expected_content_hash`, or a registry revision that moved under a Vault-management call) is reported as a retryable tool error — re-read the current state and retry rather than assuming the operation is unsafe to repeat.
+
+---
+
+Related: [[Connect your agent]] · [[How to deploy Hatchdoor with an agent]]

--- a/docs/user-vault/03 Reference/Settings and environment variables reference.md
+++ b/docs/user-vault/03 Reference/Settings and environment variables reference.md
@@ -1,0 +1,94 @@
+---
+tags: [type/reference, topic/configuration]
+---
+
+# Settings and environment variables reference
+
+Every environment variable and live setting Hatchdoor reads, what each one does, and — the distinction that matters most — whether it's deploy-time-only (set in `.env`, needs a restart to change) or a live setting (changeable from **Settings** or `PATCH /api/settings`, no restart). [[HTTP API reference]] documents the `/api/settings` wire format itself; this page explains what each key is for.
+
+## Docker Compose host mounts
+
+Read by Compose on the host, not by the Hatchdoor binary — these decide what gets mounted where, per `docker-compose.yml`.
+
+| Variable | Default | Mounted as | Contents |
+| --- | --- | --- | --- |
+| `HOST_VAULT_PATH` | `./vault` | `/data/vault` | Markdown notes and attachments |
+| `HOST_CACHE_PATH` | `./data/cache` | `/data/cache` | SQLite search cache and `settings.json` |
+| `HOST_STATE_PATH` | `./data/state` | `/data/state` | The Vault registry (`vaults.json`) and any stored Git credentials |
+| `HOST_MODELS_PATH` | `./models` | `/models` | Downloaded embedding model and the Gemma-terms acceptance record |
+
+See [[Understand where your data lives]] for what to back up.
+
+## Server and storage (environment-only)
+
+Read once at process startup via `AppConfig::from_env`. Docker Compose fixes most of these inside the container already — they matter mainly when running Hatchdoor directly, not through Compose.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VAULT_PATH` | `./vault` | The folder Hatchdoor recognizes as its first local Vault on a first start. Legacy: read once to seed the Vault registry, then ignored — later Vaults are managed through the registry, not this variable. |
+| `HATCHDOOR_CACHE_DB` | `./data/cache/hatchdoor-cache.sqlite3` | Where the disposable SQLite search cache lives. |
+| `HOST` | `127.0.0.1` | The interface the process binds to. The standard Compose file fixes this at `0.0.0.0` inside the container so Docker's port publishing can reach it — see [[The security model]] for why that makes a web token mandatory. |
+| `PORT` | `42824` | The port the process listens on. |
+| `HATCHDOOR_SETTINGS_FILE` | next to `HATCHDOOR_CACHE_DB`, named `settings.json` | Relocates the live-settings file outside the default cache directory. |
+| `HATCHDOOR_VAULT_REGISTRY_PATH` | `/data/state/vaults.json` | Relocates the Vault registry. `just dev-start` points this at `.dev/state/vaults.json` automatically for local development. |
+
+## Web access (environment-only)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HATCHDOOR_WEB_BEARER_TOKEN` | unset | Protects the browser and the HTTP API. Mandatory the moment `HOST` isn't loopback — a Docker first run without it prints a freshly generated token to the logs and refuses to start unauthenticated. See [[The security model]] and [[How to troubleshoot common problems]]. |
+| `HATCHDOOR_DEMO_MODE` | `false` | Turns the instance into a public, read-only demo: Settings and model setup disappear entirely, Vault reads become public, and writes are refused. Incompatible with `HATCHDOOR_MCP_ENABLED=true` — Hatchdoor won't start with both set. |
+
+## Live settings
+
+These live in `settings.json`, not `.env` — leave them unset in `.env` to manage them from **Settings** with no restart. A non-empty `.env` value pins that one setting until it's removed from `.env` and the instance restarted. Each entry's **Class** says what a change costs: `instant` applies immediately, `reindex` schedules a background reindex.
+
+**Note handling**
+
+| Key | Default | Class | Purpose |
+| --- | --- | --- | --- |
+| `HATCHDOOR_ARCHIVE_PREFIX` | `90-archive/` | instant | The instance-wide default archive folder `archive_note` moves a note into, when a Vault doesn't override it with its own `archive_folder`. |
+| `HATCHDOOR_EMBED_LAYERS` | `true` | reindex | Whether notes on a demoted [[The layer system\|layer]] get semantic embeddings at all, not just structural indexing. Off trades semantic search over demoted content for a smaller, faster index. |
+
+**Agent access (MCP)**
+
+| Key | Default | Class | Purpose |
+| --- | --- | --- | --- |
+| `HATCHDOOR_MCP_ENABLED` | `false` | instant | Turns `/mcp` on or off. Off, the endpoint returns `404` rather than refusing — it isn't advertised as existing. |
+| `HATCHDOOR_MCP_WRITE_ENABLED` | `false` | instant | Separately gates every content- and Vault-mutating MCP tool. An agent can read with MCP enabled and this still off. |
+| `HATCHDOOR_MCP_BEARER_TOKEN` | unset | instant | The MCP password, required even for read-only access — see [[The security model]]. Enabling `HATCHDOOR_MCP_ENABLED` without this set is a startup validation error if pinned in `.env`. |
+| `HATCHDOOR_MCP_ALLOWED_ORIGINS` | `http://127.0.0.1,http://localhost` | instant | Origin allow-list checked on every MCP request, as a defense against DNS-rebinding attacks. Mainly relevant to a browser-based MCP client, not a CLI agent. |
+
+**Uploads**
+
+| Key | Default | Class | Purpose |
+| --- | --- | --- | --- |
+| `HATCHDOOR_MAX_ATTACHMENT_BYTES` | `10485760` (10 MiB) | instant | Size limit for an attachment uploaded through the Web UI or `POST /api/v1/vaults/{vault_id}/attachments`. |
+| `HATCHDOOR_MCP_MAX_BASE64_BYTES` | `5242880` (5 MiB, decoded) | instant | Size limit for `import_attachment`, MCP's base64 fallback upload path for clients that can't make an out-of-band HTTP request. |
+
+**Legacy — single-Vault import only**
+
+The following exist solely to import a pre-registry, single-Vault `.env` deployment once; see the fuller explanation already on [[HTTP API reference#Settings|the HTTP API reference's Settings section]]. For any Vault created directly in the registry, the equivalent per-Vault field (`source`, `https_credentials`, `commit_identity`) is the only place the setting lives — none of these override it.
+
+| Key | Legacy default | Stands in for |
+| --- | --- | --- |
+| `HATCHDOOR_EXCLUDE` | empty | A Vault's `exclude_patterns` |
+| `HATCHDOOR_GIT_SYNC_ENABLED` | `false` | A Vault's Git `mode` |
+| `HATCHDOOR_GIT_HTTPS_USERNAME` | `hatchdoor` | A Vault's `https_credentials` username |
+| `HATCHDOOR_GIT_HTTPS_TOKEN` | empty | A Vault's `https_credentials` token |
+| `HATCHDOOR_GIT_BRANCH` | `main` | A Vault's `branch` |
+| `HATCHDOOR_GIT_AUTHOR_NAME` / `HATCHDOOR_GIT_AUTHOR_EMAIL` | `Hatchdoor` / `hatchdoor@localhost` | A Vault's `commit_identity` |
+| `HATCHDOOR_GIT_DEBOUNCE_SECONDS` | `30` | No registry equivalent — retired once imported |
+
+> [!warning]
+> Leave these exactly as they were in an upgraded single-Vault `.env` for one start so Hatchdoor can import them, then delete them — it refuses to start again while they're still set, since they aren't valid configuration for a registry Vault.
+
+## Logging (environment-only)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RUST_LOG` | `hatchdoor=info,tower_http=info,axum::rejection=warn` | Standard `tracing`/`EnvFilter` syntax; controls log verbosity per module. |
+
+---
+
+Related: [[HTTP API reference]] · [[Install Hatchdoor with Docker Compose]] · [[How to troubleshoot common problems]]

--- a/docs/user-vault/03 Reference/Supported Markdown reference.md
+++ b/docs/user-vault/03 Reference/Supported Markdown reference.md
@@ -1,0 +1,106 @@
+---
+tags: [type/reference, topic/markdown]
+---
+
+# Supported Markdown reference
+
+A dictionary of the Markdown features Hatchdoor renders. Every note in a Vault is a plain `.md` file — this page shows what that file can contain and how Hatchdoor displays it.
+
+## Inline formatting
+
+Plain text can include **bold**, *italic*, ***bold italic***, ~~strikethrough~~, `inline code`, and links such as <https://example.com>.
+
+Raw HTML is not part of the supported Markdown contract. Keep notes portable by using Markdown syntax where possible.
+
+## Headings
+
+`#` through `######` produce heading levels 1 through 6. Headings receive generated IDs, which is what makes a heading wikilink (below) and the table of contents work.
+
+## Lists
+
+Unordered lists (`-`), ordered lists (`1.`), and nested lists at any depth are all supported. Task lists use `- [x]` (done) and `- [ ]` (open).
+
+## Tables
+
+```markdown
+| Feature | Markdown trigger |
+| --- | --- |
+| Wikilink | `[[Note]]` |
+| Callout | `> [!note]` |
+```
+
+Tables scroll horizontally on small screens rather than breaking layout.
+
+## Blockquotes and callouts
+
+A plain blockquote (`>`) is an ordinary quoted excerpt. A callout is a blockquote whose first line is `[!type]`, optionally followed by a custom title:
+
+```markdown
+> [!note]
+> A note callout for neutral information.
+
+> [!warning] Read this first
+> A warning callout with a custom title.
+```
+
+Supported types: `note`, `info`, `tip`, `warning`, `danger`, `success`, `question`, `example`, `summary`, `abstract`, and likely others — the type controls the icon and color, not the rendering mechanism. Add `+` after the type to make it collapsible and start open, or `-` to start closed: `> [!summary]+`.
+
+## Code blocks
+
+Fenced code blocks (` ``` `) render with syntax highlighting when a language is given (` ```rust `, ` ```bash `, ` ```json `, and so on) and as a plain block when it's omitted.
+
+## Mermaid diagrams
+
+A fenced block with the `mermaid` language renders as a diagram instead of code:
+
+````markdown
+```mermaid
+flowchart LR
+    A[Markdown files] --> B[Hatchdoor index]
+    B --> C[Search]
+```
+````
+
+## Math
+
+Inline math uses single `$...$`; block math uses `$$...$$` on its own lines. Both render with KaTeX.
+
+## Images and PDFs
+
+Local Markdown image syntax works as expected:
+
+```markdown
+![Alt text](image-file-name.jpg)
+```
+
+Store an image near the note that references it, and use safe filenames — lowercase ASCII letters, numbers, and hyphens. A Markdown link to a local PDF is marked as a document and opens in a new tab: `[Open the report](report.pdf)`. The same attachment can instead be embedded inline, with page controls, using Obsidian's embed syntax: `![[report.pdf]]`.
+
+## Wikilinks
+
+Hatchdoor resolves `[[Note Title]]` to another note in the same Vault, and refreshes those links whenever Markdown changes. Four forms:
+
+- Plain: `[[Connect your agent]]` → [[Connect your agent]]
+- Aliased: `[[Connect your agent|connect an agent]]` — displays custom text
+- Heading-scoped: `[[Connect your agent#Configure your MCP client]]` — links straight to a heading
+- A wikilink to a note that doesn't exist yet still renders — it just has nowhere to go until that note is created: `[[This Note Does Not Exist Yet]]`
+
+## Horizontal rule
+
+Three hyphens (`---`) on their own line renders a horizontal rule, useful for dividing a long note into sections. (It's also frontmatter's delimiter — see below — so this only renders as a rule when it isn't at the very top of the file.)
+
+## Frontmatter
+
+A note may open with a YAML frontmatter block:
+
+```yaml
+---
+tags: [type/reference]
+status: current
+---
+```
+
+Hatchdoor parses frontmatter and can show properties (tags, aliases, and arbitrary key/value pairs) separately from the note body, without them cluttering the rendered text.
+
+---
+
+Related: [[MCP tools reference]] · [[HTTP API reference]]

--- a/docs/user-vault/03 Reference/The LLM wiki pattern (external reference).md
+++ b/docs/user-vault/03 Reference/The LLM wiki pattern (external reference).md
@@ -1,0 +1,58 @@
+---
+tags: [type/reference, topic/agent-workflow, topic/layers]
+---
+
+# The LLM wiki pattern (external reference)
+
+Hatchdoor's layer system and its [[How to run an LLM wiki in Hatchdoor|LLM-wiki workflow guide]] were built for a specific external pattern, not invented independently. This page is a dictionary of that pattern itself — what it is, in Andrej Karpathy's own words, with links to the primary sources — for anyone who wants the model behind the guide, not just the steps.
+
+> [!note]
+> "LLM Wiki" is a **workflow pattern Karpathy described**, not software he shipped. There is no official repository, package, or release — only a tweet and a follow-up write-up. Everything below is sourced from those two documents.
+
+## Primary sources
+
+| Source | Date | Link |
+| --- | --- | --- |
+| Announcement tweet, "LLM Knowledge Bases" | 2026-04-02 | [x.com/karpathy/status/2039805659525644595](https://x.com/karpathy/status/2039805659525644595) |
+| Follow-up idea document (`llm-wiki.md`) | 2026-04-04 | [gist.github.com/karpathy/442a6bf555914893e9891c11519de94f](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) |
+| Karpathy's GitHub (for context — no `llmwiki` repo exists there) | — | [github.com/karpathy](https://github.com/karpathy) |
+
+## The core idea
+
+> "Most people's experience with LLMs and documents looks like RAG: you upload a collection of files, the LLM retrieves relevant chunks at query time, and generates an answer. This works, but the LLM is rediscovering knowledge from scratch on every question. There's no accumulation... This is the key difference: the wiki is a persistent, compounding artifact." — the gist
+
+Rather than re-deriving an answer from raw documents on every question, an LLM agent incrementally writes and maintains a Markdown wiki: durable, interlinked, and readable by a human in a normal Markdown viewer.
+
+## Three layers
+
+| Layer | Role |
+| --- | --- |
+| **Raw sources** | An immutable directory of source material — articles, papers, transcripts, images. The agent reads these but never edits them. |
+| **The wiki** | Markdown pages (summaries, entity pages, concept pages) the agent writes and owns entirely, plus two special files: an index (a content catalog, updated on every ingest) and a chronological log. |
+| **The schema** | An `AGENTS.md`-style configuration document describing the wiki's own conventions, co-evolved by the human and the agent over time. |
+
+## Three operations
+
+| Operation | What happens |
+| --- | --- |
+| **Ingest** | A new source lands in raw sources. The agent reads it, writes a summary page, updates the index, and updates every existing page the new material touches — Karpathy notes "a single source might touch 10-15 wiki pages." |
+| **Query** | A question is asked against the wiki. The agent reads the index, drills into relevant pages, and answers from what the wiki already contains — researching further only when the wiki doesn't cover it, then feeding what it learns back in. |
+| **Lint** | Periodic agent-driven health checks: contradictions, stale claims, orphan pages, missing cross-references. |
+
+## Tooling named in the source material
+
+Obsidian, as the human-facing viewer (plus its Web Clipper extension for turning web articles into Markdown); Marp for slide decks generated from wiki content; matplotlib for charts; Dataview for frontmatter-driven queries; and, once a wiki outgrows a plain index file, [`qmd`](https://github.com/tobi/qmd) — a third-party local hybrid BM25/vector search engine with a CLI and an MCP server, which Karpathy calls "a good option."
+
+The pattern names no specific LLM — it's described as usable with "your own LLM Agent, e.g. OpenAI Codex, Claude Code, OpenCode / Pi, or etc.," i.e. any sufficiently capable agentic model working against a local filesystem.
+
+## Scale
+
+Karpathy reported one of his own research wikis at "~100 articles and ~400K words" as of the April 2026 tweet — the only concrete size figure he gave.
+
+## What's already community, not official
+
+Several third parties have built concrete implementations of the pattern since the gist was published — the gist itself calls the pattern "intentionally abstract... not a specific implementation," so building the actual tooling was always left to whoever adopts it. Hatchdoor's layer system and MCP tools are one such implementation, built independently of any of those other projects.
+
+---
+
+Related: [[How to run an LLM wiki in Hatchdoor]] · [[The layer system]] · [[MCP tools reference]]

--- a/docs/user-vault/03 Reference/The PARA method (external reference).md
+++ b/docs/user-vault/03 Reference/The PARA method (external reference).md
@@ -1,0 +1,46 @@
+---
+tags: [type/reference, topic/vault-organization]
+---
+
+# The PARA method (external reference)
+
+PARA is a general-purpose way to organize a Vault's folders, independent of Hatchdoor and of any agent workflow. This page is a dictionary of the method itself, for anyone deciding how to lay out a new Vault, with links to the primary source.
+
+## Primary sources
+
+| Source | Link |
+| --- | --- |
+| "The PARA Method: The Simple System for Organizing Your Digital Life" — Tiago Forte, Forte Labs | [fortelabs.com/blog/para](https://fortelabs.com/blog/para/) |
+| *The PARA Method* (book) | [buildingasecondbrain.com/para](https://www.buildingasecondbrain.com/para) |
+| Forte Labs | [fortelabs.com](https://fortelabs.com/) |
+
+## The four categories
+
+PARA sorts everything into exactly four categories, in order of how actionable they are:
+
+| Category | Definition | 
+| --- | --- |
+| **Projects** | "Short-term efforts (in your work or personal life) that you take on with a certain goal in mind" — e.g. completing a webpage design, buying a computer, finishing a language course. |
+| **Areas** | "Important parts of your work and life that require ongoing attention" — work domains (Marketing, Product Management) and personal ones (Health, Finances, Home). |
+| **Resources** | Topics "you're interested in and learning about" — graphic design, gardening, photography — without a specific outcome attached. |
+| **Archives** | "Anything from the previous three categories that is no longer active, but you might want to save for future reference" — completed projects, inactive areas, abandoned resource interests. |
+
+## The distinctions that actually matter
+
+**Projects vs. Areas** is the one people get wrong most often. The difference is permanence, not importance: an Area is an ongoing responsibility that "continues indefinitely," while a Project has a defined endpoint. Forte's example: listing "strategic planning" or "vacations" as Projects is a mistake — they never finish. Anything that "will end or change" is a Project; anything you maintain indefinitely is an Area.
+
+**Resources vs. Archives**: a Resource is a topic you're still actively engaged with; an Archive is anything — former Project, former Area, former Resource — you're keeping only for future reference, not current use.
+
+## Why it's meant to work across any tool
+
+Forte designed PARA to apply "across any platform" — a computer's file system, cloud storage, or a note-taking app — because it organizes by how actionable something is, not by any one tool's features. That portability is also why it needs nothing special from the tool it's used in: PARA is four folders and a filing habit, not a feature.
+
+## How this shows up in a Hatchdoor Vault
+
+Hatchdoor's own starter Vault layout (`10-topics/`, `20-projects/`, `30-areas/`, `40-reference/`, `90-archive/`) is a PARA variant — "Topics" in the Resources role, plus a numbered `00-inbox/` for unsorted capture that PARA itself doesn't specify. Nothing in Hatchdoor requires this or any other layout; folders are just folders.
+
+One genuine point of contact: `archive_note` (both the MCP tool and the Web UI action) moves a note into a Vault's configured archive folder in one step, which operationalizes exactly what PARA's Archives category asks for — see [[MCP tools reference]]. Beyond that, PARA and Hatchdoor's [[The layer system|layer system]] solve different problems and can be used together without conflict: PARA organizes *where* a note lives; layers control whether it shows up in *default* search and browsing, regardless of which PARA folder it's in.
+
+---
+
+Related: [[MCP tools reference]] · [[The layer system]] · [[The LLM wiki pattern (external reference)]]

--- a/docs/user-vault/04 Concepts/How indexing and search work.md
+++ b/docs/user-vault/04 Concepts/How indexing and search work.md
@@ -1,0 +1,38 @@
+---
+tags: [type/explanation, topic/search]
+---
+
+# How indexing and search work
+
+Markdown is the source of truth. Everything Hatchdoor searches, browses, and links comes from one SQLite file built from that Markdown — the index. This page explains what that file actually is, how it stays current, and how the two search modes differ, since both are easy to get wrong by assumption.
+
+## The index is disposable, on purpose
+
+The SQLite cache is a rebuildable projection of the Vault's Markdown, never a second copy of your data. Delete it and Hatchdoor rebuilds it from the files on disk — nothing is lost, because nothing important lived there in the first place. This is why [[Understand where your data lives]] tells you the cache path doesn't need backing up while the Vault path does: one is derived, one is original.
+
+## What happens when a note changes
+
+A file watcher notices any create, edit, or delete under the Vault — Markdown, attachments, and `.hatchdoor-layer` markers alike, since a marker change reclassifies notes without touching their content. Changes are debounced: a burst of saves within about half a second coalesces into one reindex pass, with a five-second ceiling so a genuinely busy editing session can't defer freshness forever.
+
+> [!note]
+> Reindexing is incremental, not a full rebuild. Each note carries a content hash; unchanged notes and unchanged chunks are reused as-is rather than re-embedded. A full rebuild only happens when something invalidates the whole cache at once — switching embedding models, or flipping `HATCHDOOR_EMBED_LAYERS` — because every vector in the cache has to share one embedding space, and a partial rebuild would leave some vectors comparable and others not.
+
+## Two search modes, not one fused "hybrid" search
+
+Hatchdoor offers **Semantic** (the default) and **Keyword** as two separate, user-selectable modes — not a combined ranking. This is a deliberate decision, not a missing feature.
+
+- **Semantic** embeds your query with the same model used to embed notes, then finds the closest vectors — it matches by meaning, so a query can find a note that never uses the query's exact words.
+- **Keyword** runs against SQLite's FTS5 full-text index (the same BM25-style engine most databases use for exact-text search) — it matches by the words actually present, which wins for a hostname, filename, tag, ID, or anything else where the precise string is what matters.
+
+> [!warning]
+> These two modes are never fused at query time. Hatchdoor evaluated combining them with Reciprocal Rank Fusion and found it added a second query and real latency for an unpredictable, often *worse* result: on the evaluation set, fusion occasionally demoted the correct top result in favor of a lexically-similar distractor. Pure semantic search won outright — see [ADR-05](https://github.com/BattermanZ/Hatchdoor/blob/main/docs/adr/semantic-search-strategy.md) for the full measurement if you want the numbers. If you see the word "hybrid" used loosely elsewhere, it does not mean fused retrieval in Hatchdoor's runtime search path.
+
+Cross-encoder reranking was evaluated too, and dropped for the same reason from the other direction: it improved nothing on the same CPU-only hardware Hatchdoor targets, while costing seconds per query instead of milliseconds.
+
+## Where layers fit in
+
+A note's [[The layer system|layer]] decides whether Semantic search reaches it by default: the default surface is always embedded, but a demoted layer only gets vectors if `HATCHDOOR_EMBED_LAYERS` is on. Keyword search doesn't care — FTS5 indexes every layer regardless, since exact-text matching costs nothing extra to keep available.
+
+---
+
+Related: [[Understand where your data lives]] · [[Search and change notes with your agent]] · [[The layer system]]

--- a/docs/user-vault/04 Concepts/The layer system.md
+++ b/docs/user-vault/04 Concepts/The layer system.md
@@ -1,0 +1,71 @@
+---
+tags: [type/explanation, topic/layers]
+---
+
+# The layer system
+
+A Vault accumulates content of different relevance: primary notes next to meeting transcripts, reference dumps, archived research, or material an agent generated on request. All of it deserves to live in the same portable Markdown tree — but not all of it deserves equal weight in a search result or a first glance at the explorer.
+
+Layers let a folder opt into a **secondary surface**: still fully part of the Vault, still linkable, still versioned, but excluded from the default view someone gets by browsing or searching without asking for it specifically.
+
+> [!note]
+> Layers are not access control. There is no permission boundary here — anyone who can read the Vault at all can reach a demoted note by asking for it explicitly. What layers change is *default visibility*, not *who* can see something.
+
+## Marking a folder
+
+A folder opts into a layer by containing a `.hatchdoor-layer` file. The file is plain YAML, in one of two forms:
+
+```yaml
+sources
+```
+
+```yaml
+name: sources
+description: Raw source material, kept for reference but not for browsing.
+```
+
+The name is normalized before it becomes a layer: Unicode-folded, lowercased, spaces become hyphens, and only letters, digits, and hyphens survive. `default`, `all`, `noise`, and `none` are reserved and cannot be claimed — they mean something else to the system (see below).
+
+## Inheritance and re-promotion
+
+A layer applies to its folder and everything beneath it, by longest matching path — a note three folders under a marker still belongs to that marker's layer unless a closer marker overrides it. A subfolder can opt back out with its own marker whose name is literally `default`:
+
+```yaml
+default
+```
+
+That is not a layer — it never appears as one, and a note under it always reports `layer: null` — it exists purely to re-promote a subtree that would otherwise inherit a demotion from a parent folder.
+
+The Vault root itself can never carry a named layer marker: that would demote every note in the Vault and leave nothing on the default surface, so Hatchdoor refuses to build an index while one is present.
+
+## What being on a layer actually changes
+
+This is the detail worth getting precisely right, because the two changes it makes are easy to conflate:
+
+1. **Default search excludes it.** Search without an explicit layer selection only ever considers the default surface (`layer IS NULL`). A demoted note simply never appears in an ordinary search result.
+2. **Browsing does not.** On an ordinary, authenticated instance, the explorer tree, the graph, the recent-notes list, and reading a note directly by its slug all show **everything**, demoted or not. Layers narrow default *search*, not the operator's or the agent's ability to look around or fetch something they already know the slug of.
+
+> [!warning]
+> A public, read-only demo deployment (`HATCHDOOR_DEMO_MODE=true`) is the one exception: with no operator and no layer toggle to speak of, it narrows every surface — tree, graph, recent, exact fetch, search — to the default layer only. An ordinary deployment never does this.
+
+An agent (or a person, via the Web UI's **Keyword mode** or an explicit layer filter) that deliberately asks for a layer by name, or for `all`, gets those notes back like any other.
+
+## Semantic search and `HATCHDOOR_EMBED_LAYERS`
+
+Being on the default surface always earns a note a vector embedding, so semantic search reaches it. A demoted note's embedding is optional and instance-wide: `HATCHDOOR_EMBED_LAYERS` (default on) decides whether demoted notes get embedded too.
+
+- **On** — demoted notes are found by meaning, the same as default-surface notes, once something explicitly asks for that layer.
+- **Off** — demoted notes are still fully indexed structurally (title, links, keyword search all work), just not embedded — saving indexing time and vector-storage space at the cost of semantic search over that layer. Exact-word search still finds them either way.
+
+## Where a note's layer shows up
+
+Every note and link read (`get_note`, search hits, `get_note_links`) and every write outcome (`create_note`, `update_note`, and friends) reports the resolved `layer` — `null` for the default surface, the layer name otherwise. There is currently no dedicated "list every layer in this Vault" call: an agent discovers layer names empirically, by searching with `layers: ["all"]` and reading the `layer` field off the results, or by looking at the marker files directly while browsing the Vault.
+
+## What layers are not
+
+- **Not the archive folder.** `archive_note`/`archive_folder` moves a note into a designated folder and is a completely separate mechanism from layers; an archived note's `layer` depends only on whether *that* folder happens to carry a `.hatchdoor-layer` marker, same as any other folder.
+- **Not something an agent's write tools can set directly.** No write tool can create, rename, or move a file named `.hatchdoor-layer` — see [[How to organize a Vault with layers]] for what that means in practice.
+
+---
+
+Related: [[How to organize a Vault with layers]] · [[How to run an LLM wiki in Hatchdoor]] · [[The LLM wiki pattern (external reference)]] · [[MCP tools reference]] · [[HTTP API reference]]

--- a/docs/user-vault/04 Concepts/The security model.md
+++ b/docs/user-vault/04 Concepts/The security model.md
@@ -1,0 +1,65 @@
+---
+tags: [type/explanation, topic/security]
+---
+
+# The security model
+
+Hatchdoor has three separate secrets, not one. Each protects a different boundary, and none of them substitutes for another. Knowing which one gates what matters before you decide who gets which credential.
+
+## The three secrets
+
+| Secret | Protects | Configured as |
+| --- | --- | --- |
+| **Web bearer token** | The browser and the HTTP API — `/api/v1/vaults/...`, Settings, model setup | `HATCHDOOR_WEB_BEARER_TOKEN` |
+| **MCP bearer token** | Agent access via `/mcp`, further split into read and write | `HATCHDOOR_MCP_BEARER_TOKEN` |
+| **Git HTTPS credentials** | Hatchdoor's own outbound connection to a Git remote | Per-Vault, entered in Settings or via `create_vault`/`edit_vault` |
+
+The first two answer "who can reach Hatchdoor and do what." The third answers a completely different question — "how does Hatchdoor authenticate itself to somewhere else." A leaked Git token lets someone push to your repository as Hatchdoor; it grants nothing against Hatchdoor itself. Don't conflate the two kinds.
+
+## Web bearer token
+
+`require_web_token` middleware guards the browser and the HTTP API — Settings, model setup, and every `/api/v1/vaults/...` route when a token is configured. It's checked as `Authorization: Bearer <token>`, or as an `access_token` query parameter for contexts that can't set headers, like an `<img>` tag pointing at a downloaded attachment. Comparison is constant-time, so response timing can't leak how much of a guessed token was correct.
+
+> [!warning]
+> A non-loopback `HOST` with no web token configured refuses to start at all — Hatchdoor generates a fresh token, prints it, and asks you to add it to `.env` before it will run unauthenticated on a public interface. This is a hard startup check, not a warning you can ignore. See [[Install Hatchdoor with Docker Compose]] for what this looks like in practice.
+
+## MCP bearer token
+
+MCP has its own middleware and its own secret, checked independently of the web token. Two things make this look stricter than the web token, and they are:
+
+- **MCP requires a token even to enable it at all.** Turning on `HATCHDOOR_MCP_ENABLED` without also setting `HATCHDOOR_MCP_BEARER_TOKEN` is a startup validation error — MCP simply refuses to come up. There's no equivalent of "loopback-only, no token needed" for MCP the way there sometimes is for the web token.
+- **Read access needs the token too.** Read-only MCP still exposes the entire Vault — `search_notes`, `get_note`, `get_tree`, and the rest — through a transport that bypasses the web auth layer entirely. So the same bearer-token requirement applies whether or not write mode is on.
+
+On top of the token, two more gates apply, independently:
+
+- **`HATCHDOOR_MCP_ENABLED`** — off by default. When it's off, `/mcp` doesn't just refuse requests, it returns `404` — the endpoint isn't advertised as existing at all.
+- **`HATCHDOOR_MCP_WRITE_ENABLED`** — off by default even once MCP itself is on. This is what separates an agent that can only look around from one that can also create, edit, move, or delete notes. See [[MCP tools reference]] for exactly which tools each gate unlocks.
+
+MCP also checks the request's `Origin` header against an allow-list (`HATCHDOOR_MCP_ALLOWED_ORIGINS`) as a defense against DNS-rebinding attacks, and validates the `MCP-Protocol-Version` header — neither of those is a secret, but both run before the bearer-token check on every request.
+
+> [!note]
+> The web token and the MCP token are unrelated on purpose. An agent's MCP token leaking doesn't hand out Settings or Web UI access, and revoking one never requires rotating the other. Give an agent the MCP token, never the web token — it should never need Settings access to do its job.
+
+## Git HTTPS credentials
+
+A Vault's own remote — configured per-Vault, not instance-wide — can carry an HTTPS token for Hatchdoor to authenticate itself when it fetches or pushes. This is stored write-only: once saved, it's never echoed back in any read, and even internal debug output redacts it. Editing a Vault's credentials is a `keep` / `remove` / `replace` choice specifically so a stored secret never has to round-trip back to you just to survive an edit — see [[HTTP API reference]] for the exact request shape.
+
+This secret authenticates Hatchdoor *to the remote*, not a caller *to Hatchdoor*. It doesn't appear anywhere in the web-token or MCP-token checks above, and holding it grants no access to Hatchdoor itself — only to whatever the remote lets that token do.
+
+## What's open regardless of any token
+
+`/health`, `/ready`, `/api/startup-status`, and `/api/vault-status` are never gated by any token — they're liveness/readiness probes, meant to be checked by infrastructure (a container orchestrator, a load balancer) that has no credential to present. They report process and indexing state, never Vault content.
+
+## Demo mode's narrower rule
+
+A public, read-only demo (`HATCHDOOR_DEMO_MODE=true`) doesn't just relax these rules — it restructures them, and the result isn't uniform across surfaces:
+
+- Settings and model setup stop existing entirely — `404`, not a refusal.
+- Vault reads become public and unauthenticated, by design — that's the point of a demo.
+- Vault writes and Vault control still exist as routes, but answer `403 demo_read_only` rather than performing the action.
+
+Demo mode and MCP are mutually exclusive at startup: Hatchdoor refuses to run with both `HATCHDOOR_DEMO_MODE=true` and `HATCHDOOR_MCP_ENABLED=true` set together. A demo has no operator to hold an MCP token in the first place, so the two postures don't compose.
+
+---
+
+Related: [[Connect your agent]] · [[HTTP API reference]] · [[MCP tools reference]]

--- a/docs/user-vault/04 Concepts/Vault lifecycle states.md
+++ b/docs/user-vault/04 Concepts/Vault lifecycle states.md
@@ -1,0 +1,59 @@
+---
+tags: [type/explanation, topic/vaults]
+---
+
+# Vault lifecycle states
+
+`list_vaults` and the Settings screen report a Vault's condition, but not as one word like "healthy" or "ready" — that single-word framing doesn't actually exist. A Vault's condition is five independent signals plus one operator switch, and conflating them is the most common way to misread what's actually happening.
+
+> [!note]
+> "Healthy" and "degraded" aren't states Hatchdoor reports anywhere — they're not in the API, not in the Settings UI copy, not in the source. The closest the UI comes is describing a Git-backed Vault's sync as "healthy" in one sentence, which just means its Git status isn't `unavailable`. Don't look for a `degraded` value; it doesn't exist.
+
+## `enabled` is the operator's switch, nothing else
+
+Every Vault definition carries one boolean, `enabled`, set by the operator via **enable_vault**/**disable_vault** (or the equivalent Settings toggle). It answers exactly one question: should this Vault be running at all? It says nothing about whether the Vault is currently working — a Vault can be enabled and still be unavailable (bad path, broken remote, mid-index), or disabled while its last-known runtime state is simply frozen in place.
+
+## The five status axes
+
+Once a Vault is enabled, Hatchdoor tracks its condition on five separate axes rather than one combined phase. They can (and routinely do) disagree with each other — a Vault can be browsable while still indexing, or have a broken Git remote while its Markdown is perfectly readable:
+
+| Axis | Values | What it answers |
+| --- | --- | --- |
+| **Activation** | `active`, `disabled`, `unavailable` | Is this Vault's runtime slot up at all? |
+| **Local content** | `read_write`, `read_only`, `unavailable` | Can the authoritative Markdown on disk currently be read/written? |
+| **Search** | `unavailable`, `indexing`, `browsable`, `ready`, `stale` | What state is the search index in? |
+| **Git** | `disabled`, `pending`, `ready`, `unavailable` | Is Git sync (if configured) working? |
+| **Watcher** | `running`, `disabled`, `unavailable` | Is the file-change watcher keeping the index current? |
+
+**Search** deserves the closest look, because its middle values are easy to misread:
+
+- `indexing` — actively building; nothing usable yet for this axis.
+- `browsable` — a real, load-bearing state, not a typo for "ready." The Vault's structure (notes, links, headings) is published and current, but this generation has no vectors yet. You can open and read every note; semantic search returns nothing. This is reached once, on a Vault's very first successful index, between the structure pass and the embedding pass — a later rebuild of an already-searchable Vault never regresses through it, it just keeps serving the prior generation while the rebuild runs.
+- `ready` — fully current, structure and vectors both.
+- `stale` — a prior generation is still being served (so search still works) while a newer build is in progress or the last build failed; not an error by itself, just "what you're seeing might be a build behind."
+
+## What capabilities actually come from
+
+`browse`, `search`, `mutate`, `pull`, `push`, and `retry` — the six flags that decide what the UI shows and what an MCP/API write is allowed to do — are derived from combinations of the axes above, not from any single one:
+
+- **`browse`** — true whenever local content is `read_write` or `read_only`. Notably independent of the search axis: a Vault mid-index (or even stuck at `browsable`) is still fully browsable.
+- **`search`** — true only for `ready` or `stale`. `browsable` and `indexing` both grant `browse` but not `search`.
+- **`mutate`** — true only when local content is `read_write` *and* the Vault isn't a `pull_only` Git Vault. A `pull_only` Vault never allows local edits, regardless of how healthy everything else looks, since edits would just conflict with the next pull.
+- **`pull`** / **`push`** — true only when Git status is `ready`, gated further by the configured Git mode (`pull_only` or `two_way` for pull; `two_way` only for push).
+- **`retry`** — true if *any* of the four per-axis error fields (activation, search, git, watcher) is marked retryable. This is what puts a **Try again** button in front of an operator instead of leaving a Vault silently stuck.
+
+## Two different things both called "Recovery"
+
+There are two unrelated recovery mechanisms, and they don't overlap:
+
+1. **Registry recovery** — the registry file itself (`vaults.json`) fails to load: it's corrupt, or its schema version is unsupported or from a newer Hatchdoor than this one. Every registry-mutating request answers `503 vault_registry_recovery_required` until the file is fixed on disk; there's no in-app action that resolves this, because the thing that's broken is the very store every other recovery path would need to write to.
+2. **Legacy-migration recovery** — narrower and specific to the one-time import of a pre-registry, single-folder `.env` deployment. If that import fails, Hatchdoor exposes **start_with_no_vaults** as an explicit escape hatch (`POST /api/v1/vaults/start-with-no-vaults`, requiring `{"confirm": true}`) to start from an empty, working registry rather than staying stuck. This has nothing to do with any individual Vault's own health.
+
+Neither of these is a per-Vault state — both describe the registry as a whole being unable to tell you about any Vault at all, which is a different kind of problem than one Vault having a bad Git remote or a locked file.
+
+> [!warning]
+> There's also an older, single-Vault-only `TermsRequired → Downloading → Validating → Scanning → Indexing → Ready → Unavailable` phase sequence still present in the code, from before the multi-vault registry existed. It only governs the legacy first-run embedding-model setup (accepting Gemma's terms, downloading a model) and has no bearing on how a Vault created through the registry is described — don't confuse it with the five-axis model above if you come across it.
+
+---
+
+Related: [[Connect your first Vault]] · [[How to set up a Git-backed Vault]] · [[HTTP API reference]]

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -48,6 +48,7 @@ Guides, Reference, and Concepts will grow from this starting point.
 - [[HTTP API reference]]
 - [[MCP tools reference]]
 - [[Supported Markdown reference]]
+- [[Settings and environment variables reference]]
 - [[The LLM wiki pattern (external reference)]]
 - [[The PARA method (external reference)]]
 

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -5,10 +5,7 @@ status: current
 
 # Hatchdoor documentation
 
-Hatchdoor is an agent-first notes app for Markdown Vaults you own. Connect an
-agent to search and change notes through Hatchdoor's guarded tools, then use
-the Web UI to read and review the same files. Markdown stays authoritative;
-Hatchdoor supplies the operational layer around it.
+Hatchdoor is an agent-first notes app for Markdown Vaults you own. Connect an agent to search and change notes through Hatchdoor's guarded tools, then use the Web UI to read and review the same files. Markdown stays authoritative; Hatchdoor supplies the operational layer around it.
 
 > [!tip]
 > Start an agent read-only. It should search before it reads, read before it changes, and use the current note version when it saves.
@@ -22,9 +19,10 @@ flowchart LR
 
 ## Start here
 
-Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent,
-make one deliberate change, and review it in the browser. These docs target
-Hatchdoor v2.5.0.
+Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent, make one deliberate change, and review it in the browser. These docs target Hatchdoor v2.5.0.
+
+> [!tip]
+> Starting a new Vault and not sure how to organize it? Hatchdoor doesn't require any particular layout. Two established patterns worth knowing about: [[The PARA method (external reference)|PARA]] sorts folders by how actionable a note is (Projects, Areas, Resources, Archives); [[The LLM wiki pattern (external reference)|the LLM wiki pattern]] has an agent build and maintain an interlinked wiki for you. They aren't mutually exclusive — see [[How to run an LLM wiki in Hatchdoor]].
 
 ## Documentation areas
 
@@ -36,3 +34,26 @@ Hatchdoor v2.5.0.
 | **Concepts** | How Hatchdoor stores, indexes, and protects notes |
 
 Guides, Reference, and Concepts will grow from this starting point.
+
+**Guides**
+
+- [[How to deploy Hatchdoor with an agent]]
+- [[How to set up a Git-backed Vault]]
+- [[How to organize a Vault with layers]]
+- [[How to run an LLM wiki in Hatchdoor]]
+- [[How to troubleshoot common problems]]
+
+**Reference**
+
+- [[HTTP API reference]]
+- [[MCP tools reference]]
+- [[Supported Markdown reference]]
+- [[The LLM wiki pattern (external reference)]]
+- [[The PARA method (external reference)]]
+
+**Concepts**
+
+- [[The layer system]]
+- [[How indexing and search work]]
+- [[The security model]]
+- [[Vault lifecycle states]]

--- a/justfile
+++ b/justfile
@@ -70,8 +70,9 @@ dev-start profile="": _prepare-cargo _kill-stale
 
 # Rebuild the dev Vault fixtures under .dev/vaults and rewrite the registry.
 # Profiles: clean (one healthy Vault), messy (healthy + pathological content +
-# every degraded state), broken (degraded states only). Destroys and recreates
-# the fixture tree, so never point this at a Vault you care about.
+# every degraded state), broken (degraded states only), demo (the four public
+# demo-vaults/* side by side). Destroys and recreates the fixture tree, so
+# never point this at a Vault you care about.
 dev-vaults profile="clean":
     @scripts/dev-vaults.sh "{{profile}}"
 

--- a/scripts/dev-vaults.sh
+++ b/scripts/dev-vaults.sh
@@ -8,7 +8,7 @@
 # NFC/NFD near-duplicates, symlinks), so keeping it out of the tree is what
 # lets the repo stay clonable on any platform.
 #
-# Usage: scripts/dev-vaults.sh <clean|messy|broken>
+# Usage: scripts/dev-vaults.sh <clean|messy|broken|demo>
 
 set -euo pipefail
 
@@ -41,10 +41,24 @@ note() {
 build_healthy() {
     local dest="$vaults_dir/healthy"
     mkdir -p "$dest"
-    if [ -d "$repo_root/demo-vault" ]; then
-        cp -a "$repo_root/demo-vault/." "$dest/"
+    if [ -d "$repo_root/demo-vaults/para" ]; then
+        cp -a "$repo_root/demo-vaults/para/." "$dest/"
     else
         cp -a "$repo_root/docs/starter-vault/." "$dest/"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# demo: the four public-demo vaults side by side, one per organisation style
+# (PARA, LLM wiki, Zettelkasten, flat/tag-only). Skips any vault whose folder
+# under demo-vaults/ hasn't been provisioned locally yet.
+# ---------------------------------------------------------------------------
+build_demo_vault() {
+    local style="$1"
+    local dest="$vaults_dir/demo-$style"
+    if [ -d "$repo_root/demo-vaults/$style" ]; then
+        mkdir -p "$dest"
+        cp -a "$repo_root/demo-vaults/$style/." "$dest/"
     fi
 }
 
@@ -632,8 +646,8 @@ EOF
         cp "$repo_root/docs/starter-vault/40-reference/pdf-preview-sample.pdf" \
             "$media/dossier — résumé (final) v2.pdf"
     fi
-    if [ -d "$repo_root/demo-vault/Media" ]; then
-        cp "$repo_root/demo-vault/Media/demo-dashboard.png" "$media/スクリーンショット 2026-08-16 🎉.png" 2>/dev/null || true
+    if [ -d "$repo_root/demo-vaults/para/Media" ]; then
+        cp "$repo_root/demo-vaults/para/Media/demo-dashboard.png" "$media/スクリーンショット 2026-08-16 🎉.png" 2>/dev/null || true
     fi
     printf 'not really a png\n' > "$media/lying-extension.png"
     head -c 12 /dev/urandom > "$media/no-extension"
@@ -718,6 +732,10 @@ ID_DISABLED="66666666-6666-4666-8666-666666666666"
 ID_GIT_BROKEN="77777777-7777-4777-8777-777777777777"
 ID_GIT_OK="88888888-8888-4888-8888-888888888888"
 ID_GIT_AUTH="99999999-9999-4999-8999-999999999999"
+ID_DEMO_PARA="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+ID_DEMO_LLM_WIKI="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+ID_DEMO_ZETTELKASTEN="cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+ID_DEMO_FLAT="dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 
 # Real repositories on the lab Forgejo. The three Git fixtures fail (or not) in
 # genuinely different code paths: a bad hostname never resolves, a private repo
@@ -762,8 +780,24 @@ case "$profile" in
             "$(git_vault_entry "$ID_GIT_OK" '"Git — clones cleanly"' "$FORGEJO_BASE/hatchdoor-dev-vault-ok.git" true)" \
             "$(git_vault_entry "$ID_GIT_AUTH" '"Git — auth refused"' "$FORGEJO_BASE/hatchdoor-dev-vault-private.git" true)"
         ;;
+    demo)
+        build_demo_vault "para"
+        build_demo_vault "llm-wiki"
+        build_demo_vault "zettelkasten"
+        build_demo_vault "flat"
+        entries=()
+        [ -d "$vaults_dir/demo-para" ] && entries+=("$(vault_entry "$ID_DEMO_PARA" '"Home & Life"' "$vaults_dir/demo-para" true)")
+        [ -d "$vaults_dir/demo-llm-wiki" ] && entries+=("$(vault_entry "$ID_DEMO_LLM_WIKI" '"Research Wiki"' "$vaults_dir/demo-llm-wiki" true)")
+        [ -d "$vaults_dir/demo-zettelkasten" ] && entries+=("$(vault_entry "$ID_DEMO_ZETTELKASTEN" '"Reading Notes"' "$vaults_dir/demo-zettelkasten" true)")
+        [ -d "$vaults_dir/demo-flat" ] && entries+=("$(vault_entry "$ID_DEMO_FLAT" '"Team Docs"' "$vaults_dir/demo-flat" true)")
+        if [ "${#entries[@]}" -eq 0 ]; then
+            echo "no demo-vaults/* folders found yet — nothing to register" >&2
+            exit 1
+        fi
+        write_registry "${entries[@]}"
+        ;;
     *)
-        echo "unknown profile '$profile' (expected: clean, messy, broken)" >&2
+        echo "unknown profile '$profile' (expected: clean, messy, broken, demo)" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Expands the public Hatchdoor documentation Vault with new Guides, Reference, and Concepts pages, plus a full settings/environment-variables reference page (already on `development`, carried into this merge).
- Adds tooling support for running multiple demo Vaults side by side locally (`demo-vaults/<style>/` instead of a single `demo-vault/`): updates `.gitignore`, `CONTRIBUTING.md`, `justfile`, and adds a `demo` profile to `scripts/dev-vaults.sh` (`just dev-vaults demo`). The demo Vault content itself stays gitignored, same as before — this only changes the local dev-fixture tooling.

## Test plan
- [x] `bash -n scripts/dev-vaults.sh` — syntax check passes
- [x] `just dev-start demo` locally — all four demo Vaults registered, indexed, and browsable

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01D6aBjGDD7VxJnMfoB3GA2e