### PR TITLE
fix(write): let attachment moves carry bytes that are not text

### DIFF
--- a/src/vault/write/fs_ops.rs
+++ b/src/vault/write/fs_ops.rs
@@ -547,7 +547,7 @@ pub(super) fn move_file_no_follow(source: &Path, destination: &Path) -> Result<(
             destination.display()
         )));
     }
-    if let Err(error) = read_regular_file_at(&destination_parent, &destination_name) {
+    if let Err(error) = assert_regular_file_at(&destination_parent, &destination_name) {
         restore_move_from_gate(
             &source_parent,
             &source_name,
@@ -739,7 +739,10 @@ fn read_file_at_no_follow(parent: &fs::File, name: &CString) -> Result<String, s
     Ok(content)
 }
 
-fn read_regular_file_at(parent: &fs::File, name: &CString) -> Result<String, std::io::Error> {
+/// Assert the entry is an ordinary file: not a symlink, directory, device
+/// node, or FIFO. This is the whole of the safety property the move guard
+/// needs, and it says nothing about the bytes inside.
+fn assert_regular_file_at(parent: &fs::File, name: &CString) -> Result<(), std::io::Error> {
     let metadata = metadata_at_no_follow(parent, name)?;
     if metadata.st_mode & libc::S_IFMT != libc::S_IFREG {
         return Err(std::io::Error::new(
@@ -747,6 +750,15 @@ fn read_regular_file_at(parent: &fs::File, name: &CString) -> Result<String, std
             "source is not a regular file",
         ));
     }
+    Ok(())
+}
+
+/// The regular-file assertion plus a text read, for the paths that go on to
+/// hash the content as Markdown. Anything that only needs the file to be a
+/// file must call [`assert_regular_file_at`] instead: an attachment is
+/// arbitrary bytes and need not decode as UTF-8 (#220).
+fn read_regular_file_at(parent: &fs::File, name: &CString) -> Result<String, std::io::Error> {
+    assert_regular_file_at(parent, name)?;
     read_file_at_no_follow(parent, name)
 }
 
@@ -809,8 +821,18 @@ fn rename_exchange(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vault::write::tests::BINARY_ASSET;
     use crate::vault::write::types::AssetMove;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        use std::os::unix::ffi::OsStrExt;
+
+        let name = CString::new(path.as_os_str().as_bytes()).expect("fifo path");
+        let result = unsafe { libc::mkfifo(name.as_ptr(), 0o600) };
+        assert_eq!(result, 0, "mkfifo: {}", std::io::Error::last_os_error());
+    }
 
     #[test]
     fn atomic_write_persists_content_and_leaves_no_temp_file() {
@@ -940,6 +962,85 @@ mod tests {
         assert!(source.is_symlink());
         assert!(!destination.exists());
         assert_eq!(fs::read_to_string(&sentinel).unwrap(), "sentinel");
+    }
+
+    #[test]
+    fn move_file_no_follow_moves_bytes_that_are_not_valid_utf8() {
+        // issue #220: an attachment is arbitrary bytes. The post-move guard
+        // exists to prove the moved thing is a regular file, not that it
+        // decodes as text, so a real image or PDF must move unchanged.
+        let dir = tempdir().expect("tempdir");
+        let source = dir.path().join("photo.jpg");
+        let destination = dir.path().join("moved.jpg");
+        fs::write(&source, BINARY_ASSET).expect("source");
+
+        move_file_no_follow(&source, &destination).expect("a binary asset must move");
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(&destination).unwrap(), BINARY_ASSET);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn move_file_no_follow_rejects_a_fifo_source_and_restores_it() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dir = tempdir().expect("tempdir");
+        let source = dir.path().join("asset.png");
+        let destination = dir.path().join("moved.png");
+        make_fifo(&source);
+
+        let error =
+            move_file_no_follow(&source, &destination).expect_err("a FIFO must not be moved");
+
+        assert!(matches!(error, WriteError::Conflict(_)));
+        assert!(
+            fs::symlink_metadata(&source)
+                .expect("fifo metadata")
+                .file_type()
+                .is_fifo(),
+            "the refused source must be restored as it was"
+        );
+        assert!(!destination.exists());
+    }
+
+    #[test]
+    fn mutation_journal_restores_binary_asset_bytes_when_a_later_move_fails() {
+        // issue #220: rollback replays the same move primitive, so the bytes
+        // of an asset already moved by an earlier step must survive the round
+        // trip when a later step of the same mutation fails.
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        let binary = root.join("photo.jpg");
+        let sibling = root.join("notes.txt");
+        fs::write(&binary, BINARY_ASSET).expect("binary asset");
+        fs::write(&sibling, "text asset").expect("text asset");
+        let dst_dir = root.join("dst");
+        fs::create_dir(&dst_dir).expect("dst dir");
+
+        let mut journal = MutationJournal::new(root);
+        journal
+            .move_file(MutationPhase::Asset, &binary, &dst_dir.join("photo.jpg"))
+            .expect("binary asset move");
+        // The second asset's destination parent does not exist, so its move
+        // fails deterministically after the first has committed.
+        let cause = journal
+            .move_file(
+                MutationPhase::Asset,
+                &sibling,
+                &root.join("missing_dir").join("notes.txt"),
+            )
+            .expect_err("the later move must fail");
+        let error = journal.rollback(cause);
+
+        assert!(matches!(error, WriteError::Io(_)));
+        assert_eq!(
+            fs::read(&binary).expect("restored asset"),
+            BINARY_ASSET,
+            "rollback must restore the original bytes"
+        );
+        assert!(!dst_dir.join("photo.jpg").exists());
+        assert_eq!(fs::read_to_string(&sibling).unwrap(), "text asset");
     }
 
     #[test]

--- a/src/vault/write/tests.rs
+++ b/src/vault/write/tests.rs
@@ -975,6 +975,187 @@ fn delete_note_does_not_move_already_trashed_attachment_again() {
     assert!(root.join(".hatchdoor-trash/Notes/Target.md").exists());
 }
 
+/// A short JPEG header followed by bytes that are not valid UTF-8, standing in
+/// for a real image the way the ASCII `"png"` fixtures never did (#220). Shared
+/// with the `fs_ops` tests so both levels exercise the same bytes.
+pub(super) const BINARY_ASSET: &[u8] = &[
+    0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0x00, 0x01, 0xFE, 0xFF, 0x80,
+];
+
+#[test]
+fn move_attachment_carries_bytes_that_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Media")).expect("media");
+    fs::write(root.join("Media/photo.jpg"), BINARY_ASSET).expect("asset");
+    fs::write(root.join("Note.md"), "![](Media/photo.jpg)").expect("note");
+    let index = build(root);
+
+    move_attachment(root, &index, "Media/photo.jpg", "Archive/photo.jpg").expect("move attachment");
+
+    assert!(!root.join("Media/photo.jpg").exists());
+    assert_eq!(
+        fs::read(root.join("Archive/photo.jpg")).expect("moved asset"),
+        BINARY_ASSET
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("Note.md")).expect("note"),
+        "![](Archive/photo.jpg)"
+    );
+}
+
+#[test]
+fn rename_attachment_keeps_bytes_that_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Media")).expect("media");
+    fs::write(root.join("Media/photo.jpg"), BINARY_ASSET).expect("asset");
+    fs::write(root.join("Note.md"), "![](Media/photo.jpg)").expect("note");
+    let index = build(root);
+
+    rename_attachment(root, &index, "Media/photo.jpg", "cover.jpg").expect("rename attachment");
+
+    assert!(!root.join("Media/photo.jpg").exists());
+    assert_eq!(
+        fs::read(root.join("Media/cover.jpg")).expect("renamed asset"),
+        BINARY_ASSET
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("Note.md")).expect("note"),
+        "![](Media/cover.jpg)"
+    );
+}
+
+#[test]
+fn delete_attachment_trashes_bytes_that_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Media")).expect("media");
+    fs::write(root.join("Media/photo.jpg"), BINARY_ASSET).expect("asset");
+    fs::write(root.join("Note.md"), "![](Media/photo.jpg)").expect("note");
+    let index = build(root);
+
+    let outcome = delete_attachment(root, &index, "Media/photo.jpg").expect("delete attachment");
+
+    let trashed = outcome.trashed_path.expect("trash path");
+    assert!(!root.join("Media/photo.jpg").exists());
+    assert_eq!(
+        fs::read(root.join(&trashed)).expect("trashed asset"),
+        BINARY_ASSET
+    );
+}
+
+#[test]
+fn move_note_carries_a_sibling_asset_whose_bytes_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::write(root.join("Notes/Target.md"), "body\n![](photo.jpg)").expect("target");
+    fs::write(root.join("Notes/photo.jpg"), BINARY_ASSET).expect("asset");
+    fs::write(root.join("Backlink.md"), "![](Notes/photo.jpg) [[Target]]").expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    let outcome = move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Renamed.md",
+        &content_hash("body\n![](photo.jpg)"),
+    )
+    .expect("move a note holding a binary attachment");
+
+    assert_eq!(outcome.moved_assets, 1);
+    assert!(root.join("Archive/Renamed.md").exists());
+    assert_eq!(
+        fs::read(root.join("Archive/photo.jpg")).expect("moved asset"),
+        BINARY_ASSET
+    );
+    let backlink = fs::read_to_string(root.join("Backlink.md")).expect("backlink");
+    assert!(backlink.contains("![](Archive/photo.jpg)"));
+    assert!(backlink.contains("[[Archive/Renamed]]"));
+}
+
+/// A note in `Notes/` holding one attachment whose bytes are not valid UTF-8.
+fn note_with_a_binary_asset(root: &Path) {
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::write(root.join("Notes/Target.md"), BINARY_ASSET_NOTE).expect("target");
+    fs::write(root.join("Notes/photo.jpg"), BINARY_ASSET).expect("asset");
+}
+
+const BINARY_ASSET_NOTE: &str = "body ![](photo.jpg)";
+
+#[test]
+fn archive_note_carries_an_asset_whose_bytes_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    note_with_a_binary_asset(root);
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    archive_note(
+        root,
+        &index,
+        entry,
+        "90-archive/",
+        &content_hash(BINARY_ASSET_NOTE),
+    )
+    .expect("archive a note holding a binary attachment");
+
+    assert!(!root.join("Notes/photo.jpg").exists());
+    assert_eq!(
+        fs::read(root.join("90-archive/photo.jpg")).expect("archived asset"),
+        BINARY_ASSET
+    );
+}
+
+#[test]
+fn delete_note_trashes_an_asset_whose_bytes_are_not_valid_utf8() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    note_with_a_binary_asset(root);
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    delete_note(root, &index, entry, &content_hash(BINARY_ASSET_NOTE))
+        .expect("delete a note holding a binary attachment");
+
+    assert!(!root.join("Notes/photo.jpg").exists());
+    assert_eq!(
+        fs::read(root.join(".hatchdoor-trash/photo.jpg")).expect("trashed asset"),
+        BINARY_ASSET
+    );
+}
+
+#[test]
+fn move_note_reports_a_stale_hash_as_a_changed_note_not_an_unsafe_source() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::write(root.join("Notes/Target.md"), "body").expect("target");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    let error = move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Target.md",
+        &content_hash("something else"),
+    )
+    .expect_err("a stale hash must refuse the move");
+
+    let WriteError::Conflict(message) = error else {
+        panic!("expected a conflict");
+    };
+    assert!(
+        message.contains("note changed since it was read"),
+        "the optimistic-concurrency failure must stay distinct from an unsafe source: {message}"
+    );
+    assert!(root.join("Notes/Target.md").exists());
+    assert!(!root.join("Archive/Target.md").exists());
+}
+
 #[test]
 fn note_move_compensates_failures_after_every_completed_phase() {
     use super::types::MutationPhase;


### PR DESCRIPTION
Closes #220.

`move_attachment` could not move any binary file, and `move_note` failed for any note referencing binary siblings, both with `write_conflict: refusing to move unsafe source '<path>': stream did not contain valid UTF-8`.

## The cause

The post-move guard on an asset move called `read_regular_file_at`, which did two things at once: check `S_IFREG`, then read the file into a `String`. The second half succeeds only on valid UTF-8. Any real image, PDF, or archive failed it, the caller treated every read error as an unsafe source, and the move rolled back. Since every asset move funnels through that one primitive, the blast radius was wider than the title: a note holding a real image could not be moved, renamed, archived, or deleted, and the image itself could not be moved, renamed, or trashed.

## The fix

Split the two responsibilities. `assert_regular_file_at` carries the symlink and special-file refusal on its own; `read_regular_file_at` keeps the text read for the two callers that genuinely hash content as Markdown — the conditional note move and the atomic-write compare-and-swap. The asset move now asserts only that it moved an ordinary file.

No signature, error variant, or serialized field changed, and the change is contained to `src/vault/write/`.

## Why the suite was green

Every attachment fixture wrote the ASCII string `"png"` or `"pdf"` into a file named `.png` or `.pdf`. Valid UTF-8, so they sailed through the broken check. The new fixtures carry real binary bytes.

Seven new tests fail before the fix and pass after: the asset move primitive, a rollback where a later asset move fails after a binary asset has already committed, the three attachment tools, a note move carrying a binary sibling, and archive/delete note. Two more cover previously untested ground rather than a break: a FIFO source refusal beside the existing symlink one, and proof that a stale-hash note move still reports "note changed since it was read" rather than an unsafe source.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` (941 passed), `cargo test --all --all-features` (947 passed), and the documentation freshness review, acknowledged after reading the notes it named plus the attachments guide — none of which documented the refusal.

Live acceptance ran against a dev instance over MCP with a real 241-byte PNG, byte-compared against the source fixture after every step: import, move, rename, note move carrying the sibling, delete-attachment, archive-note, delete-note all preserved the bytes exactly. A symlink source is still refused, source restored and destination absent, now reporting `source is not a regular file` — the honest reason it was always refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxmw8c7iZbgaahcze7DWvW
