### PR TITLE
ci(triage): label newly opened issues needs-triage

### DIFF
--- a/.github/workflows/triage-inbox.yml
+++ b/.github/workflows/triage-inbox.yml
@@ -1,0 +1,29 @@
+name: Triage inbox
+
+# Every issue carries one state label saying where it sits in triage. A freshly
+# opened report sits in the inbox, so it gets `needs-triage` here rather than
+# relying on someone remembering.
+#
+# Only issues opened with no labels at all are touched. Tickets published by
+# tooling already arrive with their own state label (`ready-for-agent`), and a
+# second state label would contradict the first.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    name: needs-triage
+    if: ${{ github.event.issue.labels[0] == null }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label the new issue as needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$NUMBER" --repo "$REPO" --add-label needs-triage


### PR DESCRIPTION
Adds a workflow that puts `needs-triage` on every newly opened issue.

An issue that arrives with no labels is sitting in the triage inbox, and saying so should not depend on someone remembering. The label makes the inbox a single reliable query, and tells an outside reporter that their report landed somewhere with a queue rather than in a void.

The job skips any issue opened with labels already on it. Tickets published by tooling arrive carrying `ready-for-agent`, and without that guard they would land with two contradictory state labels on day one.

Uses the built-in workflow token, scoped to `issues: write`. Nothing to configure.

Context: this completes the triage label set. `needs-triage`, `needs-info` and `ready-for-human` were created on the tracker alongside the existing `bug`, `enhancement`, `wontfix` and `ready-for-agent`, so every issue can now carry exactly one category label and one state label.

Only `needs-triage` is automated. Category labels stay manual on purpose: deciding whether a report is a bug or an enhancement is one of the few real judgements in triage, and reporters guess wrong often enough that a form would get it wrong regularly. `ready-for-agent` stays manual because it is a promise that a written brief exists, and a label that can appear without the brief stops meaning anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kRUWXQ9mx7RxW68PZH3Rz