### PR TITLE
fix(index): release a moving slug before any note claims it

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1269,6 +1269,11 @@ and embedder identity/dimensions.
 - Every shared snapshot row and relationship is Vault-ID-qualified; failed
   replacement retains the prior snapshot as stale, disabling removes only
   participation, and disconnect deletes only that Vault's disposable rows.
+- A population pass drops every cached note row that will not still hold its
+  slug when the pass ends - the notes that left the Vault and the notes whose
+  slug moved to another path - before it writes any row. A slug is unique and
+  migrates between paths whenever a note is added, moved, or renamed beside a
+  same-named sibling, so releasing it late fails the whole turn (issue #226).
 
 **Validation:** `cargo test cache` and full backend checks. Schema/population
 changes require search and application-state tests too.

--- a/src/cache/populate.rs
+++ b/src/cache/populate.rs
@@ -257,21 +257,41 @@ impl SqliteCache {
         let layer_catalog_json = serde_json::to_string(&layer_catalog)
             .map_err(|e| format!("failed serializing layer catalog: {e}"))?;
 
-        let current_paths = entries
+        let slug_by_path = entries
             .iter()
-            .map(|entry| entry.relative_path.clone())
-            .collect::<HashSet<_>>();
+            .map(|entry| (entry.relative_path.as_str(), entry.slug.as_str()))
+            .collect::<HashMap<_, _>>();
         let now = current_unix_timestamp();
         let mut conn = self.connection()?;
         let tx = conn
             .transaction()
             .map_err(|e| format!("failed to start SQLite cache refresh: {e}"))?;
 
-        let cached_paths = cached_relative_paths(&tx)?;
-        let is_incremental_refresh = !cached_paths.is_empty();
-        for cached_path in cached_paths {
-            if !current_paths.contains(&cached_path) {
-                delete_note_by_relative_path(&tx, &cached_path)?;
+        // Drop every cached row that will not still be holding its slug when
+        // this pass ends: the notes that left the Vault, and the notes whose
+        // slug moved to another path. Both have to go before the first insert
+        // below, because `notes` constrains `slug` as well as `relative_path`
+        // and the note upsert can only resolve a `relative_path` conflict.
+        //
+        // A slug moves for an ordinary reason: it is derived from a filename
+        // alone, so adding `Archive/Overview.md` beside an indexed
+        // `Projects/Overview.md` hands `overview` to the new note and
+        // `overview-2` to the old one. Insert the new note while the old row
+        // still holds `overview` and the turn dies on the slug constraint -
+        // and it dies there on every following turn too, because each one
+        // seeds its candidate from the same published snapshot (issue #226).
+        //
+        // This runs before any note is read, so a slug-mover that happens to be
+        // unreadable on this pass loses its row and drops out of the generation
+        // this pass publishes, rather than being retained the way the per-note
+        // loop below retains an unreadable note. Retaining it is not available:
+        // its row is precisely the one holding a slug another note is about to
+        // claim. It returns on the first turn that can read it again.
+        let cached_slugs = cached_note_paths_and_slugs(&tx)?;
+        let is_incremental_refresh = !cached_slugs.is_empty();
+        for (cached_path, cached_slug) in &cached_slugs {
+            if slug_by_path.get(cached_path.as_str()) != Some(&cached_slug.as_str()) {
+                delete_note_by_relative_path(&tx, cached_path)?;
             }
         }
 
@@ -994,12 +1014,17 @@ struct CachedNoteState {
     snapshot: FileSnapshot,
 }
 
-fn cached_relative_paths(tx: &Transaction<'_>) -> Result<Vec<String>, String> {
+/// Every cached note as `(relative_path, slug)`. The pass needs both: the path
+/// says whether the note still exists, and the slug says whether this row is
+/// still the one entitled to hold it.
+fn cached_note_paths_and_slugs(tx: &Transaction<'_>) -> Result<Vec<(String, String)>, String> {
     let mut stmt = tx
-        .prepare("SELECT relative_path FROM notes")
+        .prepare("SELECT relative_path, slug FROM notes")
         .map_err(|error| format!("failed to prepare cached path query: {error}"))?;
     let rows = stmt
-        .query_map([], |row| row.get::<_, String>(0))
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
         .map_err(|error| format!("failed to query cached note paths: {error}"))?;
 
     rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -1155,6 +1180,11 @@ fn retain_vanished_classifications(
         .collect()
 }
 
+/// Requires that the caller has already dropped every cached row not entitled
+/// to the slug it holds. Under that precondition a surviving row at
+/// `entry.relative_path` always carries `entry.slug`, and `entry.slug` is held
+/// by no other row, so the upsert below can settle everything through its
+/// `relative_path` conflict target.
 fn upsert_note_if_changed(
     tx: &Transaction<'_>,
     entry: &NoteEntry,
@@ -1196,12 +1226,6 @@ fn upsert_note_if_changed(
             update_note_file_metadata(tx, entry, &content, snapshot, indexed_at)?;
             return Ok(UpsertOutcome::Unchanged);
         }
-    }
-
-    if let Some(cached) = cached.as_ref()
-        && cached.slug != entry.slug
-    {
-        delete_note_by_relative_path(tx, &entry.relative_path)?;
     }
 
     upsert_note_content(tx, entry, &content, &hash, snapshot, indexed_at)?;
@@ -2217,6 +2241,147 @@ mod tests {
         assert!(
             dur.parse::<f64>().is_ok(),
             "duration should parse as f64, got {dur}"
+        );
+    }
+
+    /// Reads the `slug` a note path holds in the notes table, or `None` when
+    /// no row carries that path.
+    #[cfg(test)]
+    fn cached_slug_for_path(cache: &SqliteCache, relative_path: &str) -> Option<String> {
+        let conn = cache.connection().expect("connection");
+        conn.query_row(
+            "SELECT slug FROM notes WHERE relative_path = ?1",
+            params![relative_path],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .expect("query slug")
+    }
+
+    /// A slug comes from a note's filename alone, so `Archive/Overview.md` and
+    /// `Projects/Overview.md` both want `overview`, and the index build hands it
+    /// to whichever path sorts first. The loser's cached row still holds that
+    /// slug when the winner is inserted, and `notes.slug` is unique, so the
+    /// rebuild used to die on the constraint - permanently, because the next
+    /// turn seeds from the same rows and reproduces it (issue #226).
+    #[test]
+    fn a_slug_moving_to_another_path_does_not_break_an_incremental_rebuild() {
+        let dir = tempdir().expect("temp dir");
+        std::fs::create_dir_all(dir.path().join("Projects")).expect("dirs");
+        std::fs::write(
+            dir.path().join("Projects/Overview.md"),
+            "# Overview\n\nprojects body",
+        )
+        .expect("note");
+        let cache = SqliteCache::in_memory(384).expect("cache");
+        let embedder = StubEmbedder::new(384);
+        cache
+            .replace_from_index_with_embedder(
+                &VaultIndex::build(dir.path()).expect("index"),
+                &embedder,
+            )
+            .expect("first populate");
+        assert_eq!(
+            cached_slug_for_path(&cache, "Projects/Overview").as_deref(),
+            Some("overview"),
+            "the only Overview note holds the undecorated slug"
+        );
+
+        std::fs::create_dir_all(dir.path().join("Archive")).expect("dirs");
+        std::fs::write(
+            dir.path().join("Archive/Overview.md"),
+            "# Overview\n\narchive body",
+        )
+        .expect("note");
+        let index = VaultIndex::build(dir.path()).expect("reindex");
+
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("a duplicate filename stem must not fail the rebuild");
+
+        assert_eq!(
+            cached_slug_for_path(&cache, "Archive/Overview").as_deref(),
+            Some("overview"),
+            "the earlier-sorting path takes the slug the build assigned it"
+        );
+        assert_eq!(
+            cached_slug_for_path(&cache, "Projects/Overview").as_deref(),
+            Some("overview-2"),
+            "the note that lost the slug keeps its row under the new one"
+        );
+    }
+
+    /// The pre-pass releases a moving slug before any note is read, so a note
+    /// that is mid-write on the very pass its slug moves away loses its row.
+    /// The alternative is not "keep the note": its row is the one holding the
+    /// slug the arriving note needs, so keeping it fails the whole turn. Pin
+    /// the tradeoff - the pass still publishes everything readable, and the
+    /// note returns on the first pass that can read it.
+    #[test]
+    fn an_unreadable_slug_mover_drops_out_of_the_pass_instead_of_failing_it() {
+        let dir = tempdir().expect("temp dir");
+        std::fs::create_dir_all(dir.path().join("Projects")).expect("dirs");
+        std::fs::write(dir.path().join("Home.md"), "# Home\n\nhome body").expect("note");
+        std::fs::write(
+            dir.path().join("Projects/Overview.md"),
+            "# Overview\n\nprojects body",
+        )
+        .expect("note");
+        let cache = SqliteCache::in_memory(384).expect("cache");
+        let embedder = StubEmbedder::new(384);
+        cache
+            .replace_from_index_with_embedder(
+                &VaultIndex::build(dir.path()).expect("index"),
+                &embedder,
+            )
+            .expect("first populate");
+
+        std::fs::create_dir_all(dir.path().join("Archive")).expect("dirs");
+        std::fs::write(
+            dir.path().join("Archive/Overview.md"),
+            "# Overview\n\narchive body",
+        )
+        .expect("note");
+        let index = VaultIndex::build(dir.path()).expect("reindex");
+        std::fs::remove_file(dir.path().join("Projects/Overview.md"))
+            .expect("make the slug mover unreadable after the scan listed it");
+
+        cache
+            .replace_from_index_with_embedder(&index, &embedder)
+            .expect("one unreadable note must not fail the pass");
+
+        assert_eq!(
+            cached_slug_for_path(&cache, "Archive/Overview").as_deref(),
+            Some("overview"),
+            "the arriving note still takes the slug it was assigned"
+        );
+        assert_eq!(
+            cached_slug_for_path(&cache, "Projects/Overview"),
+            None,
+            "the unreadable slug mover drops out of this generation"
+        );
+        assert_eq!(
+            cached_slug_for_path(&cache, "Home").as_deref(),
+            Some("home"),
+            "every other note is untouched"
+        );
+
+        std::fs::write(
+            dir.path().join("Projects/Overview.md"),
+            "# Overview\n\nprojects body",
+        )
+        .expect("restore the note");
+        cache
+            .replace_from_index_with_embedder(
+                &VaultIndex::build(dir.path()).expect("reindex"),
+                &embedder,
+            )
+            .expect("second populate");
+
+        assert_eq!(
+            cached_slug_for_path(&cache, "Projects/Overview").as_deref(),
+            Some("overview-2"),
+            "and returns on the first pass that can read it, under its new slug"
         );
     }
 

--- a/src/cache/vault_snapshots.rs
+++ b/src/cache/vault_snapshots.rs
@@ -1744,6 +1744,171 @@ mod tests {
         );
     }
 
+    /// A slug is derived from a note's filename alone, so two notes with the
+    /// same stem in different folders compete for it and the index build hands
+    /// it to whichever path sorts first. The Index turn seeds its candidate
+    /// from the published snapshot, where the old holder still owns the slug,
+    /// so the new note's insert used to hit `notes.slug` and fail the turn -
+    /// forever, since the next turn seeds from the same unchanged snapshot
+    /// (issue #226).
+    #[test]
+    fn a_duplicate_filename_stem_in_another_folder_publishes_a_fresh_generation() {
+        let cache = SqliteCache::in_memory(384).expect("open cache");
+        let id = vault_id("12345678-1234-4567-89ab-1234567890ab");
+        let (directory, first_index) = index(&[
+            ("Home.md", "# Home\n\nhome body"),
+            ("Projects/Overview.md", "# Overview\n\nprojects body"),
+        ]);
+        let embedder = CountingEmbedder::new();
+        cache
+            .replace_vault_snapshot(id, &first_index, &embedder)
+            .expect("publish the first snapshot");
+
+        std::fs::create_dir_all(directory.path().join("Archive")).expect("archive dir");
+        std::fs::write(
+            directory.path().join("Archive/Overview.md"),
+            "# Overview\n\narchive body",
+        )
+        .expect("add the colliding note");
+        let collided = VaultIndex::build(directory.path()).expect("rebuild index");
+        embedder.reset();
+
+        cache
+            .replace_vault_snapshot(id, &collided, &embedder)
+            .expect("a duplicate filename stem must not fail the Index turn");
+
+        assert_eq!(
+            cache.snapshot_status(id).expect("read status"),
+            Some(VaultSnapshotStatus {
+                participating: true,
+                freshness: VaultSnapshotFreshness::Fresh,
+                searchable: true,
+            }),
+            "the turn succeeded, so collection reads must stop reporting a stale \
+             participant - a collection read's `partial` is exactly \
+             `any(state != Fresh)` over these participants"
+        );
+        let read = cache
+            .read_vault_snapshot(id)
+            .expect("read snapshot")
+            .expect("snapshot participates")
+            .read;
+        assert_eq!(read.notes.len(), 3, "every visible note is published");
+        assert_eq!(
+            cache
+                .snapshot_note_content(id, "overview")
+                .expect("content")
+                .as_deref(),
+            Some("# Overview\n\narchive body"),
+            "the earlier-sorting path holds the undecorated slug"
+        );
+        assert_eq!(
+            cache
+                .snapshot_note_content(id, "overview-2")
+                .expect("content")
+                .as_deref(),
+            Some("# Overview\n\nprojects body"),
+            "the note that lost the slug stays reachable under its new one"
+        );
+        assert_eq!(
+            cache
+                .snapshot_note_content(id, "home")
+                .expect("content")
+                .as_deref(),
+            Some("# Home\n\nhome body"),
+            "the untouched note is unaffected"
+        );
+        assert_eq!(
+            embedder.embedded(),
+            2,
+            "only the new note and the one whose slug moved may be re-embedded: \
+             an unchanged note still reuses its published vectors"
+        );
+    }
+
+    /// The wedge this bug produced: the prior generation is retained and marked
+    /// stale by a failed turn, and nothing republishes it. One successful turn
+    /// over the same duplicate-stem Vault has to clear that on its own, with no
+    /// file deleted and no cache wiped. The failed turn is staged here through
+    /// the one failure mode a fixed build still has - a Vault that reads as
+    /// empty - because the slug collision itself can no longer fail a turn; what
+    /// matters is that recovery seeds from the same stale published snapshot the
+    /// real wedge leaves behind.
+    #[test]
+    fn a_stale_snapshot_recovers_on_the_first_turn_that_indexes_a_duplicate_stem() {
+        let cache = SqliteCache::in_memory(384).expect("open cache");
+        let id = vault_id("12345678-1234-4567-89ab-1234567890ab");
+        let (directory, first_index) =
+            index(&[("Projects/Overview.md", "# Overview\n\nprojects body")]);
+        let embedder = StubEmbedder::new(384);
+        cache
+            .replace_vault_snapshot(id, &first_index, &embedder)
+            .expect("publish the first snapshot");
+
+        std::fs::create_dir_all(directory.path().join("Archive")).expect("archive dir");
+        std::fs::write(
+            directory.path().join("Archive/Overview.md"),
+            "# Overview\n\narchive body",
+        )
+        .expect("add the colliding note");
+        let collided = VaultIndex::build(directory.path()).expect("rebuild index");
+
+        // Strand the Vault exactly where a failed turn leaves it: the prior
+        // generation retained, searchable, and flagged stale.
+        std::fs::remove_file(directory.path().join("Archive/Overview.md")).expect("remove");
+        std::fs::remove_file(directory.path().join("Projects/Overview.md")).expect("remove");
+        assert!(
+            cache
+                .replace_vault_snapshot(id, &collided, &embedder)
+                .is_err(),
+            "a turn that can read nothing must fail and retain the prior generation"
+        );
+        assert_eq!(
+            cache
+                .snapshot_status(id)
+                .expect("read status")
+                .map(|status| status.freshness),
+            Some(VaultSnapshotFreshness::Stale),
+            "the Vault is now wedged the way the report describes"
+        );
+
+        std::fs::write(
+            directory.path().join("Projects/Overview.md"),
+            "# Overview\n\nprojects body",
+        )
+        .expect("restore");
+        std::fs::write(
+            directory.path().join("Archive/Overview.md"),
+            "# Overview\n\narchive body",
+        )
+        .expect("restore");
+
+        cache
+            .replace_vault_snapshot(id, &collided, &embedder)
+            .expect("one successful turn must clear the wedge");
+
+        assert_eq!(
+            cache.snapshot_status(id).expect("read status"),
+            Some(VaultSnapshotStatus {
+                participating: true,
+                freshness: VaultSnapshotFreshness::Fresh,
+                searchable: true,
+            }),
+            "recovery takes no manual intervention"
+        );
+        assert_eq!(
+            cache
+                .read_vault_snapshot(id)
+                .expect("read snapshot")
+                .expect("snapshot participates")
+                .read
+                .notes
+                .len(),
+            2,
+            "both same-stem notes are published"
+        );
+    }
+
     /// Reuse must never cross an embedding space: a different model wipes the
     /// shared cache before seeding can offer it anything.
     #[test]


### PR DESCRIPTION
Fixes #226.

## The bug

A note's slug comes from its filename stem alone, so `10-topics/Beacon Launch.md` and `20-projects/Beacon Launch.md` both want `beacon-launch`, and the index build hands it to whichever path sorts first. The cache's `notes` table constrains `slug` as well as `relative_path`, but the note upsert declares only a `relative_path` conflict target, so inserting the arriving note while the old holder's row still carried the slug died on `UNIQUE constraint failed: notes.slug`.

That failed the whole Index turn, and permanently. The retained snapshot was marked stale at the start of the turn and never republished, and the next turn seeded its candidate from that same snapshot and failed at the same note. Collection reads reported `partial: true` with a `stale` participant at a frozen `collection_revision` forever, while exact note reads stayed correct because they read the Markdown directly. That is exactly the symptom split in the report.

## The fix

The population pass now drops every cached row that will not still hold its slug when the pass ends (the notes that left the Vault, and the notes whose slug moved to another path) before it writes any row. Each surviving row then holds a slug no other entry wants, so no insert can collide.

This costs nothing the pass was not already spending: the per-note upsert already deleted and re-inserted a row whose slug had changed. The change only moves that delete ahead of every insert, and the now-unreachable branch that did it is removed. Vector reuse is untouched: an unchanged note keeps its row and its chunks, so seeding still spares it a re-embed.

One tradeoff is documented in place: the pre-pass runs before any note is read, so a slug-mover that happens to be unreadable on that pass drops out of the generation it publishes and returns on the next turn that can read it. Retaining it is not available, because its row is precisely the one holding the slug another note is about to claim, and dropping it is a strict improvement on the previous outcome, which was failing the entire turn.

## Tests

Four regression tests, all failing before the fix:

- `a_slug_moving_to_another_path_does_not_break_an_incremental_rebuild` : the populate-level reproduction.
- `a_duplicate_filename_stem_in_another_folder_publishes_a_fresh_generation` : the Index turn succeeds, publishes both notes under distinct slugs, returns to `fresh`, and re-embeds only the two notes that changed.
- `a_stale_snapshot_recovers_on_the_first_turn_that_indexes_a_duplicate_stem` : a Vault stranded with a stale published snapshot recovers on one turn, no file deleted and no cache wiped.
- `an_unreadable_slug_mover_drops_out_of_the_pass_instead_of_failing_it` : pins the tradeoff above.

## Verified live

Against a dev Vault, through MCP:

- Unfixed build: creating `10-topics/Beacon Launch.md` beside the existing `20-projects/Beacon Launch.md` wedged it: `partial: true`, participant `stale`, `vault_index_failed ... UNIQUE constraint failed: notes.slug`, and a further write left it wedged with per-note reads still correct.
- Fixed build, same wedged cache and the same files on disk: recovered on the first turn (`51 notes checked, 3 updated, 48 unchanged`). `get_tree` reports `partial: false` with a `fresh` participant; `beacon-launch` resolves to `10-topics/Beacon Launch` and `beacon-launch-2` to `20-projects/Beacon Launch`.
- A fresh collision created afterwards on the fixed build indexed cleanly, with no failing turns.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all` (950), `cargo test --all --all-features` (956+8+5+1), `node scripts/check-module-map.mjs`, and the documentation freshness review all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
