### PR TITLE
fix(watcher): cap the debounce so a burst cannot defer freshness

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -191,10 +191,14 @@ that production inventory are still checked for stale paths and duplicates.
   second legacy single-Vault cache build. Startup becomes Ready after every
   active collection Vault's Index turn settles Ready.
 - `spawn_vault_change_watcher` reports Vault-ID-qualified change intent through
-  an independently cancellable handle. `run_server()` coalesces those intents
-  through the shared `VaultWorkCoordinator` as Index requests. It is the only
-  watcher: the transitional single-Vault adapter is gone with the rest of the
-  legacy lane (#185).
+  an independently cancellable handle. A qualifying filesystem event opens a
+  quiet window that later events restart, bounded by a fixed ceiling
+  (`WATCH_MAX_DEBOUNCE`): a sustained write burst reports intent no later than
+  that ceiling after its window opened, instead of deferring it until the burst
+  stops (#229). `run_server()`
+  coalesces those intents through the shared `VaultWorkCoordinator` as Index
+  requests. It is the only watcher: the transitional single-Vault adapter is
+  gone with the rest of the legacy lane (#185).
 - The one worker loop in `run_server()` takes the next coordinator position
   and hands it to `vault_executor::VaultWorkExecutor` — see the Vault work
   execution boundary below. The loop itself holds no readiness policy, no turn

--- a/src/vault_watcher.rs
+++ b/src/vault_watcher.rs
@@ -140,6 +140,12 @@ async fn run_vault_change_watcher(
     info!(%vault_id, "Vault watcher stopped");
 }
 
+/// Wait for the burst that just started to go quiet before the caller reports
+/// the change. Each qualifying event restarts the `WATCH_DEBOUNCE` window, so a
+/// single save is reported once; `WATCH_MAX_DEBOUNCE` caps how long that
+/// restarting may defer the report. A burst that keeps writing is therefore
+/// reported no later than the ceiling after its window opened, and the next
+/// event after that opens the next window.
 async fn debounce_events(
     event_rx: &mut mpsc::UnboundedReceiver<notify::Result<Event>>,
     cache_db_path: &Path,
@@ -148,10 +154,13 @@ async fn debounce_events(
 ) {
     let timer = tokio::time::sleep(WATCH_DEBOUNCE);
     tokio::pin!(timer);
+    let ceiling = tokio::time::sleep(WATCH_MAX_DEBOUNCE);
+    tokio::pin!(ceiling);
 
     loop {
         tokio::select! {
             _ = &mut timer => break,
+            _ = &mut ceiling => break,
             Some(result) = event_rx.recv() => {
                 match result {
                     Ok(event) if should_refresh_for_event(&event, cache_db_path, vault_path, exclude) => {
@@ -478,16 +487,23 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn per_vault_watcher_reports_identity_and_can_be_cancelled() {
+    /// One watcher over an empty Vault directory, holding the temporary
+    /// directory alive for as long as the test keeps the watcher.
+    struct TestWatcher {
+        _dir: tempfile::TempDir,
+        vault_path: PathBuf,
+        vault_id: VaultId,
+        handle: VaultWatcherHandle,
+        changes: broadcast::Receiver<VaultId>,
+    }
+
+    fn spawn_test_watcher() -> TestWatcher {
         let dir = tempdir().expect("temp dir");
         let vault_path = dir.path().join("vault");
         std::fs::create_dir_all(&vault_path).expect("Vault directory");
         let cache = dir.path().join("cache.sqlite3");
-        let vault_id =
-            crate::vault_registry::VaultId::from_str("12345678-1234-4567-89ab-1234567890ab")
-                .expect("Vault ID");
-        let (changes, mut receiver) = tokio::sync::broadcast::channel(8);
+        let vault_id = VaultId::from_str("12345678-1234-4567-89ab-1234567890ab").expect("Vault ID");
+        let (changes, receiver) = broadcast::channel(64);
         let handle = spawn_vault_change_watcher(
             vault_id,
             vault_path.clone(),
@@ -497,14 +513,65 @@ mod tests {
         )
         .expect("start per-Vault watcher");
 
-        std::fs::write(vault_path.join("Changed.md"), "# Changed\n").expect("write changed note");
-        let changed = tokio::time::timeout(Duration::from_secs(3), receiver.recv())
+        TestWatcher {
+            _dir: dir,
+            vault_path,
+            vault_id,
+            handle,
+            changes: receiver,
+        }
+    }
+
+    #[tokio::test]
+    async fn per_vault_watcher_reports_identity_and_can_be_cancelled() {
+        let mut watcher = spawn_test_watcher();
+
+        std::fs::write(watcher.vault_path.join("Changed.md"), "# Changed\n")
+            .expect("write changed note");
+        let changed = tokio::time::timeout(Duration::from_secs(3), watcher.changes.recv())
             .await
             .expect("watcher change timeout")
             .expect("watcher change");
-        assert_eq!(changed, vault_id);
+        assert_eq!(changed, watcher.vault_id);
 
-        handle.cancel();
-        assert!(handle.is_cancelled());
+        watcher.handle.cancel();
+        assert!(watcher.handle.is_cancelled());
+    }
+
+    /// A sustained write burst must not defer the change intent until the burst
+    /// stops. `WATCH_MAX_DEBOUNCE` caps the quiet `WATCH_DEBOUNCE` window that
+    /// every event restarts, so a writer saving faster than that window is
+    /// exactly the case the ceiling exists for. The burst outlasts the deadline
+    /// deliberately: a change reported before it ends can only have come from
+    /// the ceiling, never from the burst going quiet.
+    #[tokio::test]
+    async fn a_sustained_write_burst_still_reports_a_change_within_the_debounce_ceiling() {
+        let mut watcher = spawn_test_watcher();
+
+        let burst_path = watcher.vault_path.clone();
+        let burst = tokio::spawn(async move {
+            let interval = WATCH_DEBOUNCE / 2;
+            let stop_writing = tokio::time::Instant::now() + WATCH_MAX_DEBOUNCE * 3;
+            let mut written = 0;
+            while tokio::time::Instant::now() < stop_writing {
+                std::fs::write(
+                    burst_path.join(format!("Note-{written}.md")),
+                    format!("# Note {written}\n"),
+                )
+                .expect("write burst note");
+                written += 1;
+                tokio::time::sleep(interval).await;
+            }
+        });
+
+        let deadline = WATCH_MAX_DEBOUNCE + WATCH_DEBOUNCE + Duration::from_secs(3);
+        let changed = tokio::time::timeout(deadline, watcher.changes.recv()).await;
+        burst.abort();
+        watcher.handle.cancel();
+
+        let changed = changed
+            .expect("a sustained burst must report a change within the debounce ceiling")
+            .expect("watcher change");
+        assert_eq!(changed, watcher.vault_id);
     }
 }


### PR DESCRIPTION
Closes #229.

## What was wrong

`WATCH_MAX_DEBOUNCE` states a contract in its own doc comment — a quiet debounce keeps a save burst together, but it must not let a busy editor defer cache freshness forever — and had no consumer left after each Vault's runtime took ownership of its own watcher. The surviving loop in `debounce_events` restarted a 500 ms timer on every qualifying filesystem event with no upper bound, so while events kept arriving closer together than that window the watcher emitted no change intent at all: no Index turn was armed, and the published snapshot could not advance until the burst stopped.

## The fix

Pin a `WATCH_MAX_DEBOUNCE` sleep alongside the quiet timer and break on whichever fires first. A sustained burst is now reported no later than the ceiling after its window opened; the next event after that opens the next window. Nothing else changes: the same intent goes through the same `VaultWorkCoordinator`, whose coalescing keeps repeated ceiling intents during one long turn collapsed into a single pending rerun.

## Tests

`a_sustained_write_burst_still_reports_a_change_within_the_debounce_ceiling` drives real filesystem events at half the quiet window for three times the ceiling and asserts an intent arrives before the burst ends — so a pass can only come from the ceiling, never from the burst going quiet. It times out without the fix (verified by removing the ceiling break). Its timings derive from the constants rather than hard-coded milliseconds, and both watcher lifecycle tests now share one `spawn_test_watcher` helper.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (951 pass), `cargo test --all --all-features` (966 pass)
- `node scripts/check-module-map.mjs`
- `just docs-freshness` + `just docs-freshness-ack` — the three `vault-lifecycle` notes were read and describe no debounce timing, so none drifted. *How indexing and search work* already promised "a five-second ceiling so a genuinely busy editing session can't defer freshness forever"; that sentence is true again.
- Live acceptance on `just dev-start`: a 25 s burst writing one note every 200 ms into the dev Vault advanced the published `/api/v1/vaults/{id}/tree` five times mid-burst (first at t=8 s, then roughly every 5 s), with matching index turns in the backend log. Before the fix nothing could publish until the burst ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
