### PR TITLE
ci(release): require pull requests into main to come from development

### DIFF
--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -1,0 +1,26 @@
+name: Release source
+
+# `main` is the release branch: it receives merges from `development` and
+# nothing else. Branch protection matches on the base branch only and cannot
+# constrain which branch a pull request comes from, so this check does it.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  from-development:
+    name: from-development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Head branch must be development
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "development" ]; then
+            echo "::error::Pull requests into main must come from development. This one comes from '$HEAD_REF'. Merge the work into development first, then release development into main."
+            exit 1
+          fi
+          echo "Head branch is development."


### PR DESCRIPTION
## Why

`main` and `development` both now require a pull request, but GitHub branch protection matches on the **base** branch only. It cannot constrain which branch a pull request comes *from*. So a feature branch could be opened straight against `main` and would satisfy every rule currently in place, bypassing `development` entirely.

This is the last gap in the branch discipline established in #203.

## What changed

`.github/workflows/release-source.yml`, the repository's first workflow. It runs on pull requests targeting `main` and fails unless the head branch is `development`.

Deliberately minimal: no checkout, `permissions: {}` so the token grants nothing, and `github.head_ref` passed through `env` rather than interpolated into the shell, since branch names are attacker-controlled in the fork case.

## Follow-up after merge

`from-development` gets added as a required status check on `main`. It is not required yet, because the workflow has to exist on `development` first for the `pull_request` event to pick it up.

## Validation

YAML parses, job context resolves to `from-development`, `just docs-freshness` clean.