### PR TITLE
fix(mcp): stop reporting a routine reindex as incomplete model setup

### DIFF
--- a/src/mcp/adapter.rs
+++ b/src/mcp/adapter.rs
@@ -62,10 +62,14 @@ impl HatchdoorMcpHandler {
 
 impl ServerHandler for HatchdoorMcpHandler {
     fn get_info(&self) -> ServerInfo {
-        let instructions = if self.state.startup.is_ready() {
-            SERVER_INSTRUCTIONS.to_string()
-        } else {
+        // `model_setup_pending`, not the collection's index readiness: a client
+        // that happens to connect while a Vault is reindexing has a fully
+        // set-up instance and needs the real instructions, not the first-run
+        // ones (#191).
+        let instructions = if self.state.startup.model_setup_pending() {
             SETUP_INSTRUCTIONS.to_string()
+        } else {
+            SERVER_INSTRUCTIONS.to_string()
         };
         // The modern wire shape advertises `tools.listChanged: true` and
         // delivers on it via `subscriptions/listen` (#170). The legacy

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -1684,6 +1684,78 @@ mod tests {
         );
     }
 
+    /// #191. A post-write Index turn reports its progress through the *same*
+    /// tracker that carries the first-run setup lifecycle, so the collection
+    /// leaves `Ready` for `Indexing` several times a minute in a write-heavy
+    /// session. Every read and write tool used to answer that window with the
+    /// first-run setup error, which is both wrong and unactionable: setup
+    /// completed long ago, and the terms tool it names can change nothing.
+    #[tokio::test]
+    async fn a_reindex_is_not_reported_as_incomplete_model_setup() {
+        let (state, _tmp) = write_state();
+        state
+            .startup
+            .set_indexing(crate::startup::IndexingProgressSnapshot::default());
+
+        for (tool, arguments) in [
+            ("get_note", json!({"slug":"home"})),
+            ("search_notes", json!({"query":"alpha"})),
+            ("resolve_wikilink", json!({"target":"Plan"})),
+            ("get_tree", json!({})),
+        ] {
+            let body = call_tool(&state, tool, arguments).await;
+            assert_eq!(
+                body["result"]["isError"], false,
+                "{tool} during a reindex: {}",
+                body["result"]["content"][0]["text"]
+            );
+        }
+
+        // A write too: the window this opens is a *consequence* of writing, so
+        // the next write in a run of edits is the call most likely to land in
+        // it.
+        let read = call_tool(&state, "get_note", json!({"slug":"home"})).await;
+        let hash = read["result"]["structuredContent"]["note"]["content_hash"]
+            .as_str()
+            .expect("content hash");
+        let edited = call_tool(
+            &state,
+            "edit_note",
+            json!({
+                "slug": "home",
+                "old_string": "alpha token",
+                "new_string": "beta token",
+                "expected_content_hash": hash,
+            }),
+        )
+        .await;
+        assert_eq!(
+            edited["result"]["isError"], false,
+            "edit_note during a reindex: {}",
+            edited["result"]["content"][0]["text"]
+        );
+    }
+
+    /// The other half of #191: following the error's own advice produced a
+    /// second, differently wrong answer ("a setup is already active"), so a
+    /// client had to fail twice to discover the Vault was merely reindexing.
+    /// Once setup is complete the terms tools stay unreachable, reindex or not,
+    /// which is the invariant `READ_OPS`' doc comment already claimed.
+    #[tokio::test]
+    async fn a_reindex_does_not_reopen_the_model_terms_tools() {
+        let (state, _tmp) = test_state();
+        state
+            .startup
+            .set_indexing(crate::startup::IndexingProgressSnapshot::default());
+
+        let declined = call_tool_unscoped(&state, "decline_gemma_terms", json!({})).await;
+        assert_eq!(declined["result"]["isError"], true);
+        assert_eq!(
+            declined["result"]["content"][0]["text"],
+            "A search model is already set up. Changing models after setup is not supported."
+        );
+    }
+
     #[tokio::test]
     async fn readiness_gate_exempts_vault_collection_discovery() {
         let (state, _tmp) = test_state();

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -46,16 +46,24 @@ pub async fn handle_tools_call(
         )));
     }
 
-    // Before the first index exists, only the explicit model-setup calls and
-    // Vault collection discovery/management may run. `state.startup` tracks
-    // the legacy single-Vault embedding-model setup, which has no bearing on
-    // the Vault registry: zero Vaults or a registry in Recovery are normal,
-    // expected states, and an agent must be able to see and repair the
+    // While model setup is still pending, only the explicit model-setup calls
+    // and Vault collection discovery/management may run. `state.startup`
+    // tracks the legacy single-Vault embedding-model setup, which has no
+    // bearing on the Vault registry: zero Vaults or a registry in Recovery are
+    // normal, expected states, and an agent must be able to see and repair the
     // collection precisely then. This mirrors `handlers/vaults.rs`, whose
     // whole HTTP surface is deliberately not gated by this legacy readiness
     // signal. The full tool catalogue is still advertised so MCP clients that
     // cache tools at connection time need no restart once setup completes.
-    if !state.startup.is_ready() && !is_collection_management_tool(name) {
+    //
+    // The question is `model_setup_pending`, not whether the collection's
+    // indexes are settled: the same tracker doubles as the live
+    // indexing-progress channel, so asking the latter also caught every
+    // routine post-write reindex and told the caller to go accept a licence it
+    // had accepted months earlier (#191). Scanning and indexing fall through
+    // to the Vault-scoped cores, which report a rebuilding Vault themselves
+    // and accurately.
+    if state.startup.model_setup_pending() && !is_collection_management_tool(name) {
         return match name {
             "accept_gemma_terms" => select_model_tool(
                 state,
@@ -73,9 +81,19 @@ pub async fn handle_tools_call(
                     model: crate::model_setup::NOMIC_MODEL_ID,
                 },
             ),
-            _ => Ok(tool_error(
-                "Hatchdoor is still being set up. Use get_model_setup_status, accept_gemma_terms, or decline_gemma_terms first.".to_string(),
-            )),
+            // Logged because the client is the only party that used to learn
+            // of this rejection: it produced no server-side record at all, so
+            // a session full of them was invisible in the logs (#191).
+            _ => {
+                tracing::info!(
+                    tool = name,
+                    setup_state = state.startup.status().state,
+                    "MCP tool call rejected: first-run model setup is not complete"
+                );
+                Ok(tool_error(
+                    "Hatchdoor is still being set up. Use get_model_setup_status, accept_gemma_terms, or decline_gemma_terms first.".to_string(),
+                ))
+            }
         };
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -646,7 +646,7 @@ async fn startup_status_handler(State(state): State<AppState>) -> Response {
 }
 
 async fn readiness_handler(State(state): State<AppState>) -> Response {
-    if state.startup.is_ready() {
+    if state.startup.collection_indexes_ready() {
         (StatusCode::OK, "ready").into_response()
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, "not ready").into_response()

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -31,6 +31,12 @@ impl IndexingProgressSnapshot {
     }
 }
 
+/// The code [`StartupTracker::set_model_setup_failed`] publishes. It is what
+/// tells a failed model setup apart from every other reason this tracker can
+/// be `Unavailable`, which is the distinction
+/// [`StartupTracker::model_setup_pending`] turns on.
+const MODEL_SETUP_FAILED: &str = "model_setup_failed";
+
 #[derive(Clone, Debug)]
 pub struct StartupTracker(VaultRuntime);
 
@@ -93,13 +99,52 @@ impl StartupTracker {
 
     pub fn set_model_setup_failed(&self) {
         self.0.set_unavailable(
-            "model_setup_failed",
+            MODEL_SETUP_FAILED,
             "The search model could not be downloaded or loaded. Check the Hatchdoor logs, then retry setup.",
         );
     }
 
-    pub fn is_ready(&self) -> bool {
+    /// Whether every active Vault's Index turn has settled `Ready`, which is
+    /// the condition `VaultWorkExecutor::publish_outcome` latches here through
+    /// `collection_indexes_ready`. It falls back to false for the duration of
+    /// each subsequent rebuild.
+    ///
+    /// Named for what it measures rather than for `Ready`, because the shorter
+    /// `is_ready` invited a question it cannot answer: three callers read it as
+    /// "has first-run setup finished", and so reported a routine post-write
+    /// reindex as incomplete setup (#191). Ask
+    /// [`Self::model_setup_pending`] for that.
+    pub fn collection_indexes_ready(&self) -> bool {
         self.0.is_ready()
+    }
+
+    /// Whether first-run model setup is genuinely what stands between a caller
+    /// and the Vault collection.
+    ///
+    /// Deliberately not the negation of [`Self::collection_indexes_ready`].
+    /// This tracker's phase does double duty: it carries the first-run setup
+    /// lifecycle, and it is also the channel `VaultWorkExecutor` reports live
+    /// indexing progress on, for whichever Vault currently has an Index turn.
+    /// So a routine post-write reindex leaves `Ready` for `Indexing` on an
+    /// instance whose setup finished long ago, and reading that as a setup
+    /// answer is what #191 was.
+    ///
+    /// Only a pending terms choice, a download in flight, and a failed setup
+    /// are conditions the setup tools can act on. Validating, scanning and
+    /// indexing are not: each Vault reports those itself, per Vault and
+    /// accurately, through its own `VaultSearchStatus`.
+    pub fn model_setup_pending(&self) -> bool {
+        let snapshot = self.0.snapshot();
+        match snapshot.phase {
+            VaultPhase::TermsRequired | VaultPhase::Downloading => true,
+            VaultPhase::Unavailable => snapshot
+                .error
+                .is_some_and(|error| error.code == MODEL_SETUP_FAILED),
+            VaultPhase::Validating
+            | VaultPhase::Scanning
+            | VaultPhase::Indexing
+            | VaultPhase::Ready => false,
+        }
     }
 
     pub fn runtime(&self) -> &VaultRuntime {
@@ -217,7 +262,7 @@ mod tests {
     #[test]
     fn terms_required_is_not_ready_and_is_exposed_to_the_ui() {
         let tracker = StartupTracker::terms_required();
-        assert!(!tracker.is_ready());
+        assert!(!tracker.collection_indexes_ready());
         let status = tracker.status();
         assert_eq!(status.state, "terms_required");
         assert!(status.percent.is_none());
@@ -240,5 +285,56 @@ mod tests {
         let tracker = StartupTracker::terms_required();
         tracker.set_downloading("Nomic Embed Text v1.5", None, None);
         assert_eq!(tracker.status().percent, None);
+    }
+
+    /// Setup is pending only while the setup tools can still change something:
+    /// a terms choice is outstanding, a download is in flight, or a setup
+    /// failed and can be retried.
+    #[test]
+    fn only_the_setup_phases_report_setup_as_pending() {
+        let tracker = StartupTracker::terms_required();
+        assert!(tracker.model_setup_pending());
+
+        tracker.set_downloading("EmbeddingGemma 300M Q4", Some(1), Some(2));
+        assert!(tracker.model_setup_pending());
+
+        tracker.set_model_setup_failed();
+        assert!(tracker.model_setup_pending());
+    }
+
+    /// A collection that is rebuilding has finished setup, so the setup tools
+    /// have nothing to offer it. This is #191: a post-write Index turn reports
+    /// its progress on this very tracker, and treating that as `!is_ready()`
+    /// sent every MCP caller to the model-setup tools for the duration.
+    #[test]
+    fn rebuilding_is_not_pending_setup() {
+        let tracker = StartupTracker::ready();
+        assert!(!tracker.model_setup_pending());
+
+        tracker.set_scanning();
+        assert!(!tracker.model_setup_pending());
+        assert!(
+            !tracker.collection_indexes_ready(),
+            "still not Ready, just not a setup problem"
+        );
+
+        tracker.set_indexing(IndexingProgressSnapshot::default());
+        assert!(!tracker.model_setup_pending());
+    }
+
+    /// `Unavailable` is not one condition: a failed index and a registry
+    /// awaiting operator recovery both land here, and neither is answered by
+    /// accepting a model licence. Only the error code tells them apart.
+    #[test]
+    fn unavailable_for_a_non_setup_reason_is_not_pending_setup() {
+        let tracker = StartupTracker::ready();
+        tracker.set_failed();
+        assert!(!tracker.model_setup_pending());
+
+        tracker.runtime().set_unavailable(
+            "startup_recovery_required",
+            "Startup recovery is required before Vaults can be activated",
+        );
+        assert!(!tracker.model_setup_pending());
     }
 }

--- a/src/vault_executor/tests.rs
+++ b/src/vault_executor/tests.rs
@@ -1788,7 +1788,7 @@ async fn publish_outcome_moves_startup_readiness_with_the_collections_index_turn
         VaultSearchStatus::Ready
     );
     assert!(
-        !executor.startup.is_ready(),
+        !executor.startup.collection_indexes_ready(),
         "one indexed Vault out of two must not make the collection ready"
     );
     assert!(
@@ -1804,7 +1804,7 @@ async fn publish_outcome_moves_startup_readiness_with_the_collections_index_turn
     );
     second_turn.result.expect("second Index turn succeeds");
     assert!(
-        executor.startup.is_ready(),
+        executor.startup.collection_indexes_ready(),
         "startup becomes ready once every active Vault's Index turn settled Ready"
     );
     assert!(
@@ -1823,7 +1823,7 @@ async fn publish_outcome_moves_startup_readiness_with_the_collections_index_turn
         )),
     });
     assert!(
-        executor.startup.is_ready(),
+        executor.startup.collection_indexes_ready(),
         "an embedder_not_ready deferral is not an indexing failure"
     );
 
@@ -1838,7 +1838,7 @@ async fn publish_outcome_moves_startup_readiness_with_the_collections_index_turn
         )),
     });
     assert!(
-        !executor.startup.is_ready(),
+        !executor.startup.collection_indexes_ready(),
         "a real Index failure fails startup"
     );
     assert!(!model_setup_started.load(Ordering::Acquire));
