### PR TITLE
fix(index): hold the mutation guard for the read phase only

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -174,7 +174,15 @@ that production inventory are still checked for stale paths and duplicates.
   acceptance, publishes its cancellation signal, and stops its watcher,
   including through already-held handles; retirement waits for both its active
   coordinator turn and any already-admitted foreground mutation to reach their
-  safe boundaries. Unchanged Vaults retain their control blocks when another
+  safe boundaries. The mutation lock also carries a per-Vault count of the
+  foreground mutations that have taken it. `acquire_mutation` advances it under
+  the lock; `acquire_mutation_for_index_reads` gives a background Index turn the
+  same exclusion without advancing it, and returns the generation it observed;
+  `blocking_retake_mutation_for_index` retakes the lock from a blocking thread
+  and answers whether a mutation intervened, under that one acquisition, so the
+  caller decides and acts without a window in between (issue #223, following the
+  `request_if_idle` rule of issue #127). The count is never readable outside a
+  holder of that lock, which is the only place its value means anything. Unchanged Vaults retain their control blocks when another
   definition changes; disabled definitions remain visible with no capabilities
   and no active runtime.
 - `ModelSetup` owns local model selection, terms acceptance, download integrity,
@@ -329,7 +337,25 @@ small public surface — no trait, no framework, no second execution lane.
   for semantic search, atomically publishes only that Vault's complete shared
   snapshot, and publishes Ready, Stale, or Unavailable search state without
   changing another Vault's snapshot or status. A retained snapshot is marked
-  stale for the duration of the rebuild, not only after a failure. A turn
+  stale for the duration of the rebuild, not only after a failure.
+  The foreground mutation guard spans the read phase only — the authoritative
+  scan, the structure pass, and every per-note content read — so a turn can
+  never observe half of a multi-file foreground mutation, and is released at
+  the read/embed boundary inside the candidate build. Holding it across the
+  embedding pass parked every HTTP and MCP Markdown write behind a turn that
+  was no longer reading anything, long enough for the caller's transport to
+  give up on a write that had already landed (issue #223). The turn retakes
+  the guard to publish and, when a foreground mutation completed while it was
+  released, publishes that generation `VaultSnapshotFreshness::Stale` rather
+  than `Fresh` and settles the runtime at `VaultSearchStatus::Stale` rather than
+  `Ready` — the same pair `retained_snapshot_search_status` derives from that
+  row after a restart. It still participates, still holds the search
+  capability, and still answers search; the watcher's change intent has already
+  armed the catch-up turn that makes it `Ready`. Retaking the guard happens
+  while the cache's process-wide model epoch is held, so that acquisition is
+  the one place the epoch waits on a per-Vault lock; the wait is bounded by one
+  in-flight foreground mutation, and no mutation path takes the epoch, so the
+  order cannot cycle. A turn
   requested before first-run model setup has installed the embedder defers
   with `embedder_not_ready` rather than wiping a valid cache.
 - `dispatch_git_turn` executes a `VaultWorkKind::Git` turn. One shared
@@ -395,7 +421,9 @@ the loop that calls it.
 
 **Invariants:** one turn observes one settings snapshot; every Git turn exit
 publishes through one path; the mutation lock is never acquired before the
-checkout lease; a returned failure is the turn's result, not a panic; no turn
+checkout lease; an Index turn holds the foreground mutation guard across every
+read it makes of the Vault and publishes a generation built across a foreground
+mutation as stale; a returned failure is the turn's result, not a panic; no turn
 starts a second execution lane or its own scheduler.
 
 **Validation:** `cargo test vault_executor`, `cargo test vault_work`,
@@ -1197,7 +1225,12 @@ the scope-less stats, explorer-tree, recently-modified, read-by-path,
 demoted-layer, note-summary, health-check, graph, and layered/filtered
 search variants are retired. The crate-private
 `vault_snapshots` seam owns Vault-ID-qualified candidate publication,
-stale/participation state, attempt ordering, and Vault-local disposal in the shared cache. `parse` is currently public and
+stale/participation state, attempt ordering, and Vault-local disposal in the
+shared cache. Publication carries the caller's freshness verdict rather than
+assuming `Fresh`, and `MutationGuardHandoff` is how an Index turn hands its
+Vault read lock through a build: released at the read/embed boundary, retaken
+to answer that verdict under one acquisition with the publication it labels
+(issue #223). `parse` is currently public and
 also supplies parsing/hash behavior to vault indexing, and its
 `frontmatter_span`/`parse_frontmatter_metadata` parsing to the shared write
 layer's frontmatter merge. The crate-private

--- a/docs/user-vault/04 Concepts/Vault lifecycle states.md
+++ b/docs/user-vault/04 Concepts/Vault lifecycle states.md
@@ -32,7 +32,7 @@ Once a Vault is enabled, Hatchdoor tracks its condition on five separate axes ra
 - `indexing` — actively building; nothing usable yet for this axis.
 - `browsable` — a real, load-bearing state, not a typo for "ready." The Vault's structure (notes, links, headings) is published and current, but this generation has no vectors yet. You can open and read every note; semantic search returns nothing. This is reached once, on a Vault's very first successful index, between the structure pass and the embedding pass — a later rebuild of an already-searchable Vault never regresses through it, it just keeps serving the prior generation while the rebuild runs.
 - `ready` — fully current, structure and vectors both.
-- `stale` — a prior generation is still being served (so search still works) while a newer build is in progress or the last build failed; not an error by itself, just "what you're seeing might be a build behind."
+- `stale` — search still works, but what it answers from is a build behind. Three ways to get here: a newer build is in progress, the last build failed, or a note was written *during* the build that just finished, so the generation it published was already behind the moment it landed. That last one is normal during a bulk edit or migration — every write arms the next reindex, and the Vault settles on `ready` once the writing stops. Not an error by itself, just "what you're seeing might be a build behind."
 
 ## What capabilities actually come from
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod vault_snapshots;
 
 pub(crate) use schema::is_recognized_legacy_cache;
 
+pub(crate) use populate::BuildHandles;
 pub use populate::BuildOptions;
 pub use queries::SemanticHit;
 use std::collections::BTreeMap;

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -56,6 +56,20 @@ impl Default for BuildOptions {
     }
 }
 
+/// What one *running* build's caller hands it beyond the index and options:
+/// where to report progress, and the Vault lock it holds only while the build
+/// is still reading Markdown from disk.
+#[derive(Default)]
+pub(crate) struct BuildHandles {
+    pub(crate) on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
+    /// The Index turn's foreground mutation guard, dropped the moment the last
+    /// note's content is in memory, so a foreground writer does not wait out
+    /// the embedding pass that follows (issue #223). Everything past that point
+    /// is in-memory work and SQLite writes to this cache; nothing downstream
+    /// opens a Vault path. `None` for a caller holding no such lock.
+    pub(crate) vault_read_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
 pub enum UpsertOutcome {
     /// The note row was written; `content` is the file text already read (and
     /// hashed) during the upsert, threaded on so chunking reuses it instead of
@@ -104,7 +118,10 @@ impl SqliteCache {
         self.replace_with_options(
             index,
             embedder,
-            on_progress,
+            BuildHandles {
+                on_progress,
+                ..BuildHandles::default()
+            },
             embed_layers,
             &BuildOptions::default(),
         )
@@ -118,7 +135,7 @@ impl SqliteCache {
         embedder: &dyn Embedder,
         opts: &BuildOptions,
     ) -> Result<(), String> {
-        self.replace_with_options(index, embedder, None, true, opts)
+        self.replace_with_options(index, embedder, BuildHandles::default(), true, opts)
     }
 
     /// Core populate. `embed_layers` (`HATCHDOOR_EMBED_LAYERS`, default true)
@@ -130,7 +147,7 @@ impl SqliteCache {
         &self,
         index: &VaultIndex,
         embedder: &dyn Embedder,
-        on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
+        handles: BuildHandles,
         embed_layers: bool,
         opts: &BuildOptions,
     ) -> Result<(), String> {
@@ -138,7 +155,7 @@ impl SqliteCache {
             .snapshot_model_epoch
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        self.replace_with_options_unlocked(index, embedder, on_progress, embed_layers, opts, None)
+        self.replace_with_options_unlocked(index, embedder, handles, embed_layers, opts, None)
     }
 
     /// Callers hold `snapshot_model_epoch`. `build_stamp` carries the metadata a
@@ -148,11 +165,15 @@ impl SqliteCache {
         &self,
         index: &VaultIndex,
         embedder: &dyn Embedder,
-        on_progress: Option<Arc<dyn Fn(IndexingProgressSnapshot) + Send + Sync>>,
+        handles: BuildHandles,
         embed_layers: bool,
         opts: &BuildOptions,
         build_stamp: Option<BuildStamp>,
     ) -> Result<(), String> {
+        let BuildHandles {
+            on_progress,
+            vault_read_guard,
+        } = handles;
         // If the embedding model changed since the last build, rebuild from
         // scratch so no vectors from the old model are reused (mixed-model vector
         // spaces make cosine/L2 distances meaningless).
@@ -316,6 +337,13 @@ impl SqliteCache {
                 }
             }
         }
+
+        // Every note's content is in memory and nothing below opens a Vault
+        // path again, so the Index turn's foreground mutation guard has done
+        // its job: it kept this loop from reading half of a multi-file
+        // mutation. Holding it any longer would only park the next write
+        // behind the embedding pass (issue #223).
+        drop(vault_read_guard);
 
         // Tolerating individual unreadable files must not extend to a Vault
         // that has become unreadable as a whole — an unmounted volume or a
@@ -502,7 +530,7 @@ impl SqliteCache {
         self.replace_with_options_unlocked(
             index,
             embedder,
-            None,
+            BuildHandles::default(),
             true,
             opts,
             Some(BuildStamp {
@@ -1941,7 +1969,7 @@ mod tests {
             .replace_with_options(
                 &index,
                 &embedder,
-                None,
+                BuildHandles::default(),
                 embed_layers,
                 &BuildOptions::default(),
             )
@@ -2072,7 +2100,13 @@ mod tests {
         // Reindex the SAME vault (no content change) with the flag now true.
         let index = VaultIndex::build(dir.path()).expect("reindex");
         cache
-            .replace_with_options(&index, &embedder, None, true, &BuildOptions::default())
+            .replace_with_options(
+                &index,
+                &embedder,
+                BuildHandles::default(),
+                true,
+                &BuildOptions::default(),
+            )
             .expect("re-embed");
 
         assert!(

--- a/src/cache/vault_snapshots.rs
+++ b/src/cache/vault_snapshots.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use rusqlite::{OptionalExtension, Transaction, params};
 
-use crate::cache::{BuildOptions, SqliteCache};
+use crate::cache::{BuildHandles, BuildOptions, SqliteCache};
 use crate::embed::Embedder;
 use crate::vault::{NoteMetadata, VaultIndex};
 use crate::vault_registry::VaultId;
@@ -32,6 +32,31 @@ pub(crate) struct VaultSnapshotStatus {
     /// rebuilds it, so folding the two into one enum would produce states no
     /// caller could represent.
     pub(crate) searchable: bool,
+}
+
+/// How an Index turn hands its Vault's foreground mutation guard through a
+/// candidate build (issue #223).
+///
+/// The build reads the Vault from disk, then embeds, then publishes. Only the
+/// first of those three touches a filesystem path, and only the first needs
+/// the guard every HTTP and MCP Markdown write takes first. Holding it across
+/// the embedding pass — minutes on a CPU-only host — parks every write behind
+/// a turn that is no longer reading anything.
+///
+/// Supplied only by the Vault-work executor. Every other caller builds with no
+/// guard to manage and publishes [`VaultSnapshotFreshness::Fresh`].
+pub(crate) struct MutationGuardHandoff {
+    /// Released the moment the last note's content is in memory. Until then
+    /// the build holds it, so it cannot observe half of a multi-file
+    /// foreground mutation; after it, a write no longer waits on embedding.
+    pub(crate) read_phase: tokio::sync::OwnedMutexGuard<()>,
+    /// Called immediately before publication. Retakes the guard and answers
+    /// whether a foreground mutation completed while it was released,
+    /// returning the still-held guard so the verdict and the publication it
+    /// labels share one acquisition — the answer cannot change in between.
+    /// Runs on the build's blocking thread, so it may block.
+    pub(crate) freshness_at_publication:
+        Box<dyn FnOnce() -> (VaultSnapshotFreshness, tokio::sync::OwnedMutexGuard<()>) + Send>,
 }
 
 /// One Vault's complete published read snapshot. This is intentionally a
@@ -135,9 +160,14 @@ impl SqliteCache {
             embedder,
             embed_layers,
             None,
+            None,
         )
     }
 
+    /// `mutation_guard` is the Index turn's hold on this Vault's foreground
+    /// mutation lock, released at the read/embed boundary inside the build and
+    /// retaken to publish. See [`MutationGuardHandoff`]; `None` builds exactly
+    /// as before and publishes fresh.
     pub(crate) fn replace_vault_snapshot_with_embed_layers_and_progress(
         &self,
         vault_id: VaultId,
@@ -145,6 +175,7 @@ impl SqliteCache {
         embedder: &dyn Embedder,
         embed_layers: bool,
         on_progress: Option<Arc<dyn Fn(crate::startup::IndexingProgressSnapshot) + Send + Sync>>,
+        mutation_guard: Option<MutationGuardHandoff>,
     ) -> Result<(), String> {
         let _epoch = self
             .snapshot_model_epoch
@@ -157,6 +188,13 @@ impl SqliteCache {
         // vector spaces.
         self.reset_if_embedder_changed(embedder)?;
         let attempt = self.begin_vault_snapshot_attempt(vault_id)?;
+        let (vault_read_guard, freshness_at_publication) = match mutation_guard {
+            Some(handoff) => (
+                Some(handoff.read_phase),
+                Some(handoff.freshness_at_publication),
+            ),
+            None => (None, None),
+        };
         let result = (|| {
             let candidate = SqliteCache::in_memory(embedder.embedding_dim())?;
             // Seed the empty candidate with this Vault's published rows so the
@@ -175,11 +213,30 @@ impl SqliteCache {
             candidate.replace_with_options(
                 index,
                 embedder,
-                on_progress,
+                BuildHandles {
+                    on_progress,
+                    vault_read_guard,
+                },
                 embed_layers,
                 &BuildOptions::default(),
             )?;
-            self.publish_vault_candidate(vault_id, attempt, &candidate, &embedder.identity(), true)
+            // The verdict comes back with the guard that makes it true, and
+            // that guard outlives the publication below.
+            let (freshness, _published_under_guard) = match freshness_at_publication {
+                Some(verdict) => {
+                    let (freshness, guard) = verdict();
+                    (freshness, Some(guard))
+                }
+                None => (VaultSnapshotFreshness::Fresh, None),
+            };
+            self.publish_vault_candidate(
+                vault_id,
+                attempt,
+                &candidate,
+                &embedder.identity(),
+                true,
+                freshness,
+            )
         })();
         if result.is_err() {
             self.mark_vault_snapshot_stale_if_current(vault_id, attempt)?;
@@ -224,14 +281,24 @@ impl SqliteCache {
             candidate.replace_with_options(
                 index,
                 embedder,
-                None,
+                // No read guard to hand over: the Index turn still holds its
+                // own across this pass — which reads every note's content —
+                // and releases it inside the embedding build that follows.
+                BuildHandles::default(),
                 embed_layers,
                 &BuildOptions {
                     embed: false,
                     ..BuildOptions::default()
                 },
             )?;
-            self.publish_vault_candidate(vault_id, attempt, &candidate, &embedder.identity(), false)
+            self.publish_vault_candidate(
+                vault_id,
+                attempt,
+                &candidate,
+                &embedder.identity(),
+                false,
+                VaultSnapshotFreshness::Fresh,
+            )
         })();
         if result.is_err() {
             self.mark_vault_snapshot_stale_if_current(vault_id, attempt)?;
@@ -699,6 +766,14 @@ impl SqliteCache {
     /// `searchable` records whether this generation carries vectors. A
     /// structure-only generation publishes with `false`; the embedding pass
     /// that follows republishes the same Vault with `true`.
+    ///
+    /// `freshness` is the caller's verdict on whether this generation still
+    /// describes the authoritative Markdown. A build that held the Vault's
+    /// foreground mutation guard from its first read to here publishes
+    /// `Fresh`; one that released the guard across its embedding pass
+    /// publishes `Stale` when a foreground mutation landed while it was
+    /// released (issue #223). A stale generation still participates and still
+    /// answers search — it is labelled, not withheld.
     fn publish_vault_candidate(
         &self,
         vault_id: VaultId,
@@ -706,6 +781,7 @@ impl SqliteCache {
         candidate: &SqliteCache,
         embedder_identity: &str,
         searchable: bool,
+        freshness: VaultSnapshotFreshness,
     ) -> Result<(), String> {
         let source = candidate.read()?;
         let attempts = self
@@ -722,10 +798,14 @@ impl SqliteCache {
             .map_err(|error| format!("start Vault snapshot publication: {error}"))?;
 
         delete_vault_snapshot(&tx, &vault_id)?;
+        let freshness = match freshness {
+            VaultSnapshotFreshness::Fresh => "fresh",
+            VaultSnapshotFreshness::Stale => "stale",
+        };
         tx.execute(
             "INSERT INTO vault_snapshots(vault_id, participating, freshness, searchable) \
-             VALUES (?1, 1, 'fresh', ?2)",
-            params![vault_id, i64::from(searchable)],
+             VALUES (?1, 1, ?2, ?3)",
+            params![vault_id, freshness, i64::from(searchable)],
         )
         .map_err(|error| format!("create Vault snapshot: {error}"))?;
 

--- a/src/vault_executor.rs
+++ b/src/vault_executor.rs
@@ -24,6 +24,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::app_state::AppState;
 use crate::cache::SqliteCache;
+use crate::cache::vault_snapshots::{MutationGuardHandoff, VaultSnapshotFreshness};
 use crate::embed::Embedder;
 use crate::git::{
     ManagedCheckoutLease, ManagedGitOutcome, ManagedGitScheduler, ManagedGitTurnConfig,
@@ -325,15 +326,24 @@ pub(crate) async fn dispatch_vault_index_turn_with_progress(
     };
 
     // HTTP and MCP Markdown mutations hold this exact per-Vault guard across
-    // their filesystem transaction. Hold it through the authoritative scan
-    // and atomic disposable-cache publication too, so an Index turn cannot
-    // observe or publish a mixed multi-file foreground mutation.
+    // their filesystem transaction. Hold it through the authoritative scan and
+    // every per-note content read, so an Index turn cannot observe a mixed
+    // multi-file foreground mutation — and release it there. The embedding
+    // pass that follows opens no Vault path, and on a CPU-only host it runs
+    // for minutes: holding the guard across it parked every write behind the
+    // turn until the caller's transport gave up on a write that had already
+    // landed (issue #223). The turn retakes the guard to publish, and reports
+    // the generation stale if a mutation landed while it was released.
     #[cfg(test)]
     notify_index_mutation_lock_attempt(vault_id);
-    let _mutation = control_block
-        .acquire_mutation()
+    let (read_guard, read_phase_generation) = control_block
+        .acquire_mutation_for_index_reads()
         .await
         .map_err(vault_index_error)?;
+    // Set inside the publication below, read back here only to report what was
+    // published. The verdict itself is decided under the guard that publishes
+    // it, never from this flag.
+    let published_stale = Arc::new(AtomicBool::new(false));
     control_block
         .set_search_status(VaultSearchStatus::Indexing, None)
         .map_err(vault_index_error)?;
@@ -351,6 +361,7 @@ pub(crate) async fn dispatch_vault_index_turn_with_progress(
         }
         let indexing_control = control_block.clone();
         let indexing_cache = cache.clone();
+        let publication_stale = published_stale.clone();
         match tokio::task::spawn_blocking(move || {
             let index = indexing_control
                 .authoritative_index()
@@ -378,6 +389,7 @@ pub(crate) async fn dispatch_vault_index_turn_with_progress(
                     "could not publish the structure-only Vault snapshot; browsing waits for the full index"
                 ),
             }
+            let publication_control = indexing_control.clone();
             indexing_cache
                 .replace_vault_snapshot_with_embed_layers_and_progress(
                     vault_id,
@@ -385,6 +397,26 @@ pub(crate) async fn dispatch_vault_index_turn_with_progress(
                     embedder.as_ref(),
                     embed_layers,
                     on_progress,
+                    Some(MutationGuardHandoff {
+                        read_phase: read_guard,
+                        freshness_at_publication: Box::new(move || {
+                            let (mutated, guard) = publication_control
+                                .blocking_retake_mutation_for_index(read_phase_generation);
+                            publication_stale.store(mutated, Ordering::Release);
+                            let freshness = if mutated {
+                                // A write landed while this turn was
+                                // embedding, so what is about to be published
+                                // is already behind the Markdown. Search keeps
+                                // answering from it; the label is what stops it
+                                // claiming to be current. The watcher has
+                                // already armed the catch-up turn.
+                                VaultSnapshotFreshness::Stale
+                            } else {
+                                VaultSnapshotFreshness::Fresh
+                            };
+                            (freshness, guard)
+                        }),
+                    }),
                 )
                 .map_err(|message| {
                     (
@@ -410,7 +442,17 @@ pub(crate) async fn dispatch_vault_index_turn_with_progress(
 
     match &result {
         Ok(()) => {
-            let _ = control_block.set_search_status(VaultSearchStatus::Ready, None);
+            // A generation published stale reports itself stale here too, which
+            // is exactly what `retained_snapshot_search_status` would derive
+            // from the same row after a restart. `Stale` still grants the
+            // search capability, so the Vault keeps answering; the watcher's
+            // change intent has already armed the turn that makes it `Ready`.
+            let status = if published_stale.load(Ordering::Acquire) {
+                VaultSearchStatus::Stale
+            } else {
+                VaultSearchStatus::Ready
+            };
+            let _ = control_block.set_search_status(status, None);
         }
         Err(error) => {
             let stale_mark_error = stale_mark_required

--- a/src/vault_executor/tests.rs
+++ b/src/vault_executor/tests.rs
@@ -69,6 +69,40 @@ impl Embedder for BlockingEmbedder {
     }
 }
 
+/// Parks a build inside its *read* phase. `token_count` is what the chunker
+/// calls while note content is still being read and chunked, before any vector
+/// work, so blocking the first call holds the turn exactly where its foreground
+/// mutation guard must still be held. Only the first call parks; the rest of
+/// the build runs normally.
+struct ReadPhaseBlockingEmbedder {
+    inner: StubEmbedder,
+    entered: Arc<std::sync::Barrier>,
+    release: Arc<std::sync::Barrier>,
+    parked: std::sync::atomic::AtomicBool,
+}
+
+impl Embedder for ReadPhaseBlockingEmbedder {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        self.inner.embed(texts)
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.inner.embedding_dim()
+    }
+
+    fn identity(&self) -> String {
+        self.inner.identity()
+    }
+
+    fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+        if !self.parked.swap(true, Ordering::SeqCst) {
+            self.entered.wait();
+            self.release.wait();
+        }
+        self.inner.token_count(text, add_special_tokens)
+    }
+}
+
 struct PanicEmbedder;
 
 impl Embedder for PanicEmbedder {
@@ -707,6 +741,352 @@ async fn active_index_turn_reports_the_retained_snapshot_stale_to_concurrent_rea
         "a successful rebuild republishes fresh"
     );
 }
+
+/// One local Vault, activated and already indexed once, with a second Index
+/// turn armed and something for it to embed.
+///
+/// The three tests below all need the same thing: a turn held open inside its
+/// embedding pass, which is where a real Vault spends minutes and where issue
+/// #223's write starvation lived.
+struct EmbeddingTurnFixture {
+    directory: tempfile::TempDir,
+    vault_id: VaultId,
+    collection: VaultCollectionRuntime,
+    worker: Option<crate::vault_work::VaultWorkWorker>,
+    cache: Arc<SqliteCache>,
+}
+
+impl EmbeddingTurnFixture {
+    async fn new() -> Self {
+        let directory = tempdir().expect("temporary state directory");
+        let vault_path = directory.path().join("vault");
+        std::fs::create_dir_all(&vault_path).expect("create Vault directory");
+        std::fs::write(vault_path.join("Home.md"), "# Home\n\nmelatonin original")
+            .expect("write note");
+
+        let registry = VaultRegistryStore::new(directory.path().join("state/vaults.json"));
+        let empty = match registry.load().expect("load empty registry") {
+            crate::vault_registry::VaultRegistryState::Ready(snapshot) => snapshot,
+            crate::vault_registry::VaultRegistryState::Recovery(_) => panic!("registry recovery"),
+        };
+        let snapshot = add_local_vault(&registry, &empty, "Only", vault_path.clone());
+        let vault_id = vault_id_named(&snapshot, "Only");
+
+        let collection = VaultCollectionRuntime::new();
+        let (coordinator, mut worker) = VaultWorkCoordinator::new();
+        let managed_git = ManagedGitScheduler::without_durable_state(coordinator.clone());
+        collection
+            .reconcile_and_reconstruct(&registry, &snapshot, &coordinator, &managed_git)
+            .await;
+        let cache = Arc::new(SqliteCache::in_memory(384).expect("open shared cache"));
+        let working: Arc<dyn Embedder> = Arc::new(StubEmbedder::new(384));
+
+        let published = worker
+            .run_next({
+                let collection = collection.clone();
+                let cache = cache.clone();
+                move |request| async move {
+                    dispatch_vault_index_turn(&collection, cache, working, request).await
+                }
+            })
+            .await
+            .expect("initial Index turn");
+        published.result.expect("initial publication succeeds");
+
+        // A write burst lands, which is what arms the next Index turn in
+        // production: the watcher forwards the change intent to this
+        // coordinator.
+        std::fs::write(vault_path.join("Home.md"), "# Home\n\nmelatonin updated")
+            .expect("update note");
+        coordinator.request(vault_id, VaultWorkKind::Index);
+
+        Self {
+            directory,
+            vault_id,
+            collection,
+            worker: Some(worker),
+            cache,
+        }
+    }
+
+    fn vault_path(&self) -> PathBuf {
+        self.directory.path().join("vault")
+    }
+
+    fn control(&self) -> VaultControlBlock {
+        self.collection
+            .runtime(self.vault_id)
+            .expect("active runtime")
+    }
+
+    fn snapshot_status(&self) -> Option<VaultSnapshotStatus> {
+        self.cache
+            .snapshot_status(self.vault_id)
+            .expect("read snapshot status")
+    }
+
+    /// Run the armed Index turn with an embedder that parks inside `embed`,
+    /// where a real Vault spends minutes and where the guard is now released.
+    /// Returns the barrier reporting it has parked, the barrier that lets it
+    /// go, and the turn itself.
+    fn hold_open_mid_embedding(
+        &mut self,
+    ) -> (
+        Arc<std::sync::Barrier>,
+        Arc<std::sync::Barrier>,
+        tokio::task::JoinHandle<Option<VaultWorkOutcome>>,
+    ) {
+        let entered = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let embedder: Arc<dyn Embedder> = Arc::new(BlockingEmbedder {
+            inner: StubEmbedder::new(384),
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        (entered, release, self.run_armed_turn(embedder))
+    }
+
+    /// The same, parked one phase earlier: inside the read loop that chunks
+    /// note content, where the guard must still be held.
+    fn hold_open_mid_read_phase(
+        &mut self,
+    ) -> (
+        Arc<std::sync::Barrier>,
+        Arc<std::sync::Barrier>,
+        tokio::task::JoinHandle<Option<VaultWorkOutcome>>,
+    ) {
+        let entered = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let embedder: Arc<dyn Embedder> = Arc::new(ReadPhaseBlockingEmbedder {
+            inner: StubEmbedder::new(384),
+            entered: entered.clone(),
+            release: release.clone(),
+            parked: std::sync::atomic::AtomicBool::new(false),
+        });
+        (entered, release, self.run_armed_turn(embedder))
+    }
+
+    fn run_armed_turn(
+        &mut self,
+        embedder: Arc<dyn Embedder>,
+    ) -> tokio::task::JoinHandle<Option<VaultWorkOutcome>> {
+        let mut worker = self.worker.take().expect("the fixture runs one held turn");
+        let collection = self.collection.clone();
+        let cache = self.cache.clone();
+        tokio::spawn(async move {
+            worker
+                .run_next(move |request| {
+                    let collection = collection.clone();
+                    let cache = cache.clone();
+                    async move {
+                        dispatch_vault_index_turn(&collection, cache, embedder, request).await
+                    }
+                })
+                .await
+        })
+    }
+}
+
+/// Meet one of the embedding pass's barriers from a blocking-pool thread. The
+/// pass runs under `spawn_blocking`, so meeting its barrier from the test's
+/// async context would park the runtime instead of the thread.
+async fn meet_barrier(barrier: &Arc<std::sync::Barrier>) {
+    let barrier = barrier.clone();
+    tokio::task::spawn_blocking(move || barrier.wait())
+        .await
+        .expect("meet the embedding barrier");
+}
+
+/// Finish a held-open turn: release the parked blocking-pool thread, then take
+/// its result. Always release before asserting — a panic with the barrier
+/// still unmet hangs the runtime on drop instead of reporting the failure
+/// (see `active_index_turn_reports_the_retained_snapshot_stale_to_concurrent_reads`).
+async fn finish_held_turn(
+    release: &Arc<std::sync::Barrier>,
+    turn: tokio::task::JoinHandle<Option<VaultWorkOutcome>>,
+) {
+    meet_barrier(release).await;
+    turn.await
+        .expect("Index turn task")
+        .expect("Index turn ran")
+        .result
+        .expect("Index turn publishes successfully");
+}
+
+/// The narrowing stops at the read phase. A foreground mutation arriving while
+/// the turn is still reading and chunking note content waits, exactly as
+/// before, which is what keeps a turn from ever observing half of a multi-file
+/// write. The control afterwards proves the guard was merely held: the same
+/// acquisition succeeds the moment the read phase ends.
+#[tokio::test]
+async fn a_foreground_mutation_waits_while_an_index_turn_is_still_reading() {
+    let mut fixture = EmbeddingTurnFixture::new().await;
+    let control = fixture.control();
+    let (entered, release, turn) = fixture.hold_open_mid_read_phase();
+    meet_barrier(&entered).await;
+
+    let blocked = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        control.acquire_mutation(),
+    )
+    .await
+    .is_err();
+
+    finish_held_turn(&release, turn).await;
+
+    assert!(
+        blocked,
+        "a foreground mutation must not start while an Index turn is still reading the Vault"
+    );
+    tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        control.acquire_mutation(),
+    )
+    .await
+    .expect("the guard is free once the turn is over")
+    .expect("mutation acquisition succeeds");
+}
+
+/// Issue #223, inverted. An Index turn used to hold this Vault's foreground
+/// mutation lock for the whole turn, embedding included, and every HTTP and
+/// MCP Markdown write takes that same lock first — `vault_mutation`'s
+/// primitives, `mcp::tools::write::acquire_mutation`, and the `batch` tool,
+/// which takes it once for a whole batch. `acquire_mutation` is an unbounded
+/// await with no timeout and no backpressure, so on a CPU-only host a write
+/// arriving during a seven-minute embedding pass did not degrade, it parked:
+/// the caller's transport gave up on a write that then landed anyway, which
+/// is an at-least-once hazard the moment the caller retries.
+///
+/// The guard now spans the read phase only, so the write starts while the turn
+/// is still embedding.
+#[tokio::test]
+async fn a_foreground_mutation_acquires_the_lock_while_an_index_turn_embeds() {
+    let mut fixture = EmbeddingTurnFixture::new().await;
+    let control = fixture.control();
+    let (entered, release, turn) = fixture.hold_open_mid_embedding();
+    meet_barrier(&entered).await;
+
+    // Parked inside `Embedder::embed`, exactly where a real Vault spends
+    // minutes. This is the call every write makes first.
+    let acquired = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        control.acquire_mutation(),
+    )
+    .await
+    .is_ok();
+
+    finish_held_turn(&release, turn).await;
+
+    assert!(
+        acquired,
+        "a foreground mutation must start while an Index turn embeds, not wait out the pass"
+    );
+}
+
+/// The other half of the decision: a write that lands mid-embedding makes the
+/// generation about to be published already behind the Markdown, so it
+/// publishes stale rather than claiming to be current. It keeps participating
+/// and keeps answering search — the label is what changes, and the watcher has
+/// already armed the catch-up turn.
+#[tokio::test]
+async fn a_mutation_during_the_embedding_pass_publishes_the_generation_stale() {
+    let mut fixture = EmbeddingTurnFixture::new().await;
+    let control = fixture.control();
+    let (entered, release, turn) = fixture.hold_open_mid_embedding();
+    meet_barrier(&entered).await;
+
+    // One complete foreground mutation, taken and released exactly as an HTTP
+    // or MCP Markdown write does.
+    let guard = control
+        .acquire_mutation()
+        .await
+        .expect("foreground mutation acquires its Vault lock");
+    std::fs::write(
+        fixture.vault_path().join("Later.md"),
+        "# Later\n\nmelatonin arrived after the scan",
+    )
+    .expect("write the mid-pass mutation");
+    drop(guard);
+
+    finish_held_turn(&release, turn).await;
+
+    assert_eq!(
+        fixture.snapshot_status(),
+        Some(VaultSnapshotStatus {
+            participating: true,
+            freshness: VaultSnapshotFreshness::Stale,
+            searchable: true,
+        }),
+        "a generation built across a foreground mutation must not publish itself fresh"
+    );
+    assert_eq!(
+        fixture.control().snapshot().search,
+        VaultSearchStatus::Stale,
+        "and the runtime says the same thing `retained_snapshot_search_status` would \
+         derive from that row after a restart, rather than claiming Ready"
+    );
+    assert!(
+        fixture.control().snapshot().capabilities.search,
+        "a stale generation keeps the search capability; it is labelled, not withheld"
+    );
+
+    let embedder: Arc<dyn Embedder> = Arc::new(StubEmbedder::new(384));
+    let response = VaultSearchCore::new(&fixture.cache, &fixture.collection, embedder.as_ref())
+        .search(VaultSearchRequest {
+            scope: VaultScope::One(fixture.vault_id),
+            query: "melatonin".to_string(),
+            mode: SearchMode::Keyword,
+            limit: 10,
+            per_note_cap: 1,
+            layers: LayerSelection::default_surface(),
+        })
+        .expect("keyword search against the stale generation");
+    assert!(
+        response
+            .data
+            .results
+            .iter()
+            .any(|hit| hit.note_slug == "home"),
+        "a stale generation still answers search"
+    );
+    assert!(
+        response.partial,
+        "and reports itself a non-fresh participant while doing so"
+    );
+}
+
+/// The control for the test above: the same released-and-retaken guard, with
+/// nothing intervening. A turn that nothing wrote under still publishes fresh.
+#[tokio::test]
+async fn an_index_turn_with_no_concurrent_mutation_publishes_fresh() {
+    let mut fixture = EmbeddingTurnFixture::new().await;
+    let (entered, release, turn) = fixture.hold_open_mid_embedding();
+    meet_barrier(&entered).await;
+
+    assert_eq!(
+        fixture.snapshot_status().map(|status| status.freshness),
+        Some(VaultSnapshotFreshness::Stale),
+        "precondition: the retained generation reads stale for the length of the rebuild"
+    );
+
+    finish_held_turn(&release, turn).await;
+
+    assert_eq!(
+        fixture.snapshot_status(),
+        Some(VaultSnapshotStatus {
+            participating: true,
+            freshness: VaultSnapshotFreshness::Fresh,
+            searchable: true,
+        }),
+        "releasing the guard across the embedding pass must not make every turn publish stale"
+    );
+    assert_eq!(
+        fixture.control().snapshot().search,
+        VaultSearchStatus::Ready,
+        "and the runtime still settles Ready, which is what startup readiness latches on"
+    );
+}
+
 /// A managed-Git Vault's control block, activated through the real
 /// registry and collection runtime exactly like production. Uses a
 /// syntactically valid but unreachable `https://` URL — like

--- a/src/vault_runtime.rs
+++ b/src/vault_runtime.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 
 use serde::{Deserialize, Serialize};
@@ -414,6 +414,12 @@ pub struct VaultControlBlock {
     vault_path: Arc<PathBuf>,
     snapshot: Arc<RwLock<CollectionVaultSnapshot>>,
     mutation_lock: Arc<tokio::sync::Mutex<()>>,
+    /// How many foreground mutations have taken `mutation_lock`. Written once
+    /// per acquisition, by the acquirer, while it holds that lock — and read
+    /// only by the two accessors below, each of which also holds it. A holder
+    /// therefore reads a value that cannot move until it releases, which is
+    /// the only way to read it honestly.
+    mutations_taken: Arc<AtomicU64>,
     refresh_lock: Arc<tokio::sync::Mutex<()>>,
     accepting_operations: Arc<AtomicBool>,
     cancellation: tokio::sync::watch::Sender<bool>,
@@ -480,6 +486,7 @@ impl VaultControlBlock {
             vault_path: Arc::new(vault_path),
             snapshot: Arc::new(RwLock::new(snapshot)),
             mutation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            mutations_taken: Arc::new(AtomicU64::new(0)),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
             accepting_operations: Arc::new(AtomicBool::new(true)),
             cancellation,
@@ -564,10 +571,71 @@ impl VaultControlBlock {
     pub async fn acquire_mutation(
         &self,
     ) -> Result<tokio::sync::OwnedMutexGuard<()>, VaultRuntimeError> {
+        let guard = self.acquire_mutation_exclusion().await?;
+        // Under the lock, and only once admission is confirmed, so the count
+        // moves exactly once per mutation that actually gets to run and only
+        // while one holder can see it move. Counted on acquisition rather than
+        // release: by the time any other holder can read it, this mutation's
+        // filesystem work has finished and its guard is gone.
+        self.mutations_taken.fetch_add(1, Ordering::Relaxed);
+        Ok(guard)
+    }
+
+    /// Take this Vault's foreground mutation guard for a background Index
+    /// turn's read phase, and report the mutation generation observed under
+    /// it. The same exclusion a Markdown write gets, so a turn can never
+    /// observe half of a multi-file foreground mutation, minus the generation
+    /// advance: an Index turn reads the Vault rather than mutating it, and
+    /// counting itself would make every turn conclude a mutation had
+    /// intervened and report its own publication stale (issue #223).
+    ///
+    /// The generation is read here rather than exposed, because it is only
+    /// meaningful under this lock: pass it back to
+    /// [`Self::blocking_retake_mutation_for_index`], which decides and hands
+    /// back the guard to act under.
+    pub(crate) async fn acquire_mutation_for_index_reads(
+        &self,
+    ) -> Result<(tokio::sync::OwnedMutexGuard<()>, u64), VaultRuntimeError> {
+        let guard = self.acquire_mutation_exclusion().await?;
+        let generation = self.mutations_taken.load(Ordering::Relaxed);
+        Ok((guard, generation))
+    }
+
+    /// The exclusion itself: everything both acquisitions above have in common,
+    /// minus what makes one a mutation and the other a read.
+    async fn acquire_mutation_exclusion(
+        &self,
+    ) -> Result<tokio::sync::OwnedMutexGuard<()>, VaultRuntimeError> {
         self.ensure_accepting_operations()?;
         let guard = self.mutation_lock.clone().lock_owned().await;
         self.ensure_accepting_operations()?;
         Ok(guard)
+    }
+
+    /// Retake the foreground mutation guard from a blocking thread and answer,
+    /// under that one acquisition, whether a foreground mutation completed
+    /// since `since` (a generation from
+    /// [`Self::acquire_mutation_for_index_reads`]).
+    ///
+    /// An Index turn releases the guard before its embedding pass and calls
+    /// this to publish afterwards: the verdict and the publication it labels
+    /// share the returned guard, so no mutation can land between deciding and
+    /// acting (the rule
+    /// [`crate::vault_work::VaultWorkCoordinator::request_if_idle`] records for
+    /// issue #127).
+    ///
+    /// Blocking by construction — call it only from a thread that is not
+    /// driving the async runtime, such as inside `spawn_blocking`; Tokio panics
+    /// otherwise. The wait is bounded by one in-flight foreground mutation, not
+    /// by a turn, which matters because the Index turn holds the cache's
+    /// process-wide model epoch across this call.
+    pub(crate) fn blocking_retake_mutation_for_index(
+        &self,
+        since: u64,
+    ) -> (bool, tokio::sync::OwnedMutexGuard<()>) {
+        let guard = self.mutation_lock.clone().blocking_lock_owned();
+        let mutated = self.mutations_taken.load(Ordering::Relaxed) != since;
+        (mutated, guard)
     }
 
     /// Wait until a mutation that was admitted before this control block was


### PR DESCRIPTION
Closes #223.

An Index turn held the Vault's foreground mutation lock for the whole turn, embedding included. Every HTTP and MCP Markdown write takes that same lock first, and `acquire_mutation` is an unbounded await with no timeout and no backpressure, so a write arriving during a multi-minute embedding pass did not degrade, it parked. The caller's transport gave up on a write that then landed anyway.

The guard now spans the read phase only: the authoritative scan, the structure pass, and every per-note content read. Everything past that point is in-memory work and SQLite writes to the candidate cache, so the turn releases the guard at that boundary and retakes it to publish.

When a foreground mutation completed while the guard was released, the published generation reports itself stale rather than fresh, and the runtime settles at the matching `VaultSearchStatus::Stale`, which is what `retained_snapshot_search_status` already derives from that row after a restart. It still participates, still holds the search capability, and still answers search.

## Interface change

```
Interface change: Index turn's foreground mutation guard scope and published freshness
Producer boundary: Vault work execution (src/vault_executor.rs), with the runtime-composition
  control block and the cache's Vault-snapshot seam
Kind: behavior-changing
Old contract: the guard is held for the whole Index turn; a successful turn always publishes
  VaultSnapshotFreshness::Fresh and VaultSearchStatus::Ready
New contract: the guard is held across the turn's disk reads only; a successful turn whose
  reads were followed by a completed foreground mutation publishes Stale and settles the
  runtime at VaultSearchStatus::Stale
Consumer boundaries: Vault-qualified read projections and the Vault-scoped search core, both
  through the existing freshness/participant/partial machinery; no new field, no schema change,
  no HTTP or MCP payload change. External consumers see a Vault report itself a non-fresh
  participant in cases where it previously claimed to be current.
Compatibility/migration: none required; the disposable cache is rebuilt from Markdown
Rollout/rollback: single binary, no ordering constraint; revert restores the prior hold
Evidence: see Validation below
```

## Validation

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo test --all` | 945 passed, 0 failed |
| `cargo test --all --all-features` | 951 + 8 + 5 + 1 passed, 0 failed |
| `node scripts/check-module-map.mjs` | 205 files, one assignment each |
| `just docs-freshness` then `just docs-freshness-ack` | 6 notes reviewed, 1 updated |

Run from the repository root.

Both new behaviours were confirmed to fail before the fix: holding `vault_read_guard` past the read loop makes `a_foreground_mutation_acquires_the_lock_while_an_index_turn_embeds` time out, and forcing the verdict to `Fresh` makes `a_mutation_during_the_embedding_pass_publishes_the_generation_stale` fail on `left: Fresh, right: Stale`.

Measured against a running instance on this branch's guard-scope change: a 400-note Vault mid-way through a 25-minute embedding pass accepted MCP `create_note` calls in 0.12 to 0.31 seconds each. The first write, issued during the turn's read phase, waited 121.7 seconds, which is the read-phase hold this change deliberately keeps.

## Work packet

`src/cache/mod.rs` was not in the issue's declared owned paths. It takes one line, `pub(crate) use populate::BuildHandles;`, so `vault_snapshots.rs` can name the type it passes to `populate.rs`. Crate-private, necessary for the declared outcome, and not a broadening of it.
