### PR TITLE
docs(troubleshooting): document the two MCP session failures

### DIFF
--- a/docs/user-vault/02 Guides/How to troubleshoot common problems.md
+++ b/docs/user-vault/02 Guides/How to troubleshoot common problems.md
@@ -23,13 +23,18 @@ You bound Hatchdoor to a non-loopback host and it generated one on first start (
 
 ## An agent can't connect over MCP
 
-Three distinct failures, distinguishable by the response:
+Five distinct failures, distinguishable by the response:
 
-- **`404 Not Found` on `/mcp`** — MCP is disabled. Turn on **Let assistants connect (MCP)** in **Settings** → **Agent access (MCP)**.
+- **`404 Not Found` on `/mcp`, with an empty body** — MCP is disabled. Turn on **Let assistants connect (MCP)** in **Settings** → **Agent access (MCP)**. Read the body before acting on a `404`: an empty one means this, and a `404` that *says* something means the next entry instead.
+- **`404 Not Found` whose body reads `Not Found: Session not found`** — MCP is on and the client got in, but the session it is quoting doesn't exist. Either it was never issued, or it was issued before Hatchdoor last restarted. The remedy belongs to the client: it has to run `initialize` again and use the session that comes back.
+- **`422 Unprocessable Entity`, "Unexpected message, expect initialize request"** — the same problem from the other side: the client sent an ordinary call with no session at all. The wording describes what the server was expecting to receive rather than what you should do about it; the remedy is the one above, re-initialize.
 - **`401`, JSON-RPC error `-32001`, "Missing or invalid MCP bearer token"** — the client's `Authorization: Bearer <token>` header doesn't match the current MCP password. Regenerate or re-copy it from Settings; the client and Settings must hold the exact same value.
 - **A write tool (`create_note`, `edit_vault`, etc.) returns "MCP write tools are disabled by HATCHDOOR_MCP_WRITE_ENABLED"** — MCP is connected and reading fine, but **Let assistants change notes** is off. This is a separate toggle from connecting at all; see [[Search and change notes with your agent]] for why that separation exists.
 
-A fourth, less common one: **`403 Forbidden`, "Forbidden MCP origin"** — an `Origin` header was sent that isn't on the allow-list (`HATCHDOOR_MCP_ALLOWED_ORIGINS`). This normally only matters for a browser-based MCP client, not a CLI agent.
+A sixth, less common one: **`403 Forbidden`, "Forbidden MCP origin"** — an `Origin` header was sent that isn't on the allow-list (`HATCHDOOR_MCP_ALLOWED_ORIGINS`). This normally only matters for a browser-based MCP client, not a CLI agent.
+
+> [!note]
+> MCP sessions are held in memory only, so restarting Hatchdoor ends every one of them. A client holding a session finds out on its next call — as the `Session not found` or the `422` above — and has to re-initialize. No Hatchdoor setting keeps sessions across a restart, so a client that keeps retrying the same failing call needs restarting or reconnecting; that lever is yours, not Hatchdoor's. Clients that don't use a session at all are unaffected.
 
 ## Model download is stuck or failed
 


### PR DESCRIPTION
Closes #215.

The troubleshooting guide told readers that a `404` on `/mcp` meant MCP was disabled. That sent anyone hitting the *other* 404 to go turn on a setting that was already on. A second failure was missing entirely.

## What changed

One file, `docs/user-vault/02 Guides/How to troubleshoot common problems.md`. No code, tests, or configuration.

The "An agent can't connect over MCP" list now separates:

- the **disabled** `404`, which has an **empty body**
- `404` with body `Not Found: Session not found` — the session is gone or was never issued
- `422 Unprocessable Entity`, "Unexpected message, expect initialize request" — the call carried no session at all

Both session failures name the same remedy: the client re-runs `initialize`. A callout records that sessions are in-memory only and do not survive a restart, and that no Hatchdoor setting changes this — restarting or reconnecting the client is the operator's lever.

## Verified on the wire

Every documented response was reproduced against a running dev server, not inferred:

| Request | Response |
| --- | --- |
| MCP disabled, valid token | `404`, `content-length: 0` |
| `Mcp-Session-Id` never issued | `404` `Not Found: Session not found` |
| No session id, `tools/list` body | `422` `Unexpected message, expect initialize request` |
| Session that returned `200`, after a restart | `404` `Not Found: Session not found` |

That last row is the restart claim, proven end to end rather than asserted.

Review caught the callout over-claiming: it originally said all connected clients find out on their next call. A session-less client is routed statelessly and is unaffected — confirmed by a session-less request returning `200`. The callout is now scoped to clients that actually hold a session.

## Scope

The responses are rmcp's, not Hatchdoor's. They are described here, not changed or intercepted, per `.out-of-scope/mcp-wire-error-semantics.md` and ADR-17.

`just docs-freshness`, `check-module-map.mjs`, and `check-docs-freshness.mjs --validate-table` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kRUWXQ9mx7RxW68PZH3Rz