@@ -1865,7 +1865,7 @@ async fn publish_outcome_moves_startup_readiness_with_the_collections_index_turn
         )),
     });
     assert!(
-        executor.startup.is_ready(),
+        executor.startup.collection_indexes_ready(),
         "readiness is an Index-turn conclusion only"
     );
 }


### PR DESCRIPTION
Closes #191.

## The bug

`StartupTracker`'s phase answers two unrelated questions with one field:

1. Where has first-run model setup got to?
2. How far along is the Index turn running right now?

`VaultWorkExecutor` writes the second into it on every Index turn, through the progress callback in `src/vault_executor.rs`. So an instance whose model setup completed months ago leaves `Ready` for `Indexing` several times a minute in a write-heavy session.

Three callers read that field as question 1. The MCP tool gate therefore answered every post-write reindex with "Hatchdoor is still being set up", naming terms tools that could change nothing — and a client that followed the advice met a second, differently wrong answer, "a search model setup is already active". Two failed calls to discover the Vault was merely reindexing.

The browser UI was never affected, because `handlers/` does not consult this signal. Only the MCP surface did.

## The fix

Ask `model_setup_pending()` instead of whether the collection's indexes are settled. It is true only for a pending terms choice, a download in flight, or a failed setup, distinguished from other `Unavailable` reasons by error code. Scanning and indexing fall through to the Vault-scoped cores, which report a rebuilding Vault per Vault and accurately through `VaultSearchStatus` — the two-axis split the per-Vault layer already had and the instance-wide tracker lacked.

