### PR TITLE
fix(scripts): summon the attachments guide for attachment mutations

### DIFF
--- a/scripts/check-docs-freshness.mjs
+++ b/scripts/check-docs-freshness.mjs
@@ -122,8 +122,16 @@ const SURFACES = [
   },
   {
     id: "attachments",
-    label: "Attachment import and serving",
-    paths: ["src/vault_read/assets.rs", "src/handlers/assets.rs"],
+    label: "Attachment import, serving, and mutation",
+    // The mutation half matters as much as import and serving: the guide
+    // documents move_attachment, rename_attachment, and delete_attachment,
+    // and without this path a change to them summoned only the note-mutation
+    // reading list (#220).
+    paths: [
+      "src/vault_read/assets.rs",
+      "src/handlers/assets.rs",
+      "src/vault/write/attachments.rs",
+    ],
     notes: [`${GUIDES}/How to import and work with attachments.md`],
   },
   {

--- a/scripts/check-docs-freshness.test.mjs
+++ b/scripts/check-docs-freshness.test.mjs
@@ -15,13 +15,17 @@ const temporaryRepositories = [];
 const MCP_NOTE = "docs/user-vault/03 Reference/MCP tools reference.md";
 const UI_NOTE =
   "docs/user-vault/01 Get started/Browse and review through the Web UI.md";
+const ATTACHMENTS_NOTE =
+  "docs/user-vault/02 Guides/How to import and work with attachments.md";
 
-// Every note the mcp-tools and web-ui surfaces name. The script refuses to
-// print a reading list containing a file it cannot open, so a fixture that
-// triggers a surface must carry that surface's whole note set.
+// Every note the mcp-tools, web-ui, attachments, and write-mutations surfaces
+// name. The script refuses to print a reading list containing a file it cannot
+// open, so a fixture that triggers a surface must carry that surface's whole
+// note set.
 const FIXTURE_NOTES = [
   MCP_NOTE,
   UI_NOTE,
+  ATTACHMENTS_NOTE,
   "docs/user-vault/01 Get started/Connect your agent.md",
   "docs/user-vault/01 Get started/Search and change notes with your agent.md",
   "docs/user-vault/02 Guides/How to edit notes with the live editor.md",
@@ -167,6 +171,21 @@ test("one change can require several surfaces' notes", async () => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /MCP tools reference\.md/);
   assert.match(result.stderr, /Browse and review through the Web UI\.md/);
+});
+
+// Attachment mutation lives under src/vault/write/, so it already triggered
+// the note-mutation surface. What it did not do was summon the guide that
+// actually documents move_attachment, rename_attachment, and delete_attachment
+// (#220), which left that guide free to drift.
+test("an attachment mutation change names the attachments guide too", async () => {
+  const root = await fixture();
+  await write(root, "src/vault/write/attachments.rs", "// move an asset\n");
+  await commit(root, "attachment mutation");
+
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /How to import and work with attachments\.md/);
+  assert.match(result.stderr, /MCP tools reference\.md/);
 });
 
 // The regression that motivated `-z`: `git status --porcelain` c-quotes any


### PR DESCRIPTION
Follow-up to #220, found while fixing it.

The documentation freshness table's `attachments` surface listed only the import and serving paths (`src/vault_read/assets.rs`, `src/handlers/assets.rs`). A change to `move_attachment`, `rename_attachment`, or `delete_attachment` therefore never named the guide that documents them.

Such a change did trip the gate — attachment mutation lives under `src/vault/write/`, which the note-mutation surface covers — but the reading list it handed over was the two note-mutation notes. The gate looked like it had done its job while leaving `How to import and work with attachments.md` free to drift. That is exactly what happened on #220.

## The change

Add `src/vault/write/attachments.rs` to that surface and widen the label to match. A file may match several surfaces, so an attachment mutation now names both reading lists rather than trading one for the other.

The accompanying test changes an attachment-mutation file and asserts both the attachments guide and the MCP tools reference appear. It fails with the table entry reverted and passes with it in place.

## Validation

`node --test scripts/check-docs-freshness.test.mjs` (19 passed), `node scripts/check-docs-freshness.mjs --validate-table` (15 surfaces, 22 notes all resolve), and `node scripts/check-module-map.mjs`. This branch's own freshness run is clean — the script is not itself a user-facing surface. No Rust or frontend code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxmw8c7iZbgaahcze7DWvW
