### PR TITLE
fix(vault): only carry assets that live inside the moving note's folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ truth.
 - The SQLite cache should live outside the vault.
 - Hatchdoor scans `.md` files under the vault while excluding built-in and
   configured noise paths (including `.hatchdoor-trash`).
-- Delete actions move notes and referenced assets into `.hatchdoor-trash`.
+- Delete actions move notes, and the assets kept inside their own folder, into `.hatchdoor-trash`.
 - Archive actions move notes under `HATCHDOOR_ARCHIVE_PREFIX`.
 - Browser write actions are available only when the vault is writable.
 - MCP is disabled by default.

--- a/docs/user-vault/01 Get started/Understand where your data lives.md
+++ b/docs/user-vault/01 Get started/Understand where your data lives.md
@@ -19,7 +19,7 @@ from them, so your notes stay usable with other Markdown tools.
 
 Hatchdoor keeps destructive operations recoverable:
 
-- [x] Deleting a note moves it and referenced assets to `.hatchdoor-trash`.
+- [x] Deleting a note moves it, and the assets kept inside its own folder, to `.hatchdoor-trash`.
 - [x] The trash folder is excluded from indexing.
 - [x] Archiving moves notes under `90-archive/` by default.
 

--- a/docs/user-vault/03 Reference/MCP tools reference.md
+++ b/docs/user-vault/03 Reference/MCP tools reference.md
@@ -174,15 +174,20 @@ Every tool below requires `HATCHDOOR_MCP_WRITE_ENABLED=true` and takes `vault_id
 | `edit_note` | `slug`, `old_string`, `new_string`, `expected_content_hash` | Surgical string replacement. `old_string` must match exactly and be unique unless `replace_all: true`; otherwise the edit is rejected without writing. Prefer this over `update_note` for small changes. |
 | `replace_section` | `slug`, `heading`, `mode`, `content`, `expected_content_hash` | Replace or insert around a Markdown section identified by its heading. `mode` is `replace` (overwrite the section — `content` should include the heading), `before`, or `after`. The section spans the heading through the next same-or-higher heading; headings inside fenced code blocks are ignored, and the heading must match exactly and be unique. |
 | `update_frontmatter` | `slug`, `frontmatter`, `expected_content_hash` | Shallow top-level merge into the note's YAML frontmatter, leaving the body untouched. Keys you don't mention survive; an explicit `null` deletes a key; a nested mapping is replaced wholesale rather than merged into. A note with no frontmatter block gets one created, and deleting its last key removes the block rather than leaving an empty one. Rejects an empty `frontmatter` object, and a creation whose values are all `null`. |
-| `rename_note` | `slug`, `new_title`, `expected_content_hash` | Rename within the current folder; rewrites wikilink backlinks and moves/rewrites referenced assets. |
+| `rename_note` | `slug`, `new_title`, `expected_content_hash` | Rename within the current folder; rewrites wikilink backlinks, and carries along the assets kept inside the note's own folder. |
 | `move_note` | `slug`, `target_folder`, `expected_content_hash` | Move to a target folder; same backlink/asset handling as rename. |
 | `move_rename_note` | `slug`, `target_relative_path`, `expected_content_hash` | Move and rename in one operation. |
 | `archive_note` | `slug`, `expected_content_hash` | Move to the configured archive folder (the Vault's own `archive_folder`, set via `create_vault`/`edit_vault` above, or the instance default). |
-| `delete_note` | `slug`, `expected_content_hash` | Trash a note under `.hatchdoor-trash`; removes backlinks to it and moves/rewrites its assets. |
+| `delete_note` | `slug`, `expected_content_hash` | Trash a note under `.hatchdoor-trash`; removes backlinks to it and trashes the assets kept inside its own folder. |
 | `import_attachment` | `content` (base64), `target_relative_path` | Upload an attachment by sending its bytes base64-encoded. This is the **fallback** for clients that cannot make an out-of-band HTTP request — size-limited (`HATCHDOOR_MCP_MAX_BASE64_BYTES`, default 5 MiB decoded). Prefer `POST /api/v1/vaults/{vault_id}/attachments` when possible; call `get_attachment_import_config` first to see current limits. |
 | `move_attachment` | `source_relative_path`, `target_relative_path` | Move an attachment and rewrite every note reference to it. |
 | `rename_attachment` | `source_relative_path`, `new_filename` | Rename an attachment in place and rewrite every note reference to it. |
 | `delete_attachment` | `source_relative_path` | Trash an attachment under `.hatchdoor-trash` and rewrite every note reference to it. |
+
+An asset travels with a note only when it already lives inside that note's own folder, or a subfolder of it. An asset the note merely points at from somewhere else, such as a shared `_system/` or `Attachments/` folder sitting beside the note's folder, stays exactly where it is: `rename_note`, `move_note`, `move_rename_note`, `archive_note` and `delete_note` leave it alone and rewrite the moved note's own link so it still resolves from the note's new home. Other notes pointing at it are left untouched too, since nothing about it changed. `moved_assets` in the response counts only the assets that actually moved.
+
+> [!note]
+> A note sitting in the Vault root has the whole Vault as its own folder, so every asset it references counts as living inside it and does travel with the note. Keep notes that share an attachments folder in a folder of their own if you want that folder left alone.
 
 Every write tool accepts an optional `commit_summary` (a one-line string) used in the Git commit body for Vaults with versioning enabled.
 

--- a/src/vault/write/assets.rs
+++ b/src/vault/write/assets.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
@@ -6,7 +6,8 @@ use crate::vault::types::{NoteEntry, VaultIndex};
 
 use super::paths::{
     create_parent_dir_inside_root, ensure_existing_path_inside_root, is_trashed_path,
-    relative_link_target, same_existing_path, unique_trash_attachment_relative_path,
+    relative_link_target, resolve_reference_inside_root, same_existing_path,
+    unique_trash_attachment_relative_path, vault_relative_dir,
 };
 use super::rewrites::{parse_fence_marker, rewrite_content_or_read};
 use super::types::{AssetMove, TextRewrite, WriteError};
@@ -27,14 +28,48 @@ pub(super) fn asset_move_plan(
     })?;
     let source_dir = moved_entry.path.parent().unwrap_or(vault_root);
     let destination_dir = destination_note.parent().unwrap_or(vault_root);
-    let mut moves = Vec::new();
-    let mut rewrites = Vec::new();
+    // The note's own folder, as a prefix an asset's vault-relative path must
+    // carry to count as living inside it. Empty for a note at the vault root,
+    // whose folder is the whole Vault.
+    let own_folder_prefix = match vault_relative_dir(vault_root, source_dir) {
+        Some(relative) if relative.is_empty() => String::new(),
+        Some(relative) => format!("{relative}/"),
+        None => {
+            return Err(WriteError::InvalidInput(
+                "path cannot escape the vault".to_string(),
+            ));
+        }
+    };
+    // Every reference is resolved before anything is planned from any of them.
+    // Collapsing `.` and `..` up front matters twice over: an unresolved `..`
+    // both misplaces the destination (it lands relative to an unrelated
+    // directory) and reaches the move primitives, which walk a path one plain
+    // name at a time and refuse anything else (#225). Resolving the whole set
+    // first also keeps a refusal side-effect-free, since an earlier reference
+    // would otherwise have had its destination folder created by the time a
+    // later one is found to point out of the Vault.
+    let mut resolved = Vec::new();
     let mut seen = HashSet::new();
     for relative_asset in referenced_assets(&content) {
         if !seen.insert(relative_asset.clone()) {
             continue;
         }
-        let source_asset = source_dir.join(&relative_asset);
+        let Some(source_relative) =
+            resolve_reference_inside_root(vault_root, source_dir, &relative_asset)
+        else {
+            return Err(WriteError::InvalidInput(format!(
+                "asset reference '{}' resolves outside the vault",
+                relative_asset.display()
+            )));
+        };
+        resolved.push((relative_asset, source_relative));
+    }
+
+    let mut moves = Vec::new();
+    let mut rewrites = Vec::new();
+    let mut stationary: HashMap<PathBuf, String> = HashMap::new();
+    for (relative_asset, source_relative) in resolved {
+        let source_asset = vault_root.join(&source_relative);
         if !source_asset.exists() || !source_asset.is_file() {
             continue;
         }
@@ -42,17 +77,29 @@ pub(super) fn asset_move_plan(
         if is_trashed_path(vault_root, &source_asset)? {
             continue;
         }
+        // An asset travels with the note only when it already lives inside the
+        // note's own folder. One kept elsewhere - the shared attachments folder
+        // of the usual Obsidian layout - stays put, and the moving note's own
+        // reference is repointed at it from the destination instead. Scattering
+        // such a folder across the Vault on an ordinary note move was the
+        // decided-against behaviour in #225.
+        let Some(own_folder_relative) = source_relative.strip_prefix(&own_folder_prefix) else {
+            if let Some(target) = relative_link_target(vault_root, destination_note, &source_asset)
+            {
+                stationary.insert(relative_asset, target);
+            }
+            continue;
+        };
         let destination_asset = if allow_trash_collision {
             // Trashing a note: the destination lives under .hatchdoor-trash and
             // may already hold an asset of the same relative path from an earlier
             // delete. Relocate to a unique name rather than failing the delete.
-            let relative_str = relative_asset.to_string_lossy();
             vault_root.join(unique_trash_attachment_relative_path(
                 vault_root,
-                &relative_str,
+                own_folder_relative,
             )?)
         } else {
-            destination_dir.join(&relative_asset)
+            destination_dir.join(own_folder_relative)
         };
         create_parent_dir_inside_root(vault_root, &destination_asset, "asset")?;
         if !allow_trash_collision && destination_asset.exists() {
@@ -75,6 +122,26 @@ pub(super) fn asset_move_plan(
             &destination_asset,
             &baseline,
         )?);
+    }
+    // The moving note is excluded from `asset_reference_rewrite_plan` because a
+    // reference to an asset travelling with it stays valid. A reference to an
+    // asset left behind does not, so the exclusion is narrowed to exactly the
+    // travelling ones and the rest are repointed here. The rewrite is keyed to
+    // the note's destination path: by the time rewrites are applied, the note
+    // itself has already moved there.
+    if !stationary.is_empty() {
+        let rewritten = transform_asset_references(&content, |target| {
+            stationary
+                .get(target)
+                .cloned()
+                .unwrap_or_else(|| target.to_string_lossy().into_owned())
+        });
+        if rewritten != content {
+            rewrites.push(TextRewrite {
+                path: destination_note.to_path_buf(),
+                content: rewritten,
+            });
+        }
     }
     Ok((moves, rewrites))
 }
@@ -416,6 +483,68 @@ fn asset_path_from_target(target: &str) -> Option<PathBuf> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// #225: `..` in a reference is the planner's problem, not the filesystem's.
+    /// The move primitives walk a path one plain name at a time and reject any
+    /// other component, so a plan carrying `..` is a plan that cannot execute.
+    #[test]
+    fn planned_asset_moves_never_carry_a_parent_component() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+
+        fs::create_dir_all(root.join("_system")).unwrap();
+        fs::write(root.join("_system/shared.png"), "img").unwrap();
+        fs::create_dir_all(root.join("folder-x/media")).unwrap();
+        fs::write(root.join("folder-x/media/own.png"), "img").unwrap();
+        fs::write(
+            root.join("folder-x/Note.md"),
+            "![](../_system/shared.png)\n![](./media/own.png)\n",
+        )
+        .unwrap();
+
+        let index = VaultIndex::build(root).expect("index");
+        let entry = index
+            .ordered_entries()
+            .into_iter()
+            .find(|e| e.slug == "note")
+            .expect("note entry");
+
+        let (moves, rewrites) = asset_move_plan(
+            root,
+            &index,
+            &entry,
+            // A different depth, so the reference to the asset left behind
+            // genuinely has to change: a same-depth move would recompute the
+            // identical `../_system/shared.png` and prove nothing.
+            &root.join("deeper/nest/Note.md"),
+            false,
+            &[],
+        )
+        .expect("plan must succeed");
+
+        assert_eq!(
+            moves.len(),
+            1,
+            "only the asset inside the note's own folder travels"
+        );
+        for asset_move in &moves {
+            for path in [&asset_move.source, &asset_move.destination] {
+                assert!(
+                    !path
+                        .components()
+                        .any(|component| component == Component::ParentDir),
+                    "planned path must be free of '..': {}",
+                    path.display()
+                );
+            }
+        }
+        assert!(
+            rewrites
+                .iter()
+                .any(|rewrite| rewrite.path == root.join("deeper/nest/Note.md")),
+            "the moving note's own reference to the asset left behind must be rewritten"
+        );
+    }
 
     #[test]
     fn trashing_an_asset_whose_name_already_exists_in_trash_picks_a_unique_name() {

--- a/src/vault/write/fs_ops.rs
+++ b/src/vault/write/fs_ops.rs
@@ -965,6 +965,33 @@ mod tests {
     }
 
     #[test]
+    fn move_file_no_follow_rejects_a_path_carrying_a_parent_component() {
+        // #225: the planner must normalise `..` away before it gets here. This
+        // pins the syscall-level rejection that catches it if it ever does not:
+        // the parent walk opens one plain name at a time, so `..` is refused
+        // rather than followed. Nothing above may relax this.
+        let dir = tempdir().expect("tempdir");
+        let nested = dir.path().join("folder-x");
+        fs::create_dir_all(&nested).expect("nested dir");
+        let source = dir.path().join("asset.png");
+        fs::write(&source, BINARY_ASSET).expect("source");
+        let destination = nested.join("../moved.png");
+
+        let error = move_file_no_follow(&source, &destination)
+            .expect_err("a destination carrying '..' must not reach the filesystem");
+
+        let WriteError::Io(message) = error else {
+            panic!("expected an I/O error naming the unsupported component");
+        };
+        assert!(
+            message.contains("write path has unsupported component"),
+            "unexpected message: {message}"
+        );
+        assert!(source.exists(), "the source must be left alone");
+        assert!(!dir.path().join("moved.png").exists());
+    }
+
+    #[test]
     fn move_file_no_follow_moves_bytes_that_are_not_valid_utf8() {
         // issue #220: an attachment is arbitrary bytes. The post-move guard
         // exists to prove the moved thing is a regular file, not that it

--- a/src/vault/write/notes.rs
+++ b/src/vault/write/notes.rs
@@ -569,8 +569,6 @@ fn move_or_rename_note_with_hook(
             normalize_note_relative_path(target_relative_path)?
         )));
     }
-    create_parent_dir_inside_root(vault_root, &target_path, "destination")?;
-
     let target_without_ext =
         strip_md_extension(&normalize_note_relative_path(target_relative_path)?).to_string();
     let slug = slug_for_relative_path(index, &target_without_ext, &target_path, Some(&entry.slug));
@@ -583,6 +581,11 @@ fn move_or_rename_note_with_hook(
         false,
         &backlink_rewrites,
     )?;
+    // Created after planning, so a plan the planner refuses outright leaves no
+    // empty destination folder behind. A plan that carries assets still creates
+    // folders while planning them; the pre-existing empty-folder-after-rollback
+    // case is unchanged and tracked separately.
+    create_parent_dir_inside_root(vault_root, &target_path, "destination")?;
     let mutation = execute_note_mutation(
         vault_root,
         entry,
@@ -685,7 +688,6 @@ fn delete_note_with_hook(
     ensure_content_hash(entry, expected_content_hash)?;
     let trash_relative = unique_trash_relative_path(vault_root, &entry.relative_path)?;
     let trash_path = vault_root.join(format!("{trash_relative}.md"));
-    create_parent_dir_inside_root(vault_root, &trash_path, "trash")?;
 
     let backlink_rewrites = backlink_rewrite_plan(index, &entry.slug, None)?;
     let (asset_moves, asset_rewrites) = asset_move_plan(
@@ -696,6 +698,7 @@ fn delete_note_with_hook(
         true,
         &backlink_rewrites,
     )?;
+    create_parent_dir_inside_root(vault_root, &trash_path, "trash")?;
     let mutation = execute_note_mutation(
         vault_root,
         entry,

--- a/src/vault/write/paths.rs
+++ b/src/vault/write/paths.rs
@@ -271,6 +271,45 @@ pub(super) fn relative_link_target(
     }
 }
 
+/// The vault-relative path of a directory that sits inside `vault_root`, as a
+/// `/`-joined string; the empty string for the vault root itself.
+pub(super) fn vault_relative_dir(vault_root: &Path, dir: &Path) -> Option<String> {
+    let relative = dir.strip_prefix(vault_root).ok()?;
+    Some(path_parts(relative)?.join("/"))
+}
+
+/// Resolve a note-relative asset reference against the folder the note lives
+/// in, collapsing `.` and `..` lexically, and return the result as a
+/// vault-relative path. `None` when the reference climbs out of the vault root
+/// or is not representable as plain UTF-8 components under it.
+///
+/// The collapsing has to happen here rather than being left to the kernel: the
+/// low-level opener walks a path one plain name at a time with `openat`, so any
+/// `..` that survives into a planned move is refused as an unsupported
+/// component (#225). Resolving lexically also keeps the check honest for a
+/// destination that does not exist yet.
+pub(super) fn resolve_reference_inside_root(
+    vault_root: &Path,
+    note_dir: &Path,
+    reference: &Path,
+) -> Option<String> {
+    let mut parts = path_parts(note_dir.strip_prefix(vault_root).ok()?)?;
+    for component in reference.components() {
+        match component {
+            Component::Normal(value) => parts.push(value.to_str()?.to_string()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
 fn path_parts(path: &Path) -> Option<Vec<String>> {
     let mut parts = Vec::new();
     for component in path.components() {

--- a/src/vault/write/tests.rs
+++ b/src/vault/write/tests.rs
@@ -1380,3 +1380,302 @@ fn compensation_failure_surfaces_bounded_recovery_details_and_continues_rollback
         "compensation must not overwrite a concurrent manual edit"
     );
 }
+
+/// A vault laid out the way Obsidian's default "keep attachments in one place"
+/// setting produces: a shared `_system/` folder holding the image, and a note
+/// elsewhere embedding it through a parent-relative reference (#225).
+fn vault_with_a_shared_attachments_folder(root: &Path) -> String {
+    let body = "# B\n![](../_system/image.png)\n";
+    fs::create_dir_all(root.join("_system")).expect("system dir");
+    fs::write(root.join("_system/image.png"), BINARY_ASSET).expect("asset");
+    fs::create_dir_all(root.join("folder-x")).expect("folder-x");
+    fs::write(root.join("folder-x/B.md"), body).expect("note");
+    body.to_string()
+}
+
+/// Resolve a note's asset reference the way a Markdown renderer would, so a
+/// test asserts the link still points at a real file rather than just matching
+/// the string a particular implementation happens to emit.
+fn embedded_asset_resolves_to(root: &Path, note_relative_path: &str, asset_relative_path: &str) {
+    let note = root.join(note_relative_path);
+    let content = fs::read_to_string(&note).expect("read note for reference check");
+    let target = content
+        .split_once("![](")
+        .and_then(|(_, rest)| rest.split_once(')'))
+        .map(|(target, _)| target.to_string())
+        .unwrap_or_else(|| panic!("note '{note_relative_path}' has no markdown embed: {content}"));
+    let resolved = note
+        .parent()
+        .expect("note parent")
+        .join(&target)
+        .canonicalize()
+        .unwrap_or_else(|error| panic!("embed '{target}' does not resolve: {error}"));
+    assert_eq!(
+        resolved,
+        root.join(asset_relative_path)
+            .canonicalize()
+            .expect("expected asset"),
+        "embed '{target}' in '{note_relative_path}' must resolve to '{asset_relative_path}'"
+    );
+}
+
+#[test]
+fn move_note_leaves_an_asset_outside_its_folder_in_place_and_repoints_its_own_reference() {
+    // #225: an asset the note merely references must not be dragged along by
+    // an ordinary move, and the move must not fail either. Every destination
+    // depth is covered because each computes a different relative reference.
+    for target in [
+        "folder-z/B.md",
+        "folder-x/deeper/B.md",
+        "B.md",
+        "_system/B.md",
+    ] {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let body = vault_with_a_shared_attachments_folder(root);
+        let index = build(root);
+        let entry = index.find_by_slug("b").expect("b");
+
+        let outcome = move_or_rename_note(root, &index, entry, target, &content_hash(&body))
+            .unwrap_or_else(|error| panic!("move to '{target}' must succeed: {error:?}"));
+
+        assert_eq!(
+            outcome.moved_assets, 0,
+            "an asset outside the note's folder must not travel to '{target}'"
+        );
+        assert_eq!(
+            fs::read(root.join("_system/image.png")).expect("asset stays put"),
+            BINARY_ASSET
+        );
+        embedded_asset_resolves_to(root, target, "_system/image.png");
+    }
+}
+
+#[test]
+fn archive_note_leaves_an_asset_outside_its_folder_in_place() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let body = vault_with_a_shared_attachments_folder(root);
+    let index = build(root);
+    let entry = index.find_by_slug("b").expect("b");
+
+    let outcome = archive_note(root, &index, entry, "90-archive/", &content_hash(&body))
+        .expect("archive must succeed");
+
+    assert_eq!(outcome.moved_assets, 0);
+    assert!(root.join("_system/image.png").exists());
+    embedded_asset_resolves_to(root, "90-archive/B.md", "_system/image.png");
+}
+
+#[test]
+fn delete_note_leaves_an_asset_outside_its_folder_in_place_and_repoints_the_trashed_copy() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let body = vault_with_a_shared_attachments_folder(root);
+    let index = build(root);
+    let entry = index.find_by_slug("b").expect("b");
+
+    let outcome = delete_note(root, &index, entry, &content_hash(&body)).expect("delete");
+
+    assert_eq!(outcome.moved_assets, 0);
+    assert!(root.join("_system/image.png").exists());
+    let trashed = format!("{}.md", outcome.trashed_path.expect("trash path"));
+    embedded_asset_resolves_to(root, &trashed, "_system/image.png");
+}
+
+#[test]
+fn a_note_whose_reference_an_earlier_move_rewrote_can_still_be_moved_archived_and_deleted() {
+    // The reporter's chain from #225: A and B share a sibling asset, A moves
+    // away and takes the asset with it, and B is left pointing over the folder
+    // boundary. B must stay fully mutable from there.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let a_body = "# A\n![](image.png)\n";
+    let b_body = "# B\n![](image.png)\n";
+    fs::create_dir_all(root.join("folder-x")).expect("folder-x");
+    fs::write(root.join("folder-x/A.md"), a_body).expect("a");
+    fs::write(root.join("folder-x/B.md"), b_body).expect("b");
+    fs::write(root.join("folder-x/image.png"), BINARY_ASSET).expect("asset");
+
+    let index = build(root);
+    let a = index.find_by_slug("a").expect("a").clone();
+    let moved_a = move_or_rename_note(root, &index, &a, "folder-y/A.md", &content_hash(a_body))
+        .expect("moving A must still carry its sibling asset");
+    assert_eq!(moved_a.moved_assets, 1);
+    let rewritten_b = fs::read_to_string(root.join("folder-x/B.md")).expect("b");
+    assert!(
+        rewritten_b.contains("![](../folder-y/image.png)"),
+        "B's reference must be repointed at the moved asset: {rewritten_b}"
+    );
+
+    let index = build(root);
+    let b = index.find_by_slug("b").expect("b").clone();
+    move_or_rename_note(
+        root,
+        &index,
+        &b,
+        "folder-z/B.md",
+        &content_hash(&rewritten_b),
+    )
+    .expect("B must be movable after the rewrite");
+    embedded_asset_resolves_to(root, "folder-z/B.md", "folder-y/image.png");
+
+    let moved_b = fs::read_to_string(root.join("folder-z/B.md")).expect("b");
+    let index = build(root);
+    let b = index.find_by_slug("b").expect("b").clone();
+    archive_note(root, &index, &b, "90-archive/", &content_hash(&moved_b))
+        .expect("B must be archivable");
+    embedded_asset_resolves_to(root, "90-archive/B.md", "folder-y/image.png");
+
+    let archived_b = fs::read_to_string(root.join("90-archive/B.md")).expect("b");
+    let index = build(root);
+    let b = index.find_by_slug("b").expect("b").clone();
+    let deleted =
+        delete_note(root, &index, &b, &content_hash(&archived_b)).expect("B must be deletable");
+    assert!(
+        root.join("folder-y/image.png").exists(),
+        "deleting B must not trash an asset it only references"
+    );
+    let trashed = format!("{}.md", deleted.trashed_path.expect("trash path"));
+    embedded_asset_resolves_to(root, &trashed, "folder-y/image.png");
+}
+
+#[test]
+fn move_note_carries_an_asset_held_in_a_subfolder_of_its_own_folder() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let body = "# Target\n![](media/image.png)\n";
+    fs::create_dir_all(root.join("Notes/media")).expect("media dir");
+    fs::write(root.join("Notes/Target.md"), body).expect("target");
+    fs::write(root.join("Notes/media/image.png"), BINARY_ASSET).expect("asset");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    let outcome = move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Target.md",
+        &content_hash(body),
+    )
+    .expect("move");
+
+    assert_eq!(outcome.moved_assets, 1);
+    assert!(!root.join("Notes/media/image.png").exists());
+    assert_eq!(
+        fs::read(root.join("Archive/media/image.png")).expect("asset travelled"),
+        BINARY_ASSET
+    );
+    embedded_asset_resolves_to(root, "Archive/Target.md", "Archive/media/image.png");
+}
+
+#[test]
+fn move_note_refuses_an_asset_reference_that_escapes_the_vault() {
+    let tmp = TempDir::new().expect("tempdir");
+    let outside = tmp.path().join("outside");
+    let root = tmp.path().join("vault");
+    fs::create_dir_all(&outside).expect("outside dir");
+    fs::create_dir_all(root.join("folder-x/media")).expect("folder-x");
+    fs::write(outside.join("image.png"), BINARY_ASSET).expect("outside asset");
+    fs::write(root.join("folder-x/media/own.png"), BINARY_ASSET).expect("own asset");
+    // The travelling reference comes first, so the refusal has to be reached
+    // before its destination folder would otherwise have been created.
+    let body = "# B\n![](media/own.png)\n![](../../outside/image.png)\n";
+    fs::write(root.join("folder-x/B.md"), body).expect("note");
+    let index = build(&root);
+    let entry = index.find_by_slug("b").expect("b");
+
+    let error = move_or_rename_note(&root, &index, entry, "folder-z/B.md", &content_hash(body))
+        .expect_err("a reference pointing out of the vault must be refused");
+
+    assert!(
+        matches!(&error, WriteError::InvalidInput(message) if message.contains("outside the vault")),
+        "expected an invalid-input refusal, got {error:?}"
+    );
+    assert!(
+        root.join("folder-x/B.md").exists(),
+        "the note must not move"
+    );
+    assert!(
+        !root.join("folder-z").exists(),
+        "a refused plan must not create any part of the destination"
+    );
+    assert!(
+        root.join("folder-x/media/own.png").exists(),
+        "the note's own asset must not move either"
+    );
+    assert_eq!(
+        fs::read(outside.join("image.png")).expect("outside asset untouched"),
+        BINARY_ASSET
+    );
+}
+
+#[test]
+fn move_note_from_the_vault_root_carries_the_assets_it_references() {
+    // A note in the Vault root has the whole Vault as its own folder, so by the
+    // #225 rule every asset it references is inside that folder and travels.
+    // Pinned deliberately: it is the one place where the rule and the "leave a
+    // shared attachments folder alone" intent point in different directions,
+    // and #225 put changing which assets travel from inside the note's own
+    // folder out of scope.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let body = "# B\n![](_system/image.png)\n";
+    fs::create_dir_all(root.join("_system")).expect("system dir");
+    fs::write(root.join("_system/image.png"), BINARY_ASSET).expect("asset");
+    fs::write(root.join("B.md"), body).expect("note");
+    let index = build(root);
+    let entry = index.find_by_slug("b").expect("b");
+
+    let outcome = move_or_rename_note(root, &index, entry, "folder-z/B.md", &content_hash(body))
+        .expect("move");
+
+    assert_eq!(outcome.moved_assets, 1);
+    assert_eq!(
+        fs::read(root.join("folder-z/_system/image.png")).expect("asset travelled"),
+        BINARY_ASSET
+    );
+    embedded_asset_resolves_to(root, "folder-z/B.md", "folder-z/_system/image.png");
+}
+
+#[test]
+fn every_path_a_planned_asset_move_hands_the_filesystem_is_accepted_by_the_move_primitive() {
+    // #225's failure was a planned path the filesystem layer refuses: the
+    // primitives walk a path one plain name at a time, so a `..` anywhere in a
+    // plan makes it unexecutable. Asserting the plan's own paths are free of
+    // `..` proves that structurally; driving each of them through the primitive
+    // proves it against the thing that actually rejects them.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("_system")).expect("system dir");
+    fs::write(root.join("_system/shared.png"), BINARY_ASSET).expect("shared asset");
+    fs::create_dir_all(root.join("folder-x/media")).expect("media dir");
+    fs::write(root.join("folder-x/media/own.png"), BINARY_ASSET).expect("own asset");
+    fs::write(
+        root.join("folder-x/B.md"),
+        "![](../_system/shared.png)\n![](./media/own.png)\n",
+    )
+    .expect("note");
+
+    let index = build(root);
+    let entry = index.find_by_slug("b").expect("b").clone();
+    let destination = root.join("deeper/nest/B.md");
+    let (moves, _rewrites) =
+        super::assets::asset_move_plan(root, &index, &entry, &destination, false, &[])
+            .expect("plan");
+
+    assert_eq!(moves.len(), 1, "only the note's own asset travels");
+    for asset_move in &moves {
+        for path in [&asset_move.source, &asset_move.destination] {
+            assert!(
+                !path
+                    .components()
+                    .any(|component| component == std::path::Component::ParentDir),
+                "a planned path must be free of '..': {}",
+                path.display()
+            );
+        }
+        super::fs_ops::move_file_no_follow(&asset_move.source, &asset_move.destination)
+            .expect("the move primitive must accept every path the planner produced");
+    }
+}


### PR DESCRIPTION
Closes #225.

## The problem

A note that referenced an asset outside its own folder could not be moved, renamed, archived or deleted. Every mutation failed, with a different error depending on the destination — `write path has unsupported component`, `Destination asset already exists`, or `path cannot escape the vault`.

The reference rewriter was not the defect: `../folder-y/image.png` is a valid relative link and it renders. The fault was in the planner that decides which assets travel with a moving note. It assumed every referenced asset was a sibling, so it built the asset's source by textually joining the reference onto the note's folder and its destination by joining the same reference onto the target folder, with no normalisation. When the reference pointed out of the note's folder, two things went wrong at once: the computed destination was relative to an unrelated directory, and the surviving `..` reached the move primitives, which walk a path one plain name at a time with `openat` and accept only plain names.

No prior move was needed to trigger it. Any note displaying an asset kept in a shared folder — the standard Obsidian "attachments in one place" layout — was already unmovable and undeletable.

## The fix

An asset travels with a note only when it already lives inside that note's own folder, or a subfolder of it. An asset kept elsewhere stays where it is, no other note is touched, and the moving note's own reference is repointed at it from the destination. The same rule applies to archive, which is a move, and to delete, which is a move into trash.

References are resolved lexically before anything is planned, so no `..` reaches the filesystem and a reference climbing out of the Vault is refused as invalid input. The `..` rejection in the low-level opener is unchanged — the fix keeps `..` away from it rather than relaxing it.

The destination folder is now created after planning rather than before, so a plan the planner refuses leaves nothing behind.

## Scope

`src/vault/write/` only: the planner (`assets.rs`), lexical path resolution helpers (`paths.rs`), the ordering change (`notes.rs`), and tests. No change to `WriteError` variants, to the write functions re-exported from the vault module, to any MCP tool schema, or to the frontend. `WriteOutcome.moved_assets` keeps its meaning and now counts only assets that actually moved; no case that previously reported a count reports a different one, because every affected case previously failed outright.

## Verification

All checks pass: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, `cargo test --all --all-features`, `node scripts/check-module-map.mjs`.

Every acceptance criterion was also exercised against a running instance through the HTTP write API, not only in tests:

| Criterion | Result |
| --- | --- |
| Shared-folder note moves to same depth, deeper, shallower, and the Vault root | `moved_assets=0` each time, asset still in `_system/`, embed re-resolves |
| Same note archives | `moved_assets=0`, asset left in place |
| Same note deletes | `moved_assets=0`, trashed copy's embed resolves |
| Reporter's full chain: A and B share a sibling, A moves away, B then moved, archived, deleted | passes at every step |
| Asset in a subfolder of the note's own folder | still travels (`moved_assets=1`) |
| Reference resolving outside the Vault root | refused with `invalid_write_input`, note unmoved, no folder created, outside file untouched |

## Documentation

`docs/user-vault/03 Reference/MCP tools reference.md`, `docs/user-vault/01 Get started/Understand where your data lives.md` and `README.md` are updated for the new rule. The documentation freshness review was performed and acknowledged.

Two stale strings sit outside this packet's owned paths and are tracked in #231: the five note-mutation MCP tool descriptions, and ADR-11's sentence describing delete.

## Note on notes at the Vault root

A note sitting in the Vault root has the whole Vault as its own folder, so every asset it references counts as living inside it and does travel with the note. That follows from the rule as settled in triage, and from the criterion that an asset in a subfolder of the note's own folder still travels. It is unchanged from previous behaviour, and is now documented and pinned by `move_note_from_the_vault_root_carries_the_assets_it_references`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
