### PR TITLE
fix(shell): let the sidebar grid read the live width off the shell

### DIFF
--- a/frontend/src/clientAuditContracts.test.ts
+++ b/frontend/src/clientAuditContracts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import appCss from "./App.css?raw";
+import appSource from "./App.tsx?raw";
 import graphPageSource from "./components/graph/GraphPage.tsx?raw";
 import notePageSource from "./components/NotePage.tsx?raw";
 import noteContentCss from "./styles/note-content.css?raw";
@@ -106,6 +107,22 @@ describe("client audit launch contracts", () => {
     );
     expect(appCss).toMatch(
       /\.modal-panel\s*{[^}]*max-height:\s*min\(720px,\s*calc\(var\(--visual-viewport-height,\s*100dvh\)/s,
+    );
+  });
+
+  it("lets the sidebar grid read the live --sidebar-width off the shell", () => {
+    // App.tsx sets --sidebar-width inline on `.app-shell`. A local
+    // declaration on `.app-layout` shadows that inherited value, so the
+    // resizer moved only the topbar column (which reads the inherited one)
+    // while the pane stayed pinned at the shadowed default.
+    expect(appSource).toMatch(
+      /app-shell[\s\S]{0,400}?"--sidebar-width":\s*`\$\{sidebarWidth\}px`/,
+    );
+    expect(explorerCss).not.toMatch(
+      /\.app-layout\s*{[^}]*--sidebar-width:\s*\d/s,
+    );
+    expect(explorerCss).toMatch(
+      /\.app-layout\s*{[^}]*grid-template-columns:\s*var\(--sidebar-width,\s*280px\)/s,
     );
   });
 

--- a/frontend/src/styles/layout-explorer.css
+++ b/frontend/src/styles/layout-explorer.css
@@ -1,7 +1,9 @@
+/* The live width comes down as an inline --sidebar-width on `.app-shell`, so
+   the default belongs in the var() fallback here, not in a local declaration
+   that would shadow it and freeze the pane while the resizer moved on. */
 .app-layout {
-  --sidebar-width: 280px;
   display: grid;
-  grid-template-columns: var(--sidebar-width) 8px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 280px) 8px minmax(0, 1fr);
   flex: 1;
   min-height: 0;
   min-width: 0;


### PR DESCRIPTION
## The bug

Dragging the sidebar resizer moved the topbar's first column — the note path — while the explorer pane itself stayed put at 280px.

## Cause

`App.tsx` hands the live width down as an inline `--sidebar-width` on `.app-shell`, but `.app-layout` redeclared the same property:

```css
.app-layout {
  --sidebar-width: 280px;                                   /* shadows the inherited value */
  grid-template-columns: var(--sidebar-width) 8px minmax(0, 1fr);
}
```

A local declaration beats an inherited one, so the grid that sizes the pane never saw the resizer's value. `.app-topbar` is a sibling of that grid rather than a descendant, so it inherited the real value from `.app-shell` and was the only thing that moved.

Measured in the browser before the fix, dragging to the 420px maximum:

```
before: paneWidth 280, shellVar 268px, layoutVar 280px, topbar col 1 268px
after:  paneWidth 280, shellVar 420px, layoutVar 280px, topbar col 1 420px
```

## The fix

Drop the local declaration and put the default in the `var()` fallback, matching how `topbar.css` already consumes the property. The narrow breakpoint in `responsive.css` overrides `grid-template-columns` outright, so mobile is untouched.

After the fix, both input paths:

```
drag  420 -> 300px : paneWidth 300, shellVar 300px, topbar col 1 300px
keys  300 -> 380px : paneWidth 380, shellVar 380px
```

## Regression test

A CSS-source contract in `clientAuditContracts.test.ts`, red before the fix and green after: the inline var lives on `.app-shell`, `.app-layout` never redeclares it, and the grid reads it with a fallback.

It is deliberately not a rendered-layout assertion. jsdom does not resolve `var()` and the frontend has no browser-level harness, so a cascade bug of this shape cannot be caught behaviourally by the suite as it stands. Worth a follow-up if this class of bug recurs.

## Checks

- `vitest run`: 831 passed across 71 files
- `tsc -b`, ESLint, Prettier: clean
- `just docs-freshness`: both Web UI notes read; neither documents sidebar width or the resizer, no drift, review acknowledged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kRUWXQ9mx7RxW68PZH3Rz