Also in scope:

- `is_ready()` becomes `collection_indexes_ready()`, so the field stops inviting the question it cannot answer. No behaviour change; `/ready` keeps its current semantics.
- The MCP `initialize` handshake had the same conflation: a client connecting mid-reindex was handed first-run setup instructions.
- The rejection is now logged. It previously reached the client and no server-side record at all, so a session full of them was invisible in `docker logs`.

## Deliberately out of scope

The dual-purpose phase itself. `/api/startup` projects it directly into `state: "indexing"` plus the progress fields, and the frontend branches on that, so separating the two axes means building a replacement channel and rewiring the UI together. #201 tracks it, including the one latent reader left behind: `readiness_handler` still returns 503 for the duration of every reindex, harmless today only because the container healthcheck probes `/health` instead.

## Testing

Regression coverage added at the seam that reproduced the report — full-stack JSON-RPC `tools/call` against an indexed Vault with the phase set to `Indexing`. Verified failing before the fix with the reported message byte-for-byte, across `get_note`, `search_notes`, `resolve_wikilink`, `get_tree` and `edit_note`, with `list_vaults` as the passing control. A second test pins the terms tools staying unreachable, and `startup.rs` unit tests pin every phase against `model_setup_pending`.

Post-rebase on `eefa0e7`: `cargo test --all --all-features` (917 passed), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `node scripts/check-module-map.mjs`. All clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kRUWXQ9mx7RxW68PZH3Rz
