### PR TITLE
docs(agents): require a branch off development for all work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,30 @@ It checks uniform lightness per theme, the chroma ceilings, and 4.5:1 contrast
 on the tinted and badge surfaces, and exits non-zero on a violation. No
 dependencies.
 
+## Branching
+
+All work happens on a branch off `development`. Never commit to `development`
+or `main` directly, whatever the size of the change.
+
+Before the first edit, check the current branch and cut one if you are sitting
+on a protected branch:
+
+```bash
+git branch --show-current
+git switch -c <prefix>/<short-slug> development
+```
+
+Use `feature/`, `fix/`, `docs/`, or `refactor/` as the prefix. Push that branch
+and open a pull request against `development`; `main` is the release branch and
+receives only merges from `development`.
+
+`development` refuses a direct push, so cutting the branch after the work is
+committed means moving commits off a branch you cannot push, not a quick fix.
+Check first.
+
+Every merge is a merge commit, including `development` into `main`. Do not
+squash, do not rebase-merge, and never force-push `development` or `main`.
+
 ## Documentation freshness before merging into `development`
 
 Merging work into `development` requires a documentation freshness review. Run:


### PR DESCRIPTION
## Why

`AGENTS.md` documented the gates for merging *into* `development` but never said where work *starts*. The branch rule lived only in `CONTRIBUTING.md`, which is addressed to outside contributors and which agents do not read. The result: 61 non-merge commits landed directly on `development` over the last three months, against 11 merges.

The built-in "branch first" behaviour in agent harnesses keys off the repository's default branch, which here is `main`. Sitting on `development` therefore never trips it.

## What changed

A `## Branching` section in `AGENTS.md`, placed immediately above the documentation-freshness section so the two merge-related rules sit together. It states the branch prefixes, tells the reader to check `git branch --show-current` before the first edit rather than at commit time, and records that every merge is a merge commit.

## Enforcement applied alongside this

Settings changes on `BatterWorks/Hatchdoor`, so the written rule and the enforced one agree:

- `development` now requires a pull request (0 required approvals, `enforce_admins` on, force-pushes disabled). Direct pushes are rejected.
- `allow_rebase_merge` disabled. With squash already off, `merge_commit` is the only remaining merge method.

## Validation

`just docs-freshness` passes: no user-facing surface changed.

This PR is itself the first change through the new gate.