### PR TITLE
docs: expand user-facing documentation Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,11 @@ under close human review, with tests and a documented safety model.
 - [Who It Is For](#who-it-is-for)
 - [Quick Start With Docker](#quick-start-with-docker)
 - [Data And Safety Model](#data-and-safety-model)
-- [Organizing a Vault for an LLM Wiki](#organizing-a-vault-for-an-llm-wiki)
-- [Permissions](#permissions)
 - [Configuration](#configuration)
-- [Using Hatchdoor](#using-hatchdoor)
 - [MCP Agent Access](#mcp-agent-access)
-- [Git Sync](#git-sync)
+- [Versioning and Git Sync](#versioning-and-git-sync)
 - [Running Without Docker](#running-without-docker)
 - [Troubleshooting](#troubleshooting)
-- [API Reference](#api-reference)
 - [Security Notes](#security-notes)
 - [Development](#development)
 - [Project Docs](#project-docs)
@@ -199,25 +195,13 @@ browser prompt.
 
 ### 4. Choose Your Search Model
 
-Hatchdoor images include no model weights. On the first launch, Hatchdoor asks
-you to choose how semantic search is set up before it downloads anything.
-
-- **Set up Gemma** is the default. EmbeddingGemma is multilingual and provides
-  the best search quality. Read and accept the Gemma terms in the web UI (or
-  through the first-run MCP setup tools); Hatchdoor then downloads the model,
-  scans the vault, and builds the index automatically.
-- **Use Nomic instead** declines Gemma and starts the same setup with Nomic
-  Embed Text v1.5. It needs no Gemma acceptance, but it is English-only and is
-  less suitable for multilingual vaults.
-
-Accepting the Gemma terms only permits Hatchdoor to download and use that model.
-It does not change ownership of your vault or its content, and Hatchdoor does
-not send vault content anywhere. The downloaded model and the local acceptance
-receipt stay in `HOST_MODELS_PATH`, so they persist across container restarts.
-
-The UI and logs show download and indexing progress. Vault features remain
-unavailable until setup is ready; if a model download fails, Hatchdoor presents
-a retry action instead of silently changing models.
+Hatchdoor images include no model weights. On first launch, before it
+downloads anything, Hatchdoor asks you to pick one: **Gemma** (multilingual,
+the default, requires accepting its terms) or **Nomic Embed Text v1.5**
+(English-only, no terms to accept). Either way the model and its acceptance
+receipt stay in `HOST_MODELS_PATH` and persist across restarts; Hatchdoor
+never sends vault content anywhere. Vault features stay unavailable until
+setup finishes.
 
 ### 5. Container Image And Paths
 
@@ -273,105 +257,26 @@ guide](docs/migrations/legacy-single-vault.md) for detection, recovery, and
 rollback constraints.
 
 If `VAULT_PATH` contains no Markdown files, Hatchdoor creates a small starter
-vault before the first index build. Existing vaults are not seeded or modified
-by this startup step (the `.hatchdoor-trash` folder is ignored when deciding
-whether a vault is empty).
+vault (a lightweight PARA-style structure with onboarding notes) before the
+first index build. Existing vaults are never seeded or modified. The starter
+notes are ordinary Markdown you can edit, move, or delete like any other.
 
-The starter vault lays out a lightweight PARA-style structure with index notes
-and onboarding references:
+For write access: browser writes, MCP writes, attachment uploads, and git sync
+all require the vault mount, cache directory, and state directory to be
+writable by the container's non-root runtime user. Read-only browsing works
+with a read-only vault mount as long as the cache and state directories stay
+writable. If write features are unexpectedly disabled, check those mount
+permissions.
 
-```text
-README.md
-10-topics/Topics Index.md
-20-projects/Projects Index.md
-30-areas/Areas Index.md
-40-reference/Hatchdoor — Getting Started.md
-40-reference/Hatchdoor — Agent Guide.md
-40-reference/Hatchdoor — Agent Skill.md
-40-reference/Hatchdoor — Markdown Feature Showcase.md
-40-reference/Hatchdoor — Starter Vault Organisation.md
-```
-
-These are ordinary notes you can edit, move, or delete like any other. The
-reference notes double as onboarding docs, including a ready-to-use **agent
-skill** template (see [MCP Agent Access](#mcp-agent-access)) for wiring an AI
-agent to the vault through MCP.
-
-## Organizing a Vault for an LLM Wiki
-
-Hatchdoor works well with the [LLM Wiki pattern described by Andrej
-Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f):
-keep original source material separate from the Markdown wiki that an LLM
-maintains.
-
-A simple vault layout looks like this:
-
-```text
-vault/
-├── raw/                    # Original articles, clips, transcripts, PDFs, etc.
-│   └── .hatchdoor-layer     # Places raw files on their own Hatchdoor layer
-├── wiki/                   # Markdown pages maintained by you or an LLM
-└── AGENTS.md               # Optional instructions for the agent maintaining the wiki
-```
-
-### Put raw sources on a separate layer
-
-Create this file inside the folder containing your raw source material:
-
-```text
-# raw/.hatchdoor-layer
-raw
-```
-
-The file contents are the layer name. In this example, every Markdown note
-under `raw/` belongs to the `raw` layer. It stays out of Hatchdoor's browser
-interface and default search results, while MCP clients can explicitly select
-it with `layers: ["raw"]`. Use a different name if you prefer, such as
-`sources`, `research`, or `evidence`.
-
-A layer is a visibility and search boundary; it does **not** make files
-read-only. If raw sources must remain unchanged, state that rule in your agent
-instructions (for example, `AGENTS.md` or `CLAUDE.md`).
-
-### Do not confuse layers with exclusions
-
-Use a layer when agents should still be able to read the files separately. In
-**Settings → Vault → Ignore these files**, add this pattern only when Hatchdoor
-should ignore the path completely:
-
-```text
-imports/,*.bak
-```
-
-Do **not** add `raw/` if agents need to search or read `raw/`: excluded files
-are absent from Hatchdoor's index.
-
-If your raw layer is large and you want to avoid creating vector embeddings for
-it, turn off **Settings → Vault → Meaning search in demoted layers**.
-
-The raw layer remains available for keyword lookup when an MCP client selects
-it, without using vector-indexing resources.
-
-## Permissions
-
-The Docker image runs as a non-root user.
-
-For read-only browsing:
-
-- Mount the vault read-only if you want.
-- Keep the cache directory writable.
-- Keep the state directory writable whenever migration or Vault management may
-  create or update the authoritative registry.
-
-For browser writes, MCP writes, attachment uploads, or git sync:
-
-- The vault mount must be writable by the container runtime user.
-- The cache directory must be writable.
-- The state directory must be writable.
-
-If Hatchdoor starts but write features are disabled, check the permissions on
-your vault mount and call `/api/write-capabilities` from an authenticated
-browser session.
+Hatchdoor doesn't require any particular vault layout — PARA, Zettelkasten,
+Andrej Karpathy's [LLM wiki
+pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f),
+or none of the above all work. The [user
+documentation](https://docs-hatchdoor.battercloud.cc) compares them, and [How
+to run an LLM wiki in
+Hatchdoor](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/how-to-run-an-llm-wiki-in-hatchdoor)
+walks through the layer-based setup (raw sources on a separate
+`.hatchdoor-layer`, default surface for the curated wiki).
 
 ## Configuration
 
@@ -379,307 +284,55 @@ Copy `.env.example` to `.env`. Its values are all commented out: Docker Compose
 and Hatchdoor supply the ordinary defaults, and Settings owns live server
 configuration. A non-empty value for a server-wide Settings key in `.env` is
 an intentional **environment pin**: it wins over the saved Settings value for
-that process. Remove the pin and restart to make that setting editable in
-Settings again. Vault definitions are managed per Vault through Settings, the
-HTTP API, or MCP; their legacy single-Vault environment variables are accepted
-only for the one-time migration described below.
+that process, and shows as **Set in .env** in Settings until the pin is
+removed and the container restarts. Vault definitions themselves are managed
+per Vault through Settings, the HTTP API, or MCP, not through `.env`.
 
-### Deployment And Environment-Only Values
+Two defaults worth knowing before you deploy:
 
-These values are not Settings controls. In Docker, Compose fixes the container
-bind address, port, vault path, and cache path to match its port and volume
-contract; change `docker-compose.yml` as one deployment change if you need a
-different container layout.
+- Hatchdoor refuses to start on `HOST=0.0.0.0` or another non-loopback bind
+  unless `HATCHDOOR_WEB_BEARER_TOKEN` is set. On refusal it prints a fresh
+  token and the `.env` line to add; that's the fix, not a bug.
+- `HATCHDOOR_DEMO_MODE=true` runs a read-only, unauthenticated instance for
+  public browsing. It has no rate limiting of its own (search embeds every
+  query, note downloads bundle attachments in memory), so put a
+  rate-limiting reverse proxy in front before exposing it publicly.
 
-| Variable | Default | How to manage it |
-| --- | --- | --- |
-| `HOST_VAULT_PATH` | `./vault` | Compose host mount input; set in `.env` for an existing vault |
-| `HOST_CACHE_PATH` | `./data/cache` | Compose host mount input |
-| `HOST_STATE_PATH` | `./data/state` | Compose host mount for authoritative Vault registry state; preserve across upgrades |
-| `HOST_MODELS_PATH` | `./models` | Compose host mount input |
-| `VAULT_PATH` | `./vault` directly; `/data/vault` in Compose | Environment-only runtime path |
-| `HATCHDOOR_CACHE_DB` | `./data/cache/hatchdoor-cache.sqlite3` directly; `/data/cache/hatchdoor-cache.sqlite3` in Compose | Environment-only runtime path |
-| `HOST` / `PORT` | `127.0.0.1` / `42824` directly; `0.0.0.0` / `42824` in Compose | Environment-only bind contract |
-| `HATCHDOOR_SETTINGS_FILE` | beside the cache database | Environment-only override for the durable Settings file |
-| `HATCHDOOR_WEB_BEARER_TOKEN` | empty | Environment-only web credential |
-| `HATCHDOOR_DEMO_MODE` | `false` | Environment-only public read-only mode |
-| `RUST_LOG` | `hatchdoor=info,tower_http=info,axum::rejection=warn` | Environment-only logging filter |
-
-### Settings: Live Values And Environment Pins
-
-The following values are editable in **Settings** and apply to the running
-server without a restart. If a non-empty `.env` value is present, Settings
-shows it as **Set in .env** and does not allow an in-browser edit. That is how
-to deliberately keep a value deployment-managed.
-
-| Settings section | Variables | Apply behavior |
-| --- | --- | --- |
-| Vault | `HATCHDOOR_ARCHIVE_PREFIX` | Applies immediately |
-| Notes handling | `HATCHDOOR_EMBED_LAYERS` | Requires confirmation, then rebuilds the search index in the background; search keeps using the previous coherent index until it is ready |
-| Agent access (MCP) | `HATCHDOOR_MCP_ENABLED`, `HATCHDOOR_MCP_WRITE_ENABLED`, `HATCHDOOR_MCP_BEARER_TOKEN`, `HATCHDOOR_MCP_ALLOWED_ORIGINS` | Applies immediately to new MCP requests |
-| Uploads | `HATCHDOOR_MAX_ATTACHMENT_BYTES`, `HATCHDOOR_MCP_MAX_BASE64_BYTES` | Applies immediately |
-
-`HATCHDOOR_EXCLUDE` and every `HATCHDOOR_GIT_*` variable are import-only
-legacy inputs, not live settings or deployment pins. Keep them for the first
-upgraded start so Hatchdoor can migrate the old Vault, then remove every key
-named by the startup refusal and restart.
-
-Settings saves its live values, including configured MCP and Git tokens, in a
-durable `settings.json` beside the cache database (or at
-`HATCHDOOR_SETTINGS_FILE`). The file is created with `0600` permissions on
-Unix; secret values are never returned in the Settings document. The file is an
-implementation detail: use the page, not hand edits, to change live
-configuration.
-
-### Web Authentication
-
-When `HATCHDOOR_WEB_BEARER_TOKEN` is set, protected requests must send:
-
-```text
-Authorization: Bearer <token>
-```
-
-The bundled PWA stores the token locally after a `401` response and attaches it
-to API calls. For image, download, and server-sent-event URLs where headers
-cannot be set, the frontend appends an `access_token` query parameter.
-
-Hatchdoor refuses to start with `HOST=0.0.0.0` or another non-loopback bind
-unless `HATCHDOOR_WEB_BEARER_TOKEN` is set. On this refusal it prints a freshly
-generated token and the `.env` assignment to use; copy it into `.env` and
-restart. The token is not persisted, so use the value printed by that refusal
-or generate a new long random token yourself.
-
-For a public test instance that people can browse without credentials, use demo
-mode:
-
-```env
-HATCHDOOR_DEMO_MODE=true
-```
-
-Demo mode is intentionally read-only. It disables browser write operations and
-the manual `/api/refresh` reindex, reports writes as unavailable through
-`/api/write-capabilities`, and refuses to start if MCP or automatic git sync are
-enabled.
-
-Demo mode does not rate-limit requests. Search computes an embedding per query
-and note downloads bundle attachments in memory, so an anonymous visitor can
-generate real CPU and memory load. Put a public demo behind a rate-limiting
-reverse proxy (e.g. nginx `limit_req`, Caddy `rate_limit`, or Traefik
-`rateLimit` middleware) before exposing it to the internet.
-
-### Indexing Changes
-
-Use the **Vault** section of Settings to choose the archive folder, exclusion
-patterns, and whether demoted layers receive semantic embeddings. Exclusions
-use comma-separated gitignore syntax. Changing exclusions or layer embedding
-requires confirmation because Hatchdoor starts a background reindex; it never
-stops search just to apply the change.
-
-## Using Hatchdoor
-
-### Browsing
-
-Hatchdoor builds a folder explorer from your vault folders and Markdown files.
-The UI root is named `Vault`. Folder names come directly from your filesystem;
-Hatchdoor does not require a PARA, Zettelkasten, or numbered folder scheme.
-
-### Vault Layers And Exclusions
-
-A folder can place its notes on a named, demoted layer by adding a
-`.hatchdoor-layer` file. The smallest useful marker is a YAML scalar:
-
-```text
-# sources/.hatchdoor-layer
-sources
-```
-
-Every Markdown note below `sources/` is then assigned to the `sources` layer.
-It is absent from the browser tree, browser search, and other default-surface
-results, while remaining available to trusted MCP clients that explicitly select
-that layer. A mapping marker can add an operator-facing description:
-
-```yaml
-name: sources
-description: Ground-truth clips and reference material.
-```
-
-Nested markers override their parent. Use `name: default` in a nested folder to
-bring that subtree back to the default surface. Named markers cannot live at the
-vault root, and `default`, `all`, `noise`, and `none` cannot be layer names.
-
-MCP read and search tools default to the default surface. Pass
-`layers: ["sources"]` to select one named layer, `layers: ["default",
-"sources"]` to include both, or `layers: ["all"]` for every layer. `get_note`
-can fetch a known note by slug or vault-relative path regardless of its layer.
-The browser intentionally has no layer selector.
-
-Noise patterns prevent files from entering the index. Hatchdoor always excludes
-`.obsidian/`, `.trash/`, `.hatchdoor-trash/`, `.DS_Store`, `*.tmp`, and
-`*.sync-conflict-*`; `.hatchdoor-layer` files are always read even if a broad
-pattern would otherwise match them. Add extra comma-separated patterns in
-**Settings → Vault → Ignore these files**. For example:
-
-```text
-imports/,*.bak
-```
-
-Patterns use gitignore syntax and are applied after the built-ins, so a leading
-`!` can reinstate a default pattern when needed:
-
-```text
-!*.sync-conflict-*
-```
-
-Writes to an excluded target are refused rather than creating a file that the
-index would hide. Marker changes trigger a full reindex; if a malformed marker
-causes startup indexing to fail, correcting it lets the vault watcher recover
-without restarting the server.
-
-To inspect the active rules, markers, layer counts, and conflicts, call
-`GET /api/diagnostics` (optionally `?path=sources/Clip.md`). Diagnostics are
-disabled in demo mode because they can reveal demoted paths; they have no
-Vault-scoped MCP replacement.
-
-### Note URLs And Links
-
-Note slugs are generated from Markdown filenames. Duplicate filenames receive
-unique suffixes so routes remain stable.
-
-Supported wikilinks include:
-
-```text
-[[Note]]
-[[Folder/Note]]
-[[Note|Alias]]
-```
-
-Hatchdoor resolves links, backlinks, headings, tags, graph data, and broken-link
-state into the SQLite cache.
-
-### Search
-
-Hatchdoor stores:
-
-- Full Markdown content
-- File metadata
-- Tags and headings
-- Wikilinks and backlinks
-- FTS5 keyword search data
-- sqlite-vec semantic vectors
-
-A recursive vault watcher refreshes the cache after Markdown or asset changes.
-Browser clients subscribe to `/api/vault-events` and reload visible data after a
-refreshed revision is broadcast.
-
-### Manual Cache Rebuild
-
-If you want to rebuild the cache from scratch:
-
-```bash
-rm ./data/cache/hatchdoor-cache.sqlite3
-docker compose restart hatchdoor
-```
-
-Adjust the path if you changed `HOST_CACHE_PATH`.
+Every deployment variable, every live Settings-editable value, layer and
+exclusion rules, and how the search index and cache work are documented in
+full in [Settings and environment variables
+reference](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/settings-and-environment-variables-reference)
+and [The layer
+system](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/the-layer-system).
 
 ## MCP Agent Access
 
-The embedded MCP endpoint is disabled by default. Enable it only for trusted
-clients.
+The embedded MCP endpoint is disabled by default, at `http://127.0.0.1:42824/mcp`.
+It has its own bearer token, separate from the web token, required even for
+read-only access, because `/mcp` bypasses the web auth layer. Turn it on and
+generate a token in **Settings → Agent access (MCP)**; turn on write access
+separately, only once you trust what the agent will do with it. Changes apply
+to new MCP requests immediately, no restart required.
 
-MCP requires a bearer token even in read-only mode because `/mcp` bypasses the
-web auth layer and can expose the full vault. In **Settings → Agent access
-(MCP)**, generate or enter an MCP password, turn on assistant access, and save.
-Turn on write access separately only when assistants may create, edit, move,
-delete, or attach files. These changes apply to new MCP requests immediately;
-they do not require editing `.env` or restarting the container.
-
-Register the endpoint with a Streamable HTTP MCP client:
-
-```text
-http://127.0.0.1:42824/mcp
-```
-
-Send:
-
-```text
-Authorization: Bearer <token>
-```
-
-### MCP Vault scope
-
-Start every agent session with `list_vaults`; it returns immutable `vault_id`
-values, collection/registry revisions, capabilities, status, and only a
-redacted credential indicator. There is no selected or default Vault.
-Collection reads (`search_notes`, `get_tree`, `get_stats`, `get_graph`, and
-`recently_modified`) require `scope`, set to one Vault ID or `all`. Exact reads,
-Markdown mutations, and controls of an existing Vault require `vault_id`.
-Collection results include `scope`, `collection_revision`, `partial`, and
-participants; agents should branch on structured error `code`, never text.
-
-### Agent Skill
-
-Hatchdoor ships with a ready-to-use **agent skill** for driving the vault
-through MCP. When Hatchdoor seeds a starter vault it writes the template to
-`40-reference/Hatchdoor — Agent Skill.md`; the source also lives at
-[`docs/starter-vault/40-reference/Hatchdoor — Agent Skill.md`](docs/starter-vault/40-reference/Hatchdoor%20%E2%80%94%20Agent%20Skill.md).
-
-Copy its `hatchdoor-vault` skill block into your agent's skills directory to
-teach the agent Hatchdoor's conventions: search before editing, pass the
-returned content hash on writes, prefer small edits, and let Hatchdoor manage
-backlinks, moves, and git sync.
-
-### Attachment Upload
-
-Agents and the web UI upload attachments directly — no shared staging folder to
-mount. Two paths cover the size/compatibility trade-off:
-
-- **`POST /api/v1/vaults/{vault_id}/attachments`** (multipart) — the default. Used by the web UI and
-  by any agent that can make an HTTP request (e.g. shell out to `curl`).
-  Accepts the web bearer token regardless of MCP write mode. An MCP agent can
-  reuse its MCP bearer token only while MCP and MCP writes are currently
-  enabled. Capped by `HATCHDOOR_MAX_ATTACHMENT_BYTES` (default 10 MiB).
-- **`import_attachment` MCP tool** — the fallback, for MCP clients that cannot
-  make an out-of-band HTTP request. Sends the file bytes base64-encoded inline;
-  works with any MCP client, but base64 rides inside the JSON-RPC message and
-  gets unreliable as files grow. Capped by `HATCHDOOR_MCP_MAX_BASE64_BYTES`
-  (default 5 MiB), measured on the decoded file.
-
-Use **Settings → Uploads** to change either limit while Hatchdoor is running.
-The `import_attachment` MCP fallback requires the same explicit `vault_id`.
+Full client setup (Claude Code, Codex, OpenClaw, Hermes), the Vault-scope
+contract every tool call needs, and the attachment-upload paths are in
+[Connect your
+agent](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/connect-your-agent)
+and [MCP tools
+reference](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/mcp-tools-reference).
 
 ## Versioning and Git Sync
 
-Versioning is configured per Vault. In that Vault's Settings page, choose No
-Git, Local history, Pull-only, or Two-way when the Vault's source supports the
-behavior. Repository identity, branch, Vault subdirectory, credentials, poll
-schedule, and commit identity live on the Vault definition rather than on the
-server.
+Versioning is configured per Vault, not per server: choose No Git, Local
+history, Pull-only, or Two-way on that Vault's Settings page. Merge conflicts
+are always kept for human resolution; Hatchdoor never force-checks out over
+uncommitted manual vault edits.
 
-Local mode can initialise an untouched vault after one explicit confirmation;
-this permanently creates its `.git` history folder and ignores Hatchdoor's
-`data/` cache and `settings.json`. Switching away from remote mode also asks
-for one confirmation before future commits stop being sent remotely.
-
-Requirements:
-
-- Local mode needs only a vault Git repository (Settings can create one).
-- Pull-only and Two-way additionally require the configured branch and remote
-  repository to match the Vault definition, plus credentials when the remote
-  requires them.
-- Merge conflicts are kept for human resolution on the server; Hatchdoor never
-  force-checks out over uncommitted manual vault edits.
-
-The `HATCHDOOR_GIT_*` family above is the legacy single-vault path. A Vault in
-the registry carries its own versioning, set on that Vault in Settings, and a
-server-wide answer cannot survive a second Vault. On a first start with no
-registry those variables are read once to import an existing single-vault
-deployment. Hatchdoor then starts a restricted recovery screen until they are
-removed and the container is restarted; on a fresh install, set versioning per Vault instead and leave them unset. See
-[`docs/migrations/legacy-single-vault.md`](docs/migrations/legacy-single-vault.md).
-
-Use `list_vaults` to inspect each Vault's Git status, and `sync_vault` or
-`retry_vault` (with that `vault_id`) for eligible managed-Git Vaults.
+See [How to set up a Git-backed
+Vault](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/how-to-set-up-a-git-backed-vault)
+for setup, and
+[`docs/migrations/legacy-single-vault.md`](docs/migrations/legacy-single-vault.md)
+if you're upgrading a pre-registry single-Vault deployment.
 
 ## Running Without Docker
 
@@ -733,89 +386,21 @@ models in `./models` by default, so no model-prefetch command is required.
 ### Hatchdoor refuses to start on `0.0.0.0`
 
 Set `HATCHDOOR_WEB_BEARER_TOKEN`, bind to `127.0.0.1`, or enable
-`HATCHDOOR_DEMO_MODE=true` for a read-only public demo.
-
-This is intentional. A non-loopback bind can expose your vault to the network,
-so Hatchdoor requires web authentication unless demo mode has disabled the app's
-write surfaces.
-
-### Docker starts, but the UI cannot write
-
-Check that the mounted vault directory is writable by the container runtime
-user. Browser write support depends on filesystem permissions.
-
-### Cache errors or stale data
-
-Delete the generated SQLite cache and restart:
-
-```bash
-rm ./data/cache/hatchdoor-cache.sqlite3
-docker compose restart hatchdoor
-```
+`HATCHDOOR_DEMO_MODE=true` for a read-only public demo. This is intentional: a
+non-loopback bind can expose your vault to the network.
 
 ### The app starts with a starter vault
 
-Hatchdoor seeds starter notes only when `VAULT_PATH` contains no Markdown files.
-If you expected an existing vault, this almost always means the container
-mounted an empty directory, so double-check that `HOST_VAULT_PATH` in `.env`
-resolves to your actual vault and isn't a typo or a stale Docker volume
-shadowing the mount.
+Hatchdoor seeds starter notes only when `VAULT_PATH` contains no Markdown
+files. If you expected an existing vault, this almost always means the
+container mounted an empty directory: double-check `HOST_VAULT_PATH` in
+`.env` isn't a typo or a stale Docker volume shadowing the mount.
 
-For the full list of notes Hatchdoor creates, see
-[Data And Safety Model](#data-and-safety-model).
-
-### MCP returns `401` or `403`
-
-Check:
-
-- `HATCHDOOR_MCP_ENABLED=true`
-- `HATCHDOOR_MCP_BEARER_TOKEN` is set
-- The client sends `Authorization: Bearer <token>`
-- Browser-originated MCP requests come from an allowed origin in
-  `HATCHDOOR_MCP_ALLOWED_ORIGINS`
-
-### Remote versioning does not push
-
-Check:
-
-- The vault is a git repository root.
-- The current branch matches the branch configured on the Vault.
-- The remote exists in the repo config.
-- The HTTPS token can push.
-- There are no merge conflicts waiting for manual resolution.
-
-## API Reference
-
-Common routes:
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/health` | Health check |
-| `GET` | `/api/tree` | Folder and note tree |
-| `GET` | `/api/recently-modified` | Recently modified notes |
-| `GET` | `/api/git-status` | Current versioning lifecycle and failure status |
-| `GET` | `/api/note/:slug` | Read a note |
-| `GET` | `/api/note/:slug/links` | Outbound links and backlinks |
-| `GET` | `/api/note/:slug/download` | Download a Markdown export |
-| `GET` | `/api/resolve?target=...` | Resolve one wikilink target |
-| `POST` | `/api/resolve-batch` | Resolve multiple wikilink targets |
-| `GET` | `/api/search?q=...` | Search notes |
-| `GET` | `/api/stats` | Vault stats |
-| `GET` | `/api/graph` | Graph data |
-| `GET` | `/api/diagnostics` | Inspect layer and noise-exclusion diagnostics |
-| `POST` | `/api/refresh` | Trigger cache refresh |
-| `GET` | `/api/vault-events` | Server-sent vault revision events |
-| `GET` | `/api/write-capabilities` | Check write availability |
-| `POST` | `/api/note` | Create a note |
-| `PUT` | `/api/note/:slug` | Update a note |
-| `PATCH` | `/api/note/:slug/rename` | Rename a note |
-| `PATCH` | `/api/note/:slug/move` | Move a note |
-| `PATCH` | `/api/note/:slug/archive` | Archive a note |
-| `PATCH` | `/api/note/:slug/move-rename` | Move and rename a note |
-| `DELETE` | `/api/note/:slug` | Move a note to trash |
-| `POST` | `/api/v1/vaults/{vault_id}/attachments` | Upload an attachment |
-| `GET` | `/vault-assets/*path` | Serve vault assets |
-| `POST` | `/mcp` | Streamable HTTP MCP endpoint |
+For write permission issues, MCP `401`/`403`, git sync problems, and more, see
+[How to troubleshoot common
+problems](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/how-to-troubleshoot-common-problems)
+in the user documentation. Every HTTP endpoint is documented in [HTTP API
+reference](https://docs-hatchdoor.battercloud.cc/v/bef3df28-8c2e-4722-89ad-bd4d0bcb3def/n/http-api-reference).
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ The runtime image is **distroless and rootless**. It is built on
 `gcr.io/distroless/cc-debian13:nonroot`, ships no shell or package manager, and
 runs as an unprivileged `nonroot` user. Hatchdoor also runs unchanged under
 Podman (rootless included); swap `docker` / `docker compose` for `podman` /
-`podman compose`.
+`podman compose` **and** the image tag for `podman-latest` (or
+`podman-<version>`) — the `latest` tag above is Docker-only.
 
 Docker Compose mounts:
 

--- a/docs/user-vault/01 Get started/Browse and review through the Web UI.md
+++ b/docs/user-vault/01 Get started/Browse and review through the Web UI.md
@@ -22,8 +22,10 @@ filename, command, or ID.
 > Browser search and agent search complement each other. Search in the Web UI when you want to scan results; ask the agent when you want a controlled research or editing workflow.
 
 The UI can also edit notes when the Vault is writable. **New note** creates a
-Markdown file; **Edit** and **Save** change one. If those controls are absent,
-the Vault is read-only or the deployment is in demo mode.
+Markdown file; click any paragraph, heading, list item, or table row to edit
+it in place — see [[How to edit notes with the live editor]] for the full
+rundown. If those controls are absent, the Vault is read-only or the
+deployment is in demo mode.
 
 Hatchdoor understands wikilinks and refreshes its index when Markdown or
 attachments change. Keep the Markdown files portable: you can still open them

--- a/docs/user-vault/01 Get started/Install Hatchdoor with Docker Compose.md
+++ b/docs/user-vault/01 Get started/Install Hatchdoor with Docker Compose.md
@@ -12,7 +12,7 @@ Create `compose.yaml` with this complete content:
 ```yaml
 services:
   hatchdoor:
-    image: battermanz/hatchdoor:2.5.0
+    image: battermanz/hatchdoor:latest
     container_name: hatchdoor
     env_file:
       - .env
@@ -40,6 +40,9 @@ services:
 
 > [!note]
 > `HOST: 0.0.0.0` makes Hatchdoor reachable through Docker's internal network. The `127.0.0.1:42824:42824` port mapping keeps it accessible only from the machine running Docker.
+
+> [!tip]
+> Using Podman instead of Docker? Everything on this page works unchanged — swap `docker` / `docker compose` for `podman` / `podman compose`, but also change the image to `battermanz/hatchdoor:podman-latest` (or `podman-<version>`); the plain `latest` tag above is Docker-only. The `chown` step further down needs `podman unshare` too — see the note there.
 
 ## Optional: expose Hatchdoor to your LAN
 
@@ -74,6 +77,12 @@ mkdir -p data/cache data/state models
 chmod 700 data/cache data/state models
 sudo chown -R 65532:65532 data models
 ```
+
+> [!tip]
+> On rootless Podman, `sudo chown` targets the wrong namespace — use
+> `podman unshare chown -R 65532:65532 data models` instead. Apply the same
+> substitution to a custom `HOST_CACHE_PATH`, `HOST_STATE_PATH`, or
+> `HOST_MODELS_PATH`.
 
 The container also needs read access to your Vault. Grant it write access only
 if agents or the Web UI should change notes. On Linux, verify access for UID

--- a/docs/user-vault/01 Get started/Welcome to Hatchdoor.md
+++ b/docs/user-vault/01 Get started/Welcome to Hatchdoor.md
@@ -10,7 +10,8 @@ to find and read a note, explicitly permit one small write, and inspect the
 result in the Web UI.
 
 Hatchdoor is not a hosted sync service and does not replace your Markdown app.
-It is the agent-first operating layer for notes you keep in ordinary files.
+It is the agent-first operating layer for notes you keep in ordinary files —
+see [[What Hatchdoor is]] for the full picture.
 
 ## What you need
 

--- a/docs/user-vault/01 Get started/Welcome to Hatchdoor.md
+++ b/docs/user-vault/01 Get started/Welcome to Hatchdoor.md
@@ -24,6 +24,7 @@ It is the agent-first operating layer for notes you keep in ordinary files.
 
 You will complete this path:
 
+0. Understand the idea: [[Why keep a second brain]], then pick a way to organize one — [[The PARA method (external reference)|PARA]], [[The Zettelkasten method (external reference)|Zettelkasten]], or [[The LLM wiki pattern (external reference)|the LLM wiki pattern]]. None of it is required before installing, but it's worth five minutes before you start filing real notes.
 1. [[Install Hatchdoor with Docker Compose]]
 2. [[Connect your first Vault]]
 3. [[Connect your agent]]

--- a/docs/user-vault/02 Guides/How to deploy Hatchdoor with an agent.md
+++ b/docs/user-vault/02 Guides/How to deploy Hatchdoor with an agent.md
@@ -27,7 +27,7 @@ Create an empty deployment directory and, inside it, `compose.yaml`:
 ```yaml
 services:
   hatchdoor:
-    image: battermanz/hatchdoor:2.5.0
+    image: battermanz/hatchdoor:latest
     container_name: hatchdoor
     env_file:
       - .env

--- a/docs/user-vault/02 Guides/How to edit notes with the live editor.md
+++ b/docs/user-vault/02 Guides/How to edit notes with the live editor.md
@@ -1,0 +1,59 @@
+---
+tags: [type/how-to, topic/web-ui]
+---
+
+# How to edit notes with the live editor
+
+On a writable Vault, the note you're reading *is* the note you edit — there's no separate edit mode to switch into. Click any paragraph, heading, list item, table row, or callout line and it turns into an editable field in place; everything else on the page stays exactly as rendered. This page covers how that works day to day. For the underlying Markdown syntax itself, see [[Supported Markdown reference]]; for browsing and search, see [[Browse and review through the Web UI]].
+
+## Entering a block
+
+- **Mouse:** click the block. The caret lands roughly where you clicked.
+- **Keyboard:** `Tab` to the block, then `Enter`. Every editable block is reachable this way, not just by mouse.
+- **Touch:** double-tap the line. A single tap keeps its normal job (following a link, toggling a checkbox, expanding a callout), so a stray tap while scrolling never opens an editor by accident. The first time you visit a writable Vault on a touch device, a dismissible banner reminds you: *"Double-tap a line to edit it."* — it only shows once.
+
+Links, task-list checkboxes, and callout summary lines never open for editing on click or tap; they do what they already do (navigate, toggle, expand/collapse).
+
+## Editable units
+
+Each click targets one **block**, not the whole note: one paragraph, one heading, one list item, one table row, one callout line, or one fenced code block. Markdown syntax you don't normally see — `## `, `- `, `> `, the code fence — appears only inside the block you're actively editing, and disappears again once you move on. The rest of the note keeps rendering normally while you edit one piece of it.
+
+Note properties (the frontmatter block — tags, status, and so on) are also editable inline, right above the note body.
+
+## Moving and splitting as you type
+
+| Key | What it does |
+| --- | --- |
+| `Enter` at the end of a paragraph or heading | Starts a new block below and moves you into it |
+| `Enter` inside a list item | Starts the next list item, keeping the same marker and indent (and an unchecked box, if it was a task) |
+| `Enter` inside a fenced code block | Inserts a literal newline, same as any text editor |
+| `Shift+Enter` | A hard line break within the current block |
+| `Backspace` at the very start of a block | Merges it into the block above, caret at the join |
+| `Tab` / `Shift+Tab` in a list item | Indent / outdent |
+| `↑` / `↓` at the top/bottom line of a block | Moves to the previous/next block, keeping your column |
+| `Escape` | Commits your edit and returns to the rendered view, with focus back on that block |
+
+These are disabled inside table rows — restructuring a table (adding rows or columns) needs Source mode, below.
+
+## Saving
+
+There's no Save button. Edits save automatically: when you commit a block (by clicking elsewhere, pressing `Escape`, or moving to another block) and again after about two seconds of typing without a pause. A badge above the note tells you where things stand:
+
+- **Saving…** — a write is in flight.
+- **Saved HH:MM** — everything up to that point is on disk.
+- **Not saving** — autosave has stopped; see below.
+
+## When editing stops or isn't available
+
+- **"Edits aren't saving. This note changed somewhere else."** — someone or something else (an agent, Obsidian, a git sync) wrote to this note while you were editing. Your local changes are kept; click **Review** to compare your draft against the version on disk and choose which to keep.
+- **"Edits aren't saving. Hatchdoor could not reach the vault."** — a connectivity problem. It retries once the connection is back.
+- **"This note's source and rendered lines don't line up, so inline editing is off here."** — a rare safety guard that disables inline editing for that specific note rather than risk misplacing an edit. Use **Edit** to open Source mode instead.
+- If the Vault is read-only, or you're on a demo deployment, no block is clickable at all — the note behaves as a plain reader.
+
+## Source mode
+
+The **Edit** button next to the note title opens the older, full-note Markdown editor with an explicit Save button. Use it for anything block editing can't do: restructuring a table, editing display math or raw HTML, and resolving a conflict flagged by the **Review** button above. It's always there as a fallback — nothing you can do in Source mode is off-limits, it's just not block-by-block.
+
+---
+
+Related: [[Browse and review through the Web UI]] · [[Supported Markdown reference]] · [[How to import and work with attachments]]

--- a/docs/user-vault/02 Guides/How to import and work with attachments.md
+++ b/docs/user-vault/02 Guides/How to import and work with attachments.md
@@ -1,0 +1,65 @@
+---
+tags: [type/how-to, topic/attachments]
+---
+
+# How to import and work with attachments
+
+Attachments are images and PDFs living inside a Vault alongside its Markdown, referenced the ordinary Markdown way. This page covers getting them in (from the Web UI and from an agent) and managing them afterward. For the exact embed syntax, see [[Supported Markdown reference#Images and PDFs]].
+
+## What's supported
+
+Every upload path, browser or agent, is limited to the same file types and enforces the same size caps server-side:
+
+| | Allowed | Default limit |
+| --- | --- | --- |
+| Extensions | `png`, `jpg`, `jpeg`, `gif`, `webp`, `avif`, `bmp`, `pdf` | — |
+| HTTP upload (Web UI and agents) | — | `HATCHDOOR_MAX_ATTACHMENT_BYTES`, 10 MiB |
+| MCP base64 fallback (`import_attachment`) | — | `HATCHDOOR_MCP_MAX_BASE64_BYTES`, 5 MiB decoded |
+
+Both limits are adjustable at runtime in **Settings → Uploads** — see [[Settings and environment variables reference]].
+
+## From the Web UI
+
+Paste an image, or drag and drop an image or PDF, directly into the note editor. Hatchdoor:
+
+1. Uploads it into a Vault-root `Attachments/` folder, numbering the filename (`report-1.pdf`, `report-2.pdf`, ...) if one with that name already exists rather than overwriting it.
+2. Inserts the right embed syntax at the cursor, with a relative path that walks back out to the vault root correctly even for a note several folders deep.
+
+An unsupported file type or an oversized file is rejected inline with the reason (wrong extension, or how many MB over the limit) — nothing partially uploads.
+
+## From an agent, over MCP or HTTP
+
+An agent has two ways in, and should check which one applies before uploading rather than assuming:
+
+```text
+Call get_attachment_import_config with the target vault_id first. It reports
+whether uploads are currently possible for that Vault, which method(s) are
+available, their byte limits, and the allowed extensions — check this instead
+of guessing, since it can differ per Vault (a pull_only Git Vault, for
+instance, never accepts writes).
+```
+
+| Method | When to use it | How |
+| --- | --- | --- |
+| `POST /api/v1/vaults/{vault_id}/attachments` | The default — prefer this whenever the client can make an HTTP request (including `curl` from a shell-capable agent) | `multipart/form-data` with fields `target_relative_path` and `file`. Accepts either the web bearer token or a live MCP bearer token, so an MCP agent doesn't need separate web credentials. |
+| `import_attachment` (MCP tool) | The fallback, for clients that genuinely cannot make an out-of-band HTTP request | `content` (base64), `target_relative_path`. Rides inside the JSON-RPC message, so it gets unreliable as files approach the base64 size limit — prefer the HTTP path whenever it's available. |
+
+Both return the same shape: `vault_id`, `attachment`, `rewritten_notes`, `trashed_path`, `cleanup_warning`. Neither creates the embed syntax in a note for you — write the returned `attachment.relative_path` into the note yourself, as a link or with `![[...]]` embed syntax, the same way you'd write any other Markdown.
+
+> [!tip]
+> There's no requirement to use the Vault-root `Attachments/` folder the Web UI uses — `target_relative_path` is any Vault-relative path you choose. Keeping the Web UI's convention makes files easy to find by browsing, but an agent following its own filing scheme (per-note folders, a `Sources/` layer) works just as well.
+
+## Managing attachments already in the Vault
+
+| Tool | Does |
+| --- | --- |
+| `list_note_attachments` | Every attachment one note references, without pulling the note's full content — useful before deciding whether a move or rename is safe. |
+| `move_attachment` | Moves the file and rewrites every note that referenced it. |
+| `rename_attachment` | Renames the file in place and rewrites every reference. |
+| `delete_attachment` | Trashes the file under `.hatchdoor-trash` and rewrites every reference — the same trash mechanism `delete_note` uses (see [[MCP tools reference#Write content tools]]), so it's recoverable from disk, not gone. |
+
+All four require `HATCHDOOR_MCP_WRITE_ENABLED` and the same Vault-level `mutate` capability as any other write — see [[MCP tools reference#Write content tools]] for full parameters.
+
+---
+
+Related: [[MCP tools reference]] · [[HTTP API reference]] · [[Supported Markdown reference]] · [[Settings and environment variables reference]] · [[Search and change notes with your agent]]

--- a/docs/user-vault/02 Guides/How to manage multiple Vaults.md
+++ b/docs/user-vault/02 Guides/How to manage multiple Vaults.md
@@ -1,0 +1,56 @@
+---
+tags: [type/how-to, topic/vaults]
+---
+
+# How to manage multiple Vaults
+
+Hatchdoor is multi-vault by design — there's no selected or default Vault anywhere in the app. [[Connect your first Vault]] and [[How to set up a Git-backed Vault]] cover creating one; this page covers living with more than one: adding another, pausing and resuming, disconnecting, and the same three actions from an agent over MCP.
+
+## Add another Vault
+
+Open **Settings** → **Add a Vault**. The same creation form handles every Vault, first or fifth: **A folder on this server** for a plain directory or an existing local Git checkout, **A managed Git checkout** for a remote Hatchdoor should clone and own. See [[Connect your first Vault]] for the container-path caveat with local folders, and [[How to set up a Git-backed Vault]] for the full field-by-field walkthrough of Git behaviour.
+
+> [!note]
+> Demo mode (`HATCHDOOR_DEMO_MODE=true`) removes **Add a Vault** entirely — a public read-only instance has no Settings screen to reach it from.
+
+## Where each Vault shows up
+
+**Settings** lists every Vault, enabled or paused. The rest of the app — the sidebar, search, the graph — only ever shows enabled Vaults; a paused Vault disappears from browsing and search but keeps its entry, its files, and its history untouched. If you're looking for a Vault you know exists and can't find it while browsing, check whether it's paused in Settings before assuming something's wrong.
+
+## Pause and resume a Vault
+
+Open the Vault from the Settings index and use **Pause Vault** / **Resume Vault** in its action row. Pausing:
+
+- Removes the Vault from the sidebar, search, and the graph immediately.
+- Leaves every file, the search index, and any Git history exactly as they were — nothing is deleted or rebuilt.
+- Disables that Vault's write capability, MCP included, until it's resumed.
+
+There's no separate confirmation step for pausing — it's reversible in one click either direction, unlike disconnecting below.
+
+## Disconnect a Vault
+
+**Disconnect Vault**, in the same action row, is the one Vault-lifecycle action that isn't a toggle. It removes the Vault's *definition* from Hatchdoor's registry — the record of where it lives and how it's configured — while leaving the Vault's own files, folder, Git history, and credentials on disk exactly where they were.
+
+> [!warning]
+> Disconnecting forgets the Vault; it does not delete anything. To reconnect, use **Add a Vault** again and point it at the same folder or repository — Hatchdoor treats that as adding new content, not resuming an old identity, so any Vault-scoped settings (exclusion patterns, archive folder, commit identity) need re-entering.
+
+Disconnect has no undo inside Hatchdoor itself, which is why it's a red button with the warning line printed above it rather than a confirmation dialog after the click — the app tells you the consequence before you act, not after.
+
+## The same three actions over MCP
+
+An agent manages Vaults with the same tools it uses for everything else, gated by `HATCHDOOR_MCP_WRITE_ENABLED` like any other write — see [[MCP tools reference#Vault collection: discovery and management]] for full parameters. The pattern is the same for all three:
+
+```text
+1. Call list_vaults. Read the target Vault's vault_id and the current registry_revision.
+2. Call enable_vault / disable_vault / disconnect_vault with that vault_id and expected_registry_revision.
+3. A stale expected_registry_revision is rejected rather than silently racing another writer — re-read list_vaults and retry.
+```
+
+Creating a Vault over MCP works the same way, with `create_vault` in place of the three lifecycle calls — see [[How to deploy Hatchdoor with an agent]] for a full walkthrough of standing up Hatchdoor and its first Vault entirely from an agent session.
+
+> [!tip]
+> `list_vaults` is always callable, with or without write mode — an agent can inventory every Vault, its status, and its capabilities before deciding anything needs to change. Only the four mutating calls (`create_vault`, `edit_vault`, `enable_vault`/`disable_vault`, `disconnect_vault`) require write mode.
+
+---
+
+Related: [[Connect your first Vault]] · [[How to set up a Git-backed Vault]] · [[How to deploy Hatchdoor with an agent]] · [[MCP tools reference]] · [[HTTP API reference]] · [[Vault lifecycle states]]

--- a/docs/user-vault/03 Reference/The PARA method (external reference).md
+++ b/docs/user-vault/03 Reference/The PARA method (external reference).md
@@ -43,4 +43,4 @@ One genuine point of contact: `archive_note` (both the MCP tool and the Web UI a
 
 ---
 
-Related: [[MCP tools reference]] · [[The layer system]] · [[The LLM wiki pattern (external reference)]]
+Related: [[MCP tools reference]] · [[The layer system]] · [[The LLM wiki pattern (external reference)]] · [[The Second Brain method (external reference)]] · [[The Zettelkasten method (external reference)]]

--- a/docs/user-vault/03 Reference/The Second Brain method (external reference).md
+++ b/docs/user-vault/03 Reference/The Second Brain method (external reference).md
@@ -41,6 +41,8 @@ Like PARA, the second brain concept is tool-agnostic — Forte's own examples sp
 
 Ordinary Markdown files are already the kind of durable, portable store the practice asks for — nothing about capturing, distilling, or expressing requires a specific app, only a place that persists. What Hatchdoor adds is a second party who can act on that store: an MCP-connected agent can capture material into a note on request, distill an existing page by rewriting or trimming it, and draft the expressive output — a summary, a report — directly from what's already there, all under the same guarded read/write tools described in [[MCP tools reference]]. The human still decides what's worth keeping and reviews what changed, in the Web UI; the agent does more of the mechanical work of Organize and Distill than a second brain built for a human alone ever could.
 
+Next, find out [[Why keep a second brain]]?
+
 ---
 
 Related: [[The PARA method (external reference)]] · [[The Zettelkasten method (external reference)]] · [[Why keep a second brain]] · [[MCP tools reference]]

--- a/docs/user-vault/03 Reference/The Second Brain method (external reference).md
+++ b/docs/user-vault/03 Reference/The Second Brain method (external reference).md
@@ -1,0 +1,46 @@
+---
+tags: [type/reference, topic/vault-organization]
+---
+
+# The Second Brain method (external reference)
+
+"Second brain" is Tiago Forte's name for the underlying practice; [[The PARA method (external reference)|PARA]] is his specific scheme for organizing one. This page is a dictionary of the practice itself, for anyone deciding whether — and how — to keep one at all, with links to the primary source.
+
+## Primary sources
+
+| Source | Link |
+| --- | --- |
+| *Building a Second Brain: A Proven Method to Organize Your Digital Life and Unlock Your Creative Potential* (book) — Tiago Forte | [buildingasecondbrain.com](https://www.buildingasecondbrain.com/) |
+| "What is a Second Brain?" — Forte Labs | [fortelabs.com/blog/basb](https://fortelabs.com/blog/basb/) |
+| Forte Labs | [fortelabs.com](https://fortelabs.com/) |
+
+## The core idea
+
+A second brain is an external, trusted system for the things worth keeping — ideas, insights, quotes, references — outside of memory. The point isn't storage for its own sake; it's freeing working memory from having to hold everything, so it can be spent on thinking instead of remembering. Forte frames this as necessary given "information overload" that biological memory was never built to handle.
+
+## The CODE method
+
+Forte describes four steps for turning raw information into something usable later:
+
+| Step | What it means |
+| --- | --- |
+| **Capture** | Keep what resonates, as it happens — a note, a highlight, a screenshot — rather than trusting yourself to remember it or find it again later. |
+| **Organize** | File captured material for actionability, not by topic or source — this is where [[The PARA method (external reference)|PARA]] comes in as Forte's specific answer. |
+| **Distill** | Progressively summarize down to the essence, so a future read of the note costs seconds, not the original research time. |
+| **Express** | Turn accumulated notes into something shared with the world — a document, a decision, a piece of work — rather than letting them sit unused. |
+
+## Second Brain vs. PARA
+
+They are not two competing systems. A second brain is the practice as a whole — capture, keep, distill, and eventually use what you've kept. PARA is one part of that practice: Forte's answer to *where do captured things live*. A Vault can follow the CODE method's rhythm without adopting PARA's specific four folders, and it can adopt PARA's folders without ever thinking in CODE terms — but Forte designed them to work together, and most of his own writing treats them as a pair.
+
+## Why it's meant to work across any tool
+
+Like PARA, the second brain concept is tool-agnostic — Forte's own examples span notebooks, cloud drives, and note apps built for exactly this. Nothing about it assumes an app owns your notes; it assumes you have a durable, external place to keep them and a habit of using it.
+
+## How this shows up in a Hatchdoor Vault
+
+Ordinary Markdown files are already the kind of durable, portable store the practice asks for — nothing about capturing, distilling, or expressing requires a specific app, only a place that persists. What Hatchdoor adds is a second party who can act on that store: an MCP-connected agent can capture material into a note on request, distill an existing page by rewriting or trimming it, and draft the expressive output — a summary, a report — directly from what's already there, all under the same guarded read/write tools described in [[MCP tools reference]]. The human still decides what's worth keeping and reviews what changed, in the Web UI; the agent does more of the mechanical work of Organize and Distill than a second brain built for a human alone ever could.
+
+---
+
+Related: [[The PARA method (external reference)]] · [[The Zettelkasten method (external reference)]] · [[Why keep a second brain]] · [[MCP tools reference]]

--- a/docs/user-vault/03 Reference/The Zettelkasten method (external reference).md
+++ b/docs/user-vault/03 Reference/The Zettelkasten method (external reference).md
@@ -1,0 +1,45 @@
+---
+tags: [type/reference, topic/vault-organization]
+---
+
+# The Zettelkasten method (external reference)
+
+Zettelkasten ("slip-box") is Niklas Luhmann's note-taking method, popularized for a modern audience by Sönke Ahrens. This page is a dictionary of the method itself, for anyone deciding how to lay out a new Vault, with links to the primary sources.
+
+## Primary sources
+
+| Source | Link |
+| --- | --- |
+| *How to Take Smart Notes* (book) — Sönke Ahrens | [takesmartnotes.com](https://takesmartnotes.com/) |
+| Niklas Luhmann's Zettelkasten (digitized archive) — Bielefeld University | [niklas-luhmann-archiv.de](https://niklas-luhmann-archiv.de/) |
+| "Zettelkasten Method" overview — zettelkasten.de | [zettelkasten.de/introduction](https://zettelkasten.de/introduction/) |
+
+## The core idea
+
+Luhmann kept roughly 90,000 index cards over his career, cross-referenced by hand, and credited the slip-box itself — not just his own thinking — with the volume of work he produced. The method treats writing notes as thinking, not transcription: a note is only useful once it's rewritten in your own words, atomic, and linked to what it relates to. The slip-box's value compounds because notes accumulate connections over time, not because it stores more.
+
+## Three kinds of notes
+
+Ahrens distinguishes notes by role, not by where they're filed:
+
+| Kind | Role |
+| --- | --- |
+| **Fleeting notes** | A quick capture of a thought as it occurs — disposable, meant to be processed within a day or two, not kept long-term. |
+| **Literature notes** | What a source actually said, in your own words, tied to the source it came from. |
+| **Permanent notes** | One idea, fully written out, in a form that makes sense without its original context — this is what actually goes into the slip-box and gets linked. |
+
+## What makes a note "atomic"
+
+A permanent note holds exactly one idea, written so it stands on its own months or years later without needing the surrounding material that produced it. This is the property that makes dense linking possible: a note that bundles several ideas can only be linked as a whole, while an atomic note can be linked precisely, from every other note that actually relates to that one idea.
+
+## Links over hierarchy
+
+Luhmann's slip-box had almost no folder structure — cards were filed near a related card and connected by explicit reference numbers, so a note's context came from its links, not its location. This is the method's sharpest contrast with [[The PARA method (external reference)|PARA]]: PARA sorts by where a note belongs (which folder, based on actionability); Zettelkasten deliberately avoids that question and lets structure emerge from links accumulated over time.
+
+## How this shows up in a Hatchdoor Vault
+
+A Vault's `[[wikilinks]]` are the direct mechanical equivalent of Luhmann's card references — see [[Supported Markdown reference]] for the link syntax and [[How indexing and search work]] for how they're indexed and surfaced as backlinks. A note's slug plays the role Luhmann's ID numbers played: a stable handle other notes can point at regardless of where the file lives or gets moved. Nothing about the method requires folders at all, so a Zettelkasten-style Vault can be as flat as a single directory of permanent notes — though nothing stops combining it with [[The PARA method (external reference)|PARA]] folders or [[The layer system|layers]] for fleeting and literature notes, keeping only permanent notes on the default surface.
+
+---
+
+Related: [[The PARA method (external reference)]] · [[The Second Brain method (external reference)]] · [[Supported Markdown reference]] · [[The layer system]]

--- a/docs/user-vault/04 Concepts/What Hatchdoor is.md
+++ b/docs/user-vault/04 Concepts/What Hatchdoor is.md
@@ -1,0 +1,31 @@
+---
+tags: [type/explanation, topic/architecture]
+---
+
+# What Hatchdoor is
+
+Hatchdoor is a self-hosted web app that sits in front of a folder of plain Markdown files — an Obsidian-style Vault you already own or are starting fresh — and gives two front doors onto the exact same content: a web UI for you, and an MCP-connected agent for whichever assistant you point at it. Neither is the "real" interface; both act on the same files through the same guarded operations.
+
+## Markdown stays authoritative
+
+The files on disk are the source of truth, full stop. Hatchdoor builds a SQLite read model on top of them — for browsing, search (keyword and semantic), backlinks, tags, and graph data — but that database is disposable: delete it, and Hatchdoor rebuilds it by rescanning the Vault. This is a deliberate constraint, not an implementation detail. It's what makes a Vault portable: you can open the same notes in Obsidian, edit them with `git`, or drop Hatchdoor entirely, and nothing about the files themselves depends on it having ever existed.
+
+## Two front doors, one set of rules
+
+The Web UI edits notes directly — see [[How to edit notes with the live editor]]. An agent edits the same notes over MCP, through the guarded tools in [[MCP tools reference]]: `search_notes`, `create_note`, `edit_note`, and the rest. Both paths go through the same optimistic-concurrency-checked writes, so a human editing a note in the browser and an agent editing it a moment later can't silently clobber each other — see [[How indexing and search work]] for how a write becomes visible again.
+
+What separates the two isn't capability so much as posture. A human reviewing a note in the browser is fundamentally different from an autonomous agent acting on your Vault unsupervised, so agent access is designed to be started narrow — read-only first — and widened deliberately. [[The security model]] covers exactly which secret gates which door, and [[Search and change notes with your agent]] covers why read-before-write is the recommended default rather than a hard rule.
+
+
+
+## What it isn't
+
+Hatchdoor isn't a hosted sync service, and it doesn't replace your Markdown editor of choice. There's no proprietary format to lock into and no cloud copy of your notes — the Vault is a folder you point Hatchdoor at, optionally backed by a git remote (see [[How to set up a Git-backed Vault]]) for history and sync, and Hatchdoor's job is the operational layer around that folder: indexing it, serving it, and mediating writes to it.
+
+## Why an agent gets first-class access
+
+Most note-taking tools are built for a single author writing to their future self. Hatchdoor's premise is that a capable agent is a second party with legitimate reasons to read and write the same Vault — filing a source you hand it, cleaning up a rough note, keeping cross-links current — and that this only works if the agent is held to the same guarantees a human editing through the browser gets: atomic writes, a current-version check before saving, and content that stays plain Markdown regardless of who touched it last. [[Why keep a second brain]] goes into what that changes about the ordinary capture–organize–distill–express rhythm, and doesn't require any particular Vault layout — see the comparison in [[Home]].
+
+---
+
+Related: [[Home]] · [[Why keep a second brain]] · [[The security model]] · [[How indexing and search work]] · [[MCP tools reference]]

--- a/docs/user-vault/04 Concepts/Why keep a second brain.md
+++ b/docs/user-vault/04 Concepts/Why keep a second brain.md
@@ -1,0 +1,29 @@
+---
+tags: [type/explanation, topic/vault-organization, topic/agent-workflow]
+---
+
+# Why keep a second brain
+
+The pitch for a [[The Second Brain method (external reference)|second brain]] — an external, trusted place for the things worth keeping — doesn't depend on Hatchdoor at all. Plain Markdown files in any folder already satisfy it: durable, portable, readable without special software. What changes with Hatchdoor is who's allowed to act on that store.
+
+## A second brain built for one reader
+
+Most note-taking advice, including Forte's CODE method and Luhmann's slip-box, assumes a single author who is also the only future reader: you capture something, and later *you* organize, distill, and use it. The system's whole design optimizes for that one relationship — a human writing to their future self.
+
+## What changes when an agent can read and write it too
+
+An MCP-connected agent — see [[Connect your agent]] — is a second party with the same read/write access to the Vault a human has, gated by the same guarded tools described in [[MCP tools reference]]. That changes what the mechanical steps of keeping a second brain cost:
+
+- **Capture** stays mostly human — an agent doesn't decide what's worth keeping on your behalf, but it can take a source you hand it and file it as a note without you doing the typing.
+- **Organize and Distill** get cheaper. Rewriting a rough note into something concise, merging two notes on the same topic, or filling in cross-links between related pages are exactly the kind of mechanical, well-specified edits an agent can carry out — and does, in the [[How to run an LLM wiki in Hatchdoor|LLM-wiki workflow]], as an ongoing habit rather than a one-off cleanup.
+- **Express** can start from what the Vault already contains. An agent asked for a summary or a report searches the Vault first, the same way it's expected to in [[Search and change notes with your agent]], rather than reconstructing an answer from nothing.
+
+None of this requires trusting the agent unsupervised. Every write is optimistic-concurrency-checked against the note's current version, every note stays plain Markdown you can read without Hatchdoor at all, and [[Browse and review through the Web UI|reviewing what changed]] is a normal part of the workflow, not an afterthought.
+
+## Why this doesn't require a specific layout
+
+Nothing above depends on organizing the Vault one particular way. [[The PARA method (external reference)|PARA]], [[The Zettelkasten method (external reference)|Zettelkasten]], and [[The LLM wiki pattern (external reference)|the LLM-wiki pattern]] all describe a different answer to "how should notes be filed and linked" — an agent works the same guarded tools regardless of which one a Vault follows, or none at all. Pick a layout because it fits how you think, not because Hatchdoor asks for it.
+
+---
+
+Related: [[The Second Brain method (external reference)]] · [[The PARA method (external reference)]] · [[The Zettelkasten method (external reference)]] · [[The LLM wiki pattern (external reference)]] · [[MCP tools reference]] · [[The security model]]

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -50,8 +50,10 @@ Guides, Reference, and Concepts will grow from this starting point.
 
 - [[How to deploy Hatchdoor with an agent]]
 - [[How to set up a Git-backed Vault]]
+- [[How to manage multiple Vaults]]
 - [[How to organize a Vault with layers]]
 - [[How to run an LLM wiki in Hatchdoor]]
+- [[How to import and work with attachments]]
 - [[How to troubleshoot common problems]]
 
 **Reference**

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -54,6 +54,7 @@ Guides, Reference, and Concepts will grow from this starting point.
 - [[How to organize a Vault with layers]]
 - [[How to run an LLM wiki in Hatchdoor]]
 - [[How to import and work with attachments]]
+- [[How to edit notes with the live editor]]
 - [[How to troubleshoot common problems]]
 
 **Reference**
@@ -69,6 +70,7 @@ Guides, Reference, and Concepts will grow from this starting point.
 
 **Concepts**
 
+- [[What Hatchdoor is]]
 - [[The layer system]]
 - [[How indexing and search work]]
 - [[The security model]]

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -21,8 +21,19 @@ flowchart LR
 
 Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent, make one deliberate change, and review it in the browser. These docs target Hatchdoor v2.5.0.
 
-> [!tip]
-> Starting a new Vault and not sure how to organize it? Hatchdoor doesn't require any particular layout. Two established patterns worth knowing about: [[The PARA method (external reference)|PARA]] sorts folders by how actionable a note is (Projects, Areas, Resources, Archives); [[The LLM wiki pattern (external reference)|the LLM wiki pattern]] has an agent build and maintain an interlinked wiki for you. They aren't mutually exclusive — see [[How to run an LLM wiki in Hatchdoor]].
+## Before you start: what kind of notes app is this
+
+Hatchdoor is built for keeping a [[The Second Brain method (external reference)|second brain]] — a durable, external place for the things worth keeping — with one difference from most tools built for that: an MCP-connected agent can read and act on it too, not just you. See [[Why keep a second brain]] for what that changes about the ordinary capture-organize-distill-express rhythm.
+
+That still leaves how to lay out a Vault. Hatchdoor doesn't require any particular layout — pick whichever of these fits how you think, or mix them:
+
+| Method | What it optimizes | Reference |
+| --- | --- | --- |
+| **PARA** | Folders by how actionable a note is (Projects, Areas, Resources, Archives) | [[The PARA method (external reference)]] |
+| **Zettelkasten** | Dense links between atomic notes, little to no folder hierarchy | [[The Zettelkasten method (external reference)]] |
+| **LLM wiki** | An agent that builds and maintains an interlinked wiki for you | [[The LLM wiki pattern (external reference)]] |
+
+They aren't mutually exclusive — see [[How to run an LLM wiki in Hatchdoor]] for one way to combine an LLM wiki with folder-based organization underneath it.
 
 ## Documentation areas
 
@@ -51,6 +62,8 @@ Guides, Reference, and Concepts will grow from this starting point.
 - [[Settings and environment variables reference]]
 - [[The LLM wiki pattern (external reference)]]
 - [[The PARA method (external reference)]]
+- [[The Second Brain method (external reference)]]
+- [[The Zettelkasten method (external reference)]]
 
 **Concepts**
 
@@ -58,3 +71,4 @@ Guides, Reference, and Concepts will grow from this starting point.
 - [[How indexing and search work]]
 - [[The security model]]
 - [[Vault lifecycle states]]
+- [[Why keep a second brain]]


### PR DESCRIPTION
## Summary
- Add a how-to guide for the live inline block editor in the Web UI
- Add a Concepts note explaining what Hatchdoor is
- Fix compose examples to use the `latest` image tag instead of a pinned version
- Document the Podman image-tag difference (`podman-latest`) and `podman unshare chown` for rootless installs, in both the README and the install tutorial
- Prior commits on this branch: multi-vault lifecycle/attachment guides, Second Brain/Zettelkasten reference pages, settings/env var reference, and multi-vault demo support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6aBjGDD7VxJnMfoB3GA2e