### PR TITLE
fix(vault): activate read-only mounts that answer EROFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@
   layer; only the MCP surface guarded against it, and both surfaces now share
   one implementation. Editing a marker file you already have on disk is
   unaffected — this is about creating one through the API.
+- **A Vault on a read-only mount now activates instead of failing.** A Docker
+  bind mount made read-only with `:ro` answers the write-access probe with
+  `EROFS`, which Hatchdoor reported as `vault_path_unavailable` rather than
+  recognising as read-only; only a permission-denied answer was treated that
+  way. Such a Vault now comes up `active` with read-only content, browsable and
+  indexable, with mutations refused as they already were for any other
+  non-writable Vault. A path that is genuinely unreachable still surfaces as
+  unavailable.
 
 ## v2.5.0 - 2026-08-17
 

--- a/src/vault_runtime.rs
+++ b/src/vault_runtime.rs
@@ -1634,35 +1634,7 @@ fn directory_is_writable(
     if result == 0 {
         return Ok(true);
     }
-    let error = std::io::Error::last_os_error();
-    if refuses_writes(&error) {
-        Ok(false)
-    } else {
-        Err(VaultRuntimeError {
-            code: "vault_path_unavailable".to_string(),
-            message: format!(
-                "Vault path '{}' availability check failed: {error}",
-                vault_path.display()
-            ),
-            retryable: true,
-            detail: None,
-        })
-    }
-}
-
-/// Does this `faccessat` failure mean "the Vault is present but refuses
-/// writes", rather than "the Vault is unreachable"?
-///
-/// Issue #178: a Docker `:ro` bind mount answers the `W_OK` probe with `EROFS`,
-/// not `EACCES`. Both mean the same thing to us - browse and index the Vault,
-/// refuse mutations - so both must classify as read-only. Every other errno is
-/// a genuinely unavailable path and keeps propagating.
-#[cfg(unix)]
-fn refuses_writes(error: &std::io::Error) -> bool {
-    matches!(
-        error.kind(),
-        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
-    )
+    classify_write_probe_failure(vault_path, &std::io::Error::last_os_error())
 }
 
 #[cfg(not(unix))]
@@ -1671,6 +1643,36 @@ fn directory_is_writable(
     metadata: &std::fs::Metadata,
 ) -> Result<bool, VaultRuntimeError> {
     Ok(!metadata.permissions().readonly())
+}
+
+/// Did the `W_OK` probe fail because the Vault is present but refuses writes,
+/// or because it is unreachable? The former is `Ok(false)`, which
+/// `directory_content_status` turns into `LocalContentStatus::ReadOnly`; the
+/// latter keeps surfacing as an unavailable path.
+///
+/// Issue #178: a Docker `:ro` bind mount answers the probe with `EROFS`, not
+/// `EACCES`. Both mean the same thing to us - browse and index the Vault,
+/// refuse mutations - so both must classify as read-only.
+#[cfg(unix)]
+fn classify_write_probe_failure(
+    vault_path: &Path,
+    error: &std::io::Error,
+) -> Result<bool, VaultRuntimeError> {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+    ) {
+        return Ok(false);
+    }
+    Err(VaultRuntimeError {
+        code: "vault_path_unavailable".to_string(),
+        message: format!(
+            "Vault path '{}' availability check failed: {error}",
+            vault_path.display()
+        ),
+        retryable: true,
+        detail: None,
+    })
 }
 
 fn disabled_snapshot(definition: &VaultDefinition) -> CollectionVaultSnapshot {

--- a/src/vault_runtime.rs
+++ b/src/vault_runtime.rs
@@ -1635,7 +1635,7 @@ fn directory_is_writable(
         return Ok(true);
     }
     let error = std::io::Error::last_os_error();
-    if error.kind() == std::io::ErrorKind::PermissionDenied {
+    if refuses_writes(&error) {
         Ok(false)
     } else {
         Err(VaultRuntimeError {
@@ -1648,6 +1648,21 @@ fn directory_is_writable(
             detail: None,
         })
     }
+}
+
+/// Does this `faccessat` failure mean "the Vault is present but refuses
+/// writes", rather than "the Vault is unreachable"?
+///
+/// Issue #178: a Docker `:ro` bind mount answers the `W_OK` probe with `EROFS`,
+/// not `EACCES`. Both mean the same thing to us - browse and index the Vault,
+/// refuse mutations - so both must classify as read-only. Every other errno is
+/// a genuinely unavailable path and keeps propagating.
+#[cfg(unix)]
+fn refuses_writes(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+    )
 }
 
 #[cfg(not(unix))]

--- a/src/vault_runtime/tests.rs
+++ b/src/vault_runtime/tests.rs
@@ -2744,3 +2744,37 @@ async fn an_in_process_edit_keeps_a_backoff_status_instead_of_the_remembered_tur
          remembered non-retryable one"
     );
 }
+
+/// Issue #178: a Docker `:ro` bind mount answers the `W_OK` probe with `EROFS`,
+/// not `EACCES`. Treating only `EACCES` as read-only made such a Vault fail
+/// activation with `vault_path_unavailable`. Both errnos mean "present but not
+/// writable"; anything else stays a genuine failure.
+///
+/// This pins the errno classification directly - the `chmod 0555` coverage in
+/// `read_only_and_stale_statuses_keep_usable_local_markdown_honest` only ever
+/// produces `EACCES`, so it cannot catch this.
+#[cfg(unix)]
+#[test]
+fn read_only_filesystem_is_a_read_only_vault_not_an_unavailable_one() {
+    let read_only_filesystem = std::io::Error::from_raw_os_error(libc::EROFS);
+    assert_eq!(
+        read_only_filesystem.kind(),
+        std::io::ErrorKind::ReadOnlyFilesystem,
+        "EROFS must map to ReadOnlyFilesystem for the classification to hold"
+    );
+    assert!(
+        refuses_writes(&read_only_filesystem),
+        "a read-only mount is browsable, not unavailable"
+    );
+
+    assert!(refuses_writes(&std::io::Error::from_raw_os_error(
+        libc::EACCES
+    )));
+
+    for genuinely_unavailable in [libc::ENOENT, libc::ENOTDIR, libc::EIO] {
+        assert!(
+            !refuses_writes(&std::io::Error::from_raw_os_error(genuinely_unavailable)),
+            "errno {genuinely_unavailable} must keep surfacing as an unavailable Vault"
+        );
+    }
+}

--- a/src/vault_runtime/tests.rs
+++ b/src/vault_runtime/tests.rs
@@ -2750,30 +2750,38 @@ async fn an_in_process_edit_keeps_a_backoff_status_instead_of_the_remembered_tur
 /// activation with `vault_path_unavailable`. Both errnos mean "present but not
 /// writable"; anything else stays a genuine failure.
 ///
-/// This pins the errno classification directly - the `chmod 0555` coverage in
-/// `read_only_and_stale_statuses_keep_usable_local_markdown_honest` only ever
-/// produces `EACCES`, so it cannot catch this.
+/// This drives the probe's own failure branch, so it covers the leg no other
+/// test can reach: `read_only_and_stale_statuses_keep_usable_local_markdown_honest`
+/// builds its fixture with `chmod 0555`, which only ever produces `EACCES`, and
+/// a genuine `EROFS` needs a real read-only mount. That test carries the rest of
+/// the chain - `Ok(false)` becoming a browsable `ReadOnly` Vault.
 #[cfg(unix)]
 #[test]
 fn read_only_filesystem_is_a_read_only_vault_not_an_unavailable_one() {
-    let read_only_filesystem = std::io::Error::from_raw_os_error(libc::EROFS);
-    assert_eq!(
-        read_only_filesystem.kind(),
-        std::io::ErrorKind::ReadOnlyFilesystem,
-        "EROFS must map to ReadOnlyFilesystem for the classification to hold"
-    );
-    assert!(
-        refuses_writes(&read_only_filesystem),
-        "a read-only mount is browsable, not unavailable"
-    );
+    let vault_path = std::path::Path::new("/mnt/vault");
 
-    assert!(refuses_writes(&std::io::Error::from_raw_os_error(
-        libc::EACCES
-    )));
+    for not_writable in [libc::EROFS, libc::EACCES] {
+        let writable = classify_write_probe_failure(
+            vault_path,
+            &std::io::Error::from_raw_os_error(not_writable),
+        )
+        .unwrap_or_else(|error| {
+            panic!("errno {not_writable} is browsable, not unavailable: {error:?}")
+        });
+        assert!(
+            !writable,
+            "errno {not_writable} must report a Vault that refuses writes"
+        );
+    }
 
     for genuinely_unavailable in [libc::ENOENT, libc::ENOTDIR, libc::EIO] {
-        assert!(
-            !refuses_writes(&std::io::Error::from_raw_os_error(genuinely_unavailable)),
+        let error = classify_write_probe_failure(
+            vault_path,
+            &std::io::Error::from_raw_os_error(genuinely_unavailable),
+        )
+        .expect_err("an unreachable Vault path must not pass as merely read-only");
+        assert_eq!(
+            error.code, "vault_path_unavailable",
             "errno {genuinely_unavailable} must keep surfacing as an unavailable Vault"
         );
     }


### PR DESCRIPTION
Fixes #178.

## The bug

A Vault on a Docker `:ro` bind mount failed activation with `vault_path_unavailable: Read-only file system (os error 30)`, despite read-only browsing being supported.

`directory_is_writable` probes with `faccessat(W_OK, AT_EACCESS)` and treated only `PermissionDenied` as "present but not writable". A read-only mount answers `EROFS`, not `EACCES`, so the probe fell through to the error branch and the whole Vault was classified `Unavailable`. `activation_snapshot` then reports `Unavailable` and drops the `browse` capability.

## The fix

The probe's failure branch moves into `classify_write_probe_failure`, which accepts `EACCES` and `EROFS` alike. Every other errno still propagates as a genuinely unavailable path, so a missing or broken Vault path is unaffected.

## Verification

Reproduced against a **real** read-only mount rather than a mocked errno, using an unprivileged user namespace with `mount -o remount,ro,bind`, which reproduced the reported error string exactly:

```
activation=Unavailable local_content=Unavailable browse=false
error=vault_path_unavailable: "Read-only file system (os error 30)"
```

After the fix, the same mount gives `activation=Active local_content=ReadOnly browse=true mutate=false`.

A second probe confirmed such a Vault indexes and searches normally (`search=Ready`, `caps search=true`). The index lives in the writable state dir, so read-only content never gated search. Both probes were removed before commit.

## Why it went unnoticed

The existing read-only coverage, `read_only_and_stale_statuses_keep_usable_local_markdown_honest`, builds its fixture with `chmod 0555`, which can only ever produce `EACCES`. Read-only was tested through one mechanism while production supports two.

## The regression test

A real-mount test would need `unshare` and would silently skip where user namespaces are unavailable, which is false confidence. So the test drives `classify_write_probe_failure` directly. That function is the probe's whole failure branch rather than a helper beside it, which matters: an earlier revision of this branch asserted a standalone `refuses_writes` predicate introduced by the fix itself, so it could not fail before the fix (it would fail to compile), and a rewrite of the `faccessat` error handling that stopped consulting it would have left the test green.

The test now pins both legs the issue names: `EROFS` and `EACCES` report a Vault that refuses writes, and `ENOENT`/`ENOTDIR`/`EIO` still surface as `vault_path_unavailable`. Confirmed red against the pre-fix logic, where it fails with the reported error string verbatim:

```
errno 30 is browsable, not unavailable: VaultRuntimeError { code: "vault_path_unavailable",
  message: "Vault path '/mnt/vault' availability check failed: Read-only file system (os error 30)" }
```

The other leg of the chain, `Ok(false)` becoming a browsable `ReadOnly` Vault, stays covered by the existing `chmod 0555` test, so the two meet.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all` (912 + 5) all pass. Docs freshness reviewed and acknowledged for the `vault-lifecycle` surface: the lifecycle note already documents read-only local content as browsable, and no note had drifted.

Not run: `cargo test --all --all-features`, which downloads model weights. This change touches no feature-gated code, but it is worth a run before release for full coverage of the documented gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kRUWXQ9mx7RxW68PZH3Rz
