### PR TITLE
feat(mcp): refresh_vault requests one Vault's next index turn (#228)

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1179,12 +1179,15 @@ notify_definition_changed, subscribe_revisions}`,
 **Consumers:** `handlers/vaults.rs` (every `/api/v1/vaults` route) and
 `mcp/tools/read.rs` (`list_vaults`, `create_vault`, `edit_vault`,
 `enable_vault`, `disable_vault`, `disconnect_vault`, `sync_vault`,
-`retry_vault`). Each is a wire-shaping adapter: it parses transport input,
-calls this core once, and maps the typed response or the structured error onto
-a status code or a structured tool error. No MCP tool calls a handler function
-or decodes an HTTP response for Vault management. `mcp/results.rs` aliases the
-collection wire types as its management tool result types, so the advertised
-`outputSchema` is generated from the same structures the core returns.
+`retry_vault`, `refresh_vault`). `POST /api/v1/vaults/{vault_id}/refresh` and
+the `refresh_vault` MCP tool (#228) are the same single call onto `refresh`,
+the way sync and retry pair across the two surfaces. Each is a wire-shaping
+adapter: it parses transport input, calls this core once, and maps the typed
+response or the structured error onto a status code or a structured tool
+error. No MCP tool calls a handler function or decodes an HTTP response for
+Vault management. `mcp/results.rs` aliases the collection wire types as its
+management tool result types, so the advertised `outputSchema` is generated
+from the same structures the core returns.
 
 **Coordination paths:** `src/lib.rs` (module export).
 
@@ -2019,7 +2022,18 @@ turn (`commit_vault_drift`, `src/git/managed_sync.rs`) already commits
 whatever is dirty at that turn in one commit — a batch's writes therefore
 land in one commit the same way any burst of individual write calls would,
 without changing ADR-10's debounced background-sync semantics. Catalogue
-grows 38 → 39, purely additive.
+grows 38 → 39, purely additive. #228 adds `refresh_vault`, the eighth Vault
+management tool: a write-gated mapping onto the collection management core's
+`refresh`, which admits one Vault's next Index turn and returns its
+`VaultScheduleResponse` (`queued`, or `coalesced` when a turn for that Vault is
+already pending). It exists so a client reading a collection read's `partial:
+true` with a `stale` participant can act on it — `sync_vault` and `retry_vault`
+cannot, because both resolve a managed-Git poll interval first and refuse
+`capability_unavailable` on any Vault with no remote. It is rejected inside
+`batch` like every other management tool, and is deliberately *not* in
+`is_collection_management_tool`: that exemption keeps discovery and Vault
+control reachable while model setup is pending, and an Index turn cannot run
+without a configured search model. Catalogue grows 39 → 40, purely additive.
 
 **Kind:** adapter/security surface.
 
@@ -2062,7 +2076,7 @@ requests with HTTP 429 + `Retry-After`, and is explicitly disableable by
 configuration (`HATCHDOOR_MCP_RATE_LIMITS_ENABLED`; `limits.rs` owns the quota
 window, the concurrency pools, and the POST classification). Every tool response is a typed Rust result structure whose type
 generates the `outputSchema` advertised in `tools/list` (#167), for the full
-39-tool catalogue.
+40-tool catalogue.
 Internal JSON-RPC failures expose the stable `Internal server error` message
 while the adapter logs diagnostics. `McpConfig`, server instructions, tool
 names/schemas/results, and `HatchdoorMcpTransport` (the rmcp-backed transport

--- a/docs/starter-vault/40-reference/Hatchdoor — Agent Guide.md
+++ b/docs/starter-vault/40-reference/Hatchdoor — Agent Guide.md
@@ -47,6 +47,14 @@ Use `get_note` only after search or wikilink resolution identifies the note you 
 
 Use `get_tree` only when folder structure or broad navigation is the task.
 
+## Stale collection reads
+
+`search_notes`, `get_tree`, `get_graph`, `get_stats`, and `recently_modified` answer from a published snapshot rather than reading every file, and they report how fresh that snapshot is. A result carrying `partial: true` means not every enabled Vault contributed; the reason sits on that Vault's entry in `participants`, so read it there rather than guessing from `partial` alone.
+
+An entry reading `stale` is the case an agent can do something about: the Vault's snapshot is known to be behind its Markdown. Call `refresh_vault` with that `vault_id` to request the index turn that republishes it, then read again.
+
+`refresh_vault` returns as soon as the turn is admitted — `queued`, or `coalesced` when a turn for that Vault is already pending — not when the turn finishes. So the response confirms the request landed, not that the index is rebuilt; confirm the outcome from the freshness fields of a second read. It is not `sync_vault`: it contacts no Git remote and works on any enabled Vault, including a plain local one. A read that looks stale is never a reason to fall back to editing files directly.
+
 ## Editing workflow
 
 Before editing an existing note:
@@ -100,7 +108,8 @@ If git sync is enabled, Hatchdoor owns the commit and push workflow for vault wr
 
 After writes, use `list_vaults` to inspect the target Vault's Git status. For
 eligible managed-Git Vaults, `sync_vault` and `retry_vault` require its explicit
-`vault_id`.
+`vault_id`. Neither does anything for a Vault with no configured remote, and
+neither rebuilds the search index: for that, see [[#Stale collection reads]].
 
 Do not run manual git commands against the vault unless the user asks or Hatchdoor reports that automatic sync is disabled.
 

--- a/docs/starter-vault/40-reference/Hatchdoor — Agent Skill.md
+++ b/docs/starter-vault/40-reference/Hatchdoor — Agent Skill.md
@@ -48,6 +48,12 @@ Use `get_note_links` when backlinks or outgoing links matter.
 
 Use `get_tree` only when the task is specifically about folder structure or broad navigation. Collection responses may be partial; branch on structured error `code`, not message text.
 
+## Stale collection reads
+
+`search_notes`, `get_tree`, `get_graph`, `get_stats`, and `recently_modified` answer from a published snapshot and report its freshness. When a result comes back with `partial: true` and the Vault's entry in `participants` reads `stale`, that snapshot is behind the Vault's Markdown.
+
+Call `refresh_vault` with that `vault_id` to request the index turn that republishes it, then re-read. It returns as soon as the turn is admitted (`queued`, or `coalesced` when one is already pending), not when the turn finishes, so check the freshness fields again rather than trusting the response. This is not `sync_vault`: it contacts no Git remote and works on any Vault. Do not fall back to editing files directly because a read looked stale.
+
 ## Writing
 
 For existing notes:

--- a/docs/user-vault/03 Reference/MCP tools reference.md
+++ b/docs/user-vault/03 Reference/MCP tools reference.md
@@ -16,7 +16,7 @@ Two independent gates decide what a call can do:
 A third, per-Vault gate sits underneath write mode: a Vault's own `capabilities.mutate` (from its source type and lifecycle phase — a `pull_only` Git Vault, or one not yet `ready`, refuses writes even with `HATCHDOOR_MCP_WRITE_ENABLED=true`). Check `list_vaults` for a Vault's current capabilities before writing to it.
 
 > [!note]
-> The full tool catalogue is always advertised, even before the model-setup completes and even at zero Vaults, so a client that caches tools at connection time never needs to reconnect. Before setup finishes, only `get_model_setup_status`, `accept_gemma_terms`, `decline_gemma_terms`, and the Vault collection discovery/management tools (`list_vaults` and friends) actually run; every other tool returns "Hatchdoor is still being set up." until a model is selected.
+> The full tool catalogue is always advertised, even before the model-setup completes and even at zero Vaults, so a client that caches tools at connection time never needs to reconnect. Before setup finishes, only `get_model_setup_status`, `accept_gemma_terms`, `decline_gemma_terms`, and the Vault collection discovery/management tools (`list_vaults` and friends) actually run; every other tool returns "Hatchdoor is still being set up." until a model is selected. `refresh_vault` is the one management tool outside that exception: the index turn it asks for cannot run without a search model, so before setup finishes it answers like any other content tool.
 
 There is no selected, sole, or default Vault. Every tool below that touches content takes an explicit `vault_id`; every collection-level tool takes an explicit `scope` (a Vault ID or the literal `all`).
 
@@ -35,7 +35,7 @@ Always available, regardless of `HATCHDOOR_MCP_ENABLED`'s write posture — thes
 
 ## Vault collection: discovery and management
 
-`list_vaults` is always available. The other six require `HATCHDOOR_MCP_WRITE_ENABLED`; without it they return the same "MCP write tools are disabled" error as content write tools.
+`list_vaults` is always available. The other eight require `HATCHDOOR_MCP_WRITE_ENABLED`; without it they return the same "MCP write tools are disabled" error as content write tools.
 
 A listed Vault with a remote to poll also carries two RFC 3339 UTC timestamps describing its Git schedule: `last_checked_at`, when Hatchdoor last tried to check the remote — whether that check succeeded or failed, so read it alongside the Vault's Git status rather than as a successful sync — and `next_attempt_at`, when the next scheduled check is due. `last_checked_at` is absent until the first check completes; both are absent for a Vault with no remote and in demo mode. They are described in full under **Git schedule fields on a listed Vault** in [[HTTP API reference]], whose Vault shape `list_vaults` returns verbatim.
 
@@ -49,6 +49,7 @@ A listed Vault with a remote to poll also carries two RFC 3339 UTC timestamps de
 | `disconnect_vault` | Write mode | Remove a Vault from the registry without deleting local files, checkouts, Git history, or credentials outside the registry record. |
 | `sync_vault` | Write mode | Request immediate managed-Git synchronization for one eligible Vault. |
 | `retry_vault` | Write mode | Retry an admitted managed-Git operation for one eligible Vault. |
+| `refresh_vault` | Write mode | Request one Vault's next index turn, so the snapshot the collection reads project from is rebuilt from its Markdown. |
 
 ### `create_vault`
 
@@ -85,6 +86,28 @@ All three take just `vault_id` and `expected_registry_revision`.
 ### `sync_vault` / `retry_vault`
 
 Both take just `vault_id`. `sync_vault` requests an immediate poll for a managed-Git Vault instead of waiting for `poll_interval_secs`. `retry_vault` retries an operation the scheduler admitted but that failed (e.g. a transient network error), rather than waiting for its own backoff.
+
+Neither works on a Vault with no configured remote: both resolve the Vault's Git poll interval first and refuse with `capability_unavailable` when there is none. For rebuilding the search index of any Vault, remote or not, use `refresh_vault`.
+
+### `refresh_vault`
+
+Takes just `vault_id`. It asks Hatchdoor to re-scan that Vault's Markdown and republish the snapshot the collection reads — `get_tree`, `get_graph`, `get_stats`, `recently_modified` and `search_notes` — project from. It contacts no Git remote, so unlike `sync_vault` it works on a plain local Vault.
+
+**Call it when a collection read reports itself stale.** Those reads carry `partial` and a `participants` list (see [[#Read-only content tools]] below). A Vault whose entry reads `stale` is answering from a snapshot known to be behind its files; `refresh_vault` is how an agent asks for that to be fixed instead of waiting and hoping.
+
+It returns as soon as the turn is admitted, not when the turn finishes:
+
+| `schedule` | Meaning |
+| --- | --- |
+| `queued` | The Vault's next index turn was admitted. |
+| `coalesced` | An index turn for this Vault was already pending; this request joined it rather than queueing a second one. |
+
+So the response tells you the request landed, not that the index is rebuilt. To see the outcome, re-read a collection read and check its freshness fields again.
+
+A Vault that is not currently browsable — its `capabilities.browse` is false, which covers a missing or unreadable directory and a Vault whose runtime has not come up — is refused with `capability_unavailable`, marked retryable because the Vault may become browsable again.
+
+> [!note]
+> `refresh_vault` rebuilds the read model from the Markdown that is on disk. It does not repair a Vault whose index turn is failing for its own reasons: a turn that fails deterministically will fail the same way again.
 
 ## Vault source shapes
 
@@ -148,7 +171,7 @@ Available whenever MCP is enabled, independent of write mode.
 | `get_attachment` | `vault_id`, `relative_path` | Fetch one attachment's bytes, addressed by the same `relative_path` `list_note_attachments` reports. Optional `encoding`: `url` (the default) returns a `download_url`, `base64` returns the bytes inline. |
 | `get_attachment_import_config` | `vault_id` | Report whether uploads are currently possible for this Vault, the available methods, their byte limits, and the allowed file extensions. Call this before uploading. |
 
-Collection-scoped results (`search_notes`, `get_tree`, `get_stats`, `get_graph`, `recently_modified` with `scope: "all"`) carry `scope`, `collection_revision`, `partial`, and `participants` — an agent should branch on the structured error `code`, never on message text, and should treat `partial: true` as "not every enabled Vault contributed to this result," not as an error. A Vault can sit out for more than one reason — its snapshot was not readable, or, on `get_tree`, it simply does not have the folder that was asked for — so read the reason off that Vault's entry in `participants` rather than inferring it from `partial` alone.
+Collection-scoped results (`search_notes`, `get_tree`, `get_stats`, `get_graph`, `recently_modified` with `scope: "all"`) carry `scope`, `collection_revision`, `partial`, and `participants` — an agent should branch on the structured error `code`, never on message text, and should treat `partial: true` as "not every enabled Vault contributed to this result," not as an error. A Vault can sit out for more than one reason — its snapshot was not readable, or, on `get_tree`, it simply does not have the folder that was asked for — so read the reason off that Vault's entry in `participants` rather than inferring it from `partial` alone. A Vault whose entry reads `stale` is a case an agent can act on rather than only report: its snapshot is known to be behind its Markdown, and `refresh_vault`, under [[#Vault collection: discovery and management]], asks for the index turn that republishes it.
 
 `get_tree` with nothing but `scope` returns the whole Vault, which on a few hundred notes is large enough to overflow a client's per-result budget. Three optional arguments narrow it. `include_notes: false` is the cheap one to open with: it returns every folder at every level with its note count and no notes at all, so a several-hundred-note Vault's shape costs on the order of a kilobyte instead of seventy. `folder` returns one subtree — `"40-reference/Parenting"`, matched case-insensitively, surrounding slashes ignored. `max_depth` stops the descent: the starting folder is depth 0, a folder at the limit is listed with its count but not opened, and one that had something inside it is marked `truncated` so it cannot be mistaken for an empty leaf. Every folder reports `note_count`, the notes held directly inside it, not counting its subfolders; a subtree total is the sum of those. A `folder` naming something the Vault does not have answers the structured error `folder_not_found` rather than an empty tree, so a typo never reads as an empty folder. With `scope: "all"` that refusal is per-Vault: the Vaults that do have the folder still answer, each Vault that does not appears in `participants` carrying `folder_not_found`, and the result is marked `partial`. Only when no Vault has it does the whole call refuse, and that refusal names no Vault, because none of them is more at fault than the others; the per-Vault refusals stay on `participants`, where each one does name its own Vault.
 
@@ -209,7 +232,7 @@ A write conflict (stale `expected_content_hash`, or a registry revision that mov
 }
 ```
 
-**What may go in.** Every read tool except `list_vaults`, and every note and attachment write tool — `create_note` through `delete_attachment`, deletes included. Vault-management tools (`create_vault`, `edit_vault`, `enable_vault`, `disable_vault`, `disconnect_vault`, `sync_vault`, `retry_vault`) and the model-setup tools are not batchable, and neither is `batch` itself. An unknown or disallowed `op`, an empty `operations` array, more than **50** read-shaped items, or more than **20** write-shaped items rejects the whole call up front, before any item executes.
+**What may go in.** Every read tool except `list_vaults`, and every note and attachment write tool — `create_note` through `delete_attachment`, deletes included. Vault-management tools (`create_vault`, `edit_vault`, `enable_vault`, `disable_vault`, `disconnect_vault`, `sync_vault`, `retry_vault`, `refresh_vault`) and the model-setup tools are not batchable, and neither is `batch` itself. An unknown or disallowed `op`, an empty `operations` array, more than **50** read-shaped items, or more than **20** write-shaped items rejects the whole call up front, before any item executes.
 
 **Best-effort, in order, no rollback.** Items run one after another; an item that fails never stops the ones after it, and nothing already written is undone. There is no mid-batch visibility either — an item sees the Vault, not the batch's own bookkeeping, apart from the hash chaining below.
 

--- a/src/mcp/results.rs
+++ b/src/mcp/results.rs
@@ -54,6 +54,7 @@ pub type DisableVaultResult = VaultMutationResponse;
 pub type DisconnectVaultResult = VaultMutationResponse;
 pub type SyncVaultResult = VaultScheduleResponse;
 pub type RetryVaultResult = VaultScheduleResponse;
+pub type RefreshVaultResult = VaultScheduleResponse;
 
 // ---------------------------------------------------------------------------
 // Setup-tool results (always advertised, answered before any Vault exists)
@@ -311,6 +312,7 @@ output_schemas! {
     "disconnect_vault" => DisconnectVaultResult,
     "sync_vault" => SyncVaultResult,
     "retry_vault" => RetryVaultResult,
+    "refresh_vault" => RefreshVaultResult,
     // Note/attachment write tools
     "create_note" => NoteWriteResult,
     "update_note" => NoteWriteResult,
@@ -376,12 +378,12 @@ mod schema_tests {
             .collect();
         let total = names.len();
         assert_eq!(
-            total, 39,
-            "3 setup + 13 read + 1 batch + 7 management + 15 write tools"
+            total, 40,
+            "3 setup + 13 read + 1 batch + 8 management + 15 write tools"
         );
         names.sort();
         names.dedup();
-        assert_eq!(names.len(), 39, "tool names are unique across catalogues");
+        assert_eq!(names.len(), 40, "tool names are unique across catalogues");
 
         for name in &names {
             assert!(

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -369,6 +369,53 @@ mod tests {
         (state, tmp)
     }
 
+    /// `write_state`, but keeping the work worker `base_state` otherwise drops
+    /// on the floor, so a test can run the Index turn `refresh_vault` admits.
+    /// The coordinator is swapped wholesale rather than threaded through
+    /// `base_state`: `refresh` reaches the queue through `state.vault_work`
+    /// alone, and nothing here drives managed Git.
+    fn write_state_with_worker() -> (AppState, crate::vault_work::VaultWorkWorker, TempDir) {
+        let (mut state, tmp) = write_state();
+        let (vault_work, worker) = crate::vault_work::VaultWorkCoordinator::new();
+        state.vault_work = vault_work;
+        (state, worker, tmp)
+    }
+
+    /// A write-enabled state whose single registered Vault has lost its
+    /// directory since it was registered, so it reconciles with no usable
+    /// local Markdown and `capabilities.browse` false. The registry refuses an
+    /// unreadable path outright, which is why the directory exists for the
+    /// `add` and is removed before the reconcile that matters.
+    fn unusable_local_content_write_state() -> (AppState, TempDir) {
+        use crate::vault_registry::{NewVaultDefinition, VaultSource};
+
+        let tmp = TempDir::new().expect("temp dir");
+        let vault_root = tmp.path().join("vault-gone");
+        std::fs::create_dir_all(&vault_root).expect("create vault");
+        let mut state = base_state(&tmp);
+        state.runtime_config = mcp_runtime_config(true);
+        let snapshot = state
+            .vault_registry
+            .add(
+                0,
+                NewVaultDefinition {
+                    name: "Vault with no local content".to_string(),
+                    enabled: true,
+                    source: VaultSource::Local {
+                        path: vault_root.clone(),
+                    },
+                    exclude_patterns: Vec::new(),
+                    https_credentials: None,
+                    archive_folder: None,
+                    commit_identity: None,
+                },
+            )
+            .expect("register test Vault");
+        std::fs::remove_dir_all(&vault_root).expect("remove the Vault directory");
+        state.vaults.reconcile(&state.vault_registry, &snapshot);
+        (state, tmp)
+    }
+
     /// A zero-Vault registry, for discovery/repair reachability tests (#103).
     fn empty_test_state() -> (AppState, TempDir) {
         let tmp = TempDir::new().expect("temp dir");
@@ -1583,6 +1630,7 @@ mod tests {
             "edit_vault",
             "disable_vault",
             "sync_vault",
+            "refresh_vault",
         ] {
             assert!(
                 names.contains(&expected),
@@ -1615,6 +1663,199 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("write tools are disabled")
+        );
+    }
+
+    /// `refresh_vault` (#228) is the only MCP path to a Vault's next Index
+    /// turn, which is what republishes the snapshot every collection read
+    /// projects from. It admits the turn and returns; a second request while
+    /// one is pending joins it rather than piling a second turn onto the
+    /// Vault.
+    #[tokio::test]
+    async fn refresh_vault_admits_one_index_turn_and_coalesces_the_next() {
+        let (state, _tmp) = write_state();
+        let vault_id = vault_id_of(&state);
+
+        let queued = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(
+            queued["result"]["structuredContent"]["schedule"], "queued",
+            "{queued:#}"
+        );
+        assert_eq!(
+            queued["result"]["structuredContent"]["vault_id"],
+            json!(vault_id),
+            "{queued:#}"
+        );
+
+        let coalesced = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(
+            coalesced["result"]["structuredContent"]["schedule"], "coalesced",
+            "{coalesced:#}"
+        );
+    }
+
+    /// The annotations and the one-property schema an agent chooses on. They
+    /// match `sync_vault`/`retry_vault`: not read-only, not destructive,
+    /// idempotent, not open-world.
+    #[tokio::test]
+    async fn refresh_vault_is_advertised_as_an_idempotent_non_destructive_vault_control() {
+        let (state, _tmp) = write_state();
+        let tool = tool_named(&tools_list_result(&state).await, "refresh_vault").clone();
+
+        assert_eq!(tool["annotations"]["readOnlyHint"], false, "{tool:#}");
+        assert_eq!(tool["annotations"]["destructiveHint"], false, "{tool:#}");
+        assert_eq!(tool["annotations"]["idempotentHint"], true, "{tool:#}");
+        assert_eq!(tool["annotations"]["openWorldHint"], false, "{tool:#}");
+        assert_eq!(tool["inputSchema"]["required"], json!(["vault_id"]));
+        assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+        assert_eq!(
+            tool["inputSchema"]["properties"]
+                .as_object()
+                .expect("properties")
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["vault_id"],
+            "refresh_vault takes vault_id and nothing else"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_vault_is_hidden_and_rejected_without_mcp_write_permission() {
+        let (state, _tmp) = test_state();
+        let body = tools_list_result(&state).await;
+        assert!(
+            !body["result"]["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tool| tool["name"] == "refresh_vault")
+        );
+
+        let rejected = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(rejected["error"]["code"], -32602);
+        assert!(
+            rejected["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("write tools are disabled")
+        );
+    }
+
+    /// Every way of naming the wrong Vault, refused exactly as the other
+    /// single-Vault management tools refuse it: `all` and a malformed ID are
+    /// the core's structured `invalid_vault_id`, an unregistered ID is
+    /// `vault_not_found`, and an unexpected property is a protocol-level
+    /// rejection from `deny_unknown_fields`.
+    #[tokio::test]
+    async fn refresh_vault_rejects_all_a_malformed_id_an_unknown_id_and_extra_properties() {
+        let (state, _tmp) = write_state();
+
+        for raw in ["all", "not-a-uuid"] {
+            let body = call_tool_unscoped(&state, "refresh_vault", json!({"vault_id": raw})).await;
+            assert_eq!(body["result"]["isError"], true, "{raw}: {body:#}");
+            assert_eq!(
+                body["result"]["structuredContent"]["code"], "invalid_vault_id",
+                "{raw}: {body:#}"
+            );
+        }
+
+        let unknown = call_tool_unscoped(
+            &state,
+            "refresh_vault",
+            json!({"vault_id": "018f47a0-7768-4d0c-8da3-5aa28d1c31c7"}),
+        )
+        .await;
+        assert_eq!(unknown["result"]["isError"], true, "{unknown:#}");
+        assert_eq!(
+            unknown["result"]["structuredContent"]["code"], "vault_not_found",
+            "{unknown:#}"
+        );
+
+        let extra = call_tool(
+            &state,
+            "refresh_vault",
+            json!({"expected_registry_revision": 0}),
+        )
+        .await;
+        assert_eq!(extra["error"]["code"], -32602, "{extra:#}");
+    }
+
+    /// A Vault with no currently usable local Markdown has nothing to scan, so
+    /// the core refuses with `capability_unavailable` marked retryable — the
+    /// Vault may become browsable again — rather than a generic failure.
+    #[tokio::test]
+    async fn refresh_vault_on_a_vault_without_usable_local_markdown_is_retryable() {
+        let (state, _tmp) = unusable_local_content_write_state();
+
+        let body = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(body["result"]["isError"], true, "{body:#}");
+        assert_eq!(
+            body["result"]["structuredContent"]["code"], "capability_unavailable",
+            "{body:#}"
+        );
+        assert_eq!(
+            body["result"]["structuredContent"]["retryable"], true,
+            "{body:#}"
+        );
+    }
+
+    /// The point of the tool (#228): the freshness flags a collection read
+    /// publishes are only actionable if an MCP client can act on them. A stale
+    /// snapshot reads `partial: true`; one `refresh_vault` and the Index turn
+    /// it admits clears it.
+    #[tokio::test]
+    async fn refresh_vault_clears_a_partial_collection_read_once_its_turn_completes() {
+        let (state, mut worker, _tmp) = write_state_with_worker();
+        let vault_id = vault_id_of(&state);
+        let vault_root = registered_vault_path(&state);
+
+        state
+            .startup_sqlite
+            .mark_vault_snapshot_stale(vault_id)
+            .expect("stale the published snapshot");
+
+        let before = call_tool(&state, "get_tree", json!({})).await;
+        assert_eq!(
+            before["result"]["structuredContent"]["partial"], true,
+            "{before:#}"
+        );
+        assert_eq!(
+            before["result"]["structuredContent"]["participants"][0]["state"], "stale",
+            "{before:#}"
+        );
+
+        let queued = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(
+            queued["result"]["structuredContent"]["schedule"], "queued",
+            "{queued:#}"
+        );
+
+        // Stands in for the runtime worker's Index turn: the authoritative
+        // Markdown scan and atomic snapshot publication that `refresh_vault`
+        // only admits, never performs itself.
+        let cache = Arc::clone(&state.startup_sqlite);
+        let embedder = Arc::clone(&state.embedder);
+        let outcome = worker
+            .run_next(|request| async move {
+                assert_eq!(request.kind(), crate::vault_work::VaultWorkKind::Index);
+                let index = crate::vault::VaultIndex::build(&vault_root).expect("rebuild index");
+                cache
+                    .replace_vault_snapshot(request.vault_id(), &index, embedder.as_ref())
+                    .expect("republish snapshot");
+                Ok::<(), crate::vault_work::VaultWorkError>(())
+            })
+            .await
+            .expect("the admitted turn ran");
+        assert_eq!(outcome.request.vault_id(), vault_id);
+
+        let after = call_tool(&state, "get_tree", json!({})).await;
+        assert_eq!(
+            after["result"]["structuredContent"]["partial"], false,
+            "{after:#}"
+        );
+        assert_eq!(
+            after["result"]["structuredContent"]["participants"][0]["state"], "fresh",
+            "{after:#}"
         );
     }
 
@@ -1681,6 +1922,42 @@ mod tests {
         assert_eq!(
             blocked["result"]["content"][0]["text"],
             "Hatchdoor is still being set up. Use get_model_setup_status, accept_gemma_terms, or decline_gemma_terms first."
+        );
+    }
+
+    /// `refresh_vault` is deliberately outside the collection-management
+    /// exemption that keeps discovery and Vault control reachable while model
+    /// setup is pending (#228). That exemption is for tools which stay
+    /// meaningful at zero enabled Vaults or on a registry needing recovery;
+    /// the Index turn `refresh_vault` asks for cannot run without a configured
+    /// search model, so a caller gets the setup signal instead of a queued
+    /// turn that would go nowhere.
+    #[tokio::test]
+    async fn refresh_vault_is_not_exempt_from_the_pending_model_setup_gate() {
+        let (state, _tmp) = write_state();
+        state.startup.set_terms_required();
+
+        let blocked = call_tool(&state, "refresh_vault", json!({})).await;
+        assert_eq!(blocked["result"]["isError"], true, "{blocked:#}");
+        assert_eq!(
+            blocked["result"]["content"][0]["text"],
+            "Hatchdoor is still being set up. Use get_model_setup_status, accept_gemma_terms, or decline_gemma_terms first."
+        );
+
+        let listed = call_tool(&state, "list_vaults", json!({})).await;
+        assert!(
+            listed["result"]["structuredContent"]["vaults"].is_array(),
+            "collection discovery stays reachable during pending setup: {listed:#}"
+        );
+
+        // `sync_vault` is the neighbouring Vault control that *is* exempt, so
+        // the difference is pinned rather than assumed. It still fails here —
+        // the test Vault is Local, with no remote to poll — but it fails with
+        // the core's own refusal, which is only reachable past the setup gate.
+        let synced = call_tool(&state, "sync_vault", json!({})).await;
+        assert_eq!(
+            synced["result"]["structuredContent"]["code"], "capability_unavailable",
+            "sync_vault reaches the core during pending setup: {synced:#}"
         );
     }
 
@@ -3099,29 +3376,40 @@ mod tests {
         let (state, _tmp) = write_state();
         let vault_id = vault_id_of(&state);
 
-        let body = call_tool(
-            &state,
-            "batch",
-            json!({"operations": [
-                {"op": "disable_vault", "arguments": {"vault_id": vault_id, "expected_registry_revision": 0}},
-                {"op": "create_note", "arguments": {"vault_id": vault_id, "relative_path": "Should/NotExist.md", "content": "x"}}
-            ]}),
-        )
-        .await;
+        for (index, management) in [
+            json!({"op": "disable_vault", "arguments": {"vault_id": vault_id, "expected_registry_revision": 0}}),
+            json!({"op": "refresh_vault", "arguments": {"vault_id": vault_id}}),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let op = management["op"].clone();
+            // A distinct path per case, so a note left behind by one case
+            // cannot be mistaken for the other's.
+            let relative_path = format!("Should/NotExist{index}.md");
+            let body = call_tool(
+                &state,
+                "batch",
+                json!({"operations": [
+                    management,
+                    {"op": "create_note", "arguments": {"vault_id": vault_id, "relative_path": relative_path, "content": "x"}}
+                ]}),
+            )
+            .await;
 
-        assert_eq!(body["error"]["code"], -32602);
-        assert!(
-            body["error"]["message"]
-                .as_str()
-                .unwrap()
-                .contains("not a valid batch operation")
-        );
-        assert!(
-            !registered_vault_path(&state)
-                .join("Should/NotExist.md")
-                .exists(),
-            "nothing in the batch may execute once any op is rejected up front"
-        );
+            assert_eq!(body["error"]["code"], -32602, "{op}: {body:#}");
+            assert!(
+                body["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not a valid batch operation"),
+                "{op}: {body:#}"
+            );
+            assert!(
+                !registered_vault_path(&state).join(&relative_path).exists(),
+                "{op}: nothing in the batch may execute once any op is rejected up front"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -292,7 +292,7 @@ fn failure_to_error_value(failure: JsonRpcFailure) -> Value {
 pub(super) fn batch_tool_schema() -> Value {
     json!({
         "name": "batch",
-        "description": "Execute an ordered list of note and attachment operations in one call — the same tools available standalone (create_note through delete_attachment, and every read tool except list_vaults). Vault-management tools (create_vault, edit_vault, enable_vault, disable_vault, disconnect_vault, sync_vault, retry_vault, list_vaults) are not allowed inside a batch; those and any unrecognized op are rejected before anything executes. Execution is in order and best-effort: each item reports its own ok/result/error, one item failing does not stop the rest, and there is no rollback or mid-batch visibility between items. All resulting Vault changes are committed together on the Vault's next Git sync turn, the same as any other burst of writes. expected_content_hash checks are skipped between items that share a vault_id and slug: create or edit a note earlier in this batch, then reference it again later in the same call without knowing the intermediate hash; a note not otherwise touched in this batch still validates its expected_content_hash normally. A batch may contain at most 50 read-shaped items and 20 write-shaped items.",
+        "description": "Execute an ordered list of note and attachment operations in one call — the same tools available standalone (create_note through delete_attachment, and every read tool except list_vaults). Vault-management tools (create_vault, edit_vault, enable_vault, disable_vault, disconnect_vault, sync_vault, retry_vault, refresh_vault, list_vaults) are not allowed inside a batch; those and any unrecognized op are rejected before anything executes. Execution is in order and best-effort: each item reports its own ok/result/error, one item failing does not stop the rest, and there is no rollback or mid-batch visibility between items. All resulting Vault changes are committed together on the Vault's next Git sync turn, the same as any other burst of writes. expected_content_hash checks are skipped between items that share a vault_id and slug: create or edit a note earlier in this batch, then reference it again later in the same call without knowing the intermediate hash; a note not otherwise touched in this batch still validates its expected_content_hash normally. A batch may contain at most 50 read-shaped items and 20 write-shaped items.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -346,6 +346,7 @@ mod tests {
             "disconnect_vault",
             "sync_vault",
             "retry_vault",
+            "refresh_vault",
             "get_model_setup_status",
             "accept_gemma_terms",
             "decline_gemma_terms",

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -125,6 +125,7 @@ pub async fn handle_tools_call(
         }
         "sync_vault" if config.write_enabled => read::sync_vault_tool(state, arguments).await,
         "retry_vault" if config.write_enabled => read::retry_vault_tool(state, arguments).await,
+        "refresh_vault" if config.write_enabled => read::refresh_vault_tool(state, arguments).await,
         write_op if write::WRITE_OPS.contains(&write_op) && config.write_enabled => {
             let vault = write::scoped_vault(&state, &arguments)?;
             // This is the same per-Vault mutation lock used by the V1 HTTP
@@ -137,7 +138,7 @@ pub async fn handle_tools_call(
             Err(JsonRpcFailure::invalid_params(WRITE_DISABLED_MESSAGE))
         }
         "create_vault" | "edit_vault" | "enable_vault" | "disable_vault" | "disconnect_vault"
-        | "sync_vault" | "retry_vault" => {
+        | "sync_vault" | "retry_vault" | "refresh_vault" => {
             Err(JsonRpcFailure::invalid_params(WRITE_DISABLED_MESSAGE))
         }
         other => Err(JsonRpcFailure::invalid_params(format!(
@@ -320,6 +321,14 @@ pub fn setup_tools_list() -> Vec<Value> {
 /// registry needing recovery. `config.write_enabled` still gates the
 /// mutating ones exactly as it does when the legacy readiness gate is not the
 /// blocker in play.
+///
+/// `refresh_vault` is deliberately absent (#228), and its absence is the
+/// decision rather than an oversight: this exemption is for tools that stay
+/// meaningful at zero enabled Vaults or on a registry needing recovery, and
+/// `refresh_vault` targets one enabled, browsable Vault whose Index turn
+/// cannot run without a configured search model. A caller reaching for it
+/// during pending setup should get the model-setup signal like any other
+/// content tool.
 fn is_collection_management_tool(name: &str) -> bool {
     matches!(
         name,

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -775,6 +775,22 @@ pub(super) async fn retry_vault_tool(
     )
 }
 
+/// Unlike `sync_vault`/`retry_vault` above, this one talks to no Git remote:
+/// it admits the Vault's next Index turn, which is what republishes the
+/// snapshot every collection read projects from. It is the only MCP path to
+/// that turn, and the reason a client can now act on a collection read that
+/// reports itself stale rather than only observe it (#228).
+pub(super) async fn refresh_vault_tool(
+    state: AppState,
+    arguments: Value,
+) -> Result<Value, JsonRpcFailure> {
+    let args: VaultIdArgs = parse("refresh_vault", arguments)?;
+    let core = VaultCollectionManagement::new(&state);
+    management_result::<results::RefreshVaultResult>(
+        management_vault_id(&args.vault_id).and_then(|vault_id| core.refresh(vault_id)),
+    )
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct EmptyArgs {}
@@ -1056,6 +1072,7 @@ pub(super) fn management_tools_list() -> Vec<Value> {
         ),
         json!({"name":"sync_vault","description":"Request immediate managed-Git synchronization for exactly one eligible Vault.","inputSchema":{"type":"object","properties":{"vault_id":vault_id_schema()},"required":["vault_id"],"additionalProperties":false},"annotations":super::write_tool_annotations(false, true)}),
         json!({"name":"retry_vault","description":"Retry an admitted managed-Git operation for exactly one eligible Vault.","inputSchema":{"type":"object","properties":{"vault_id":vault_id_schema()},"required":["vault_id"],"additionalProperties":false},"annotations":super::write_tool_annotations(false, true)}),
+        json!({"name":"refresh_vault","description":"Request one Vault's next index turn: Hatchdoor re-scans that Vault's Markdown and republishes the snapshot get_tree, get_graph, get_stats, recently_modified and search_notes project from. Call this when one of those reads comes back with partial: true and a stale participant for the Vault. This is not sync_vault: it contacts no Git remote and works on any enabled Vault with usable local Markdown. It returns as soon as the turn is admitted, not when the turn finishes — schedule is queued, or coalesced when a turn for that Vault is already pending — so observe the outcome by re-reading a collection read's freshness fields rather than by this response.","inputSchema":{"type":"object","properties":{"vault_id":vault_id_schema()},"required":["vault_id"],"additionalProperties":false},"annotations":super::write_tool_annotations(false, true)}),
     ]
 }
 
@@ -1205,6 +1222,7 @@ mod tests {
             "disconnect_vault",
             "sync_vault",
             "retry_vault",
+            "refresh_vault",
         ] {
             let tool = tools
                 .iter()


### PR DESCRIPTION
Closes #228.

Collection reads report honestly when their published snapshot has fallen behind the Markdown, but an MCP client had no way to act on that report. `sync_vault` and `retry_vault` cannot stand in: both resolve a managed-Git poll interval first and refuse with `capability_unavailable` on any Vault with no remote, so a plain local Vault had no MCP path to a rebuild at all.

`refresh_vault` takes one `vault_id`, calls the Vault collection management core's existing `refresh`, and returns its schedule response.

## Interface change

```
Interface change: refresh_vault MCP tool
Producer boundary: MCP adapter (src/mcp/)
Kind: additive
Old contract: no MCP path to a Vault's index turn; sync_vault/retry_vault refuse on any Vault with no remote
New contract: refresh_vault { vault_id } -> VaultScheduleResponse { vault_id, schedule }, schedule queued|coalesced;
  write-mode gated; rejected inside batch; annotations readOnly=false, destructive=false, idempotent=true, openWorld=false
Consumer boundaries: MCP clients (external, unknown). No in-repository consumer beyond the catalogue's own tests and docs.
Compatibility/migration: purely additive, catalogue 39 -> 40. No existing tool's shape or behaviour changes.
Rollout/rollback: none needed; removing the tool is the rollback.
Evidence: see Validation below.
```

ADR checks: ADR-19 holds, the tool is a wire-shaping adapter that calls the core once and never reaches past it. ADR-03 N/A, it mutates no Markdown. ADR-01 unchanged, SQLite stays disposable and this asks for a rebuild. ADR-13, no new abstraction; it reuses `VaultScheduleResponse` and the existing management helpers. Auth is no weaker: write-mode gated like every other Vault control.

## Decisions carried from the ticket, not reopened

- A new tool rather than widening `sync_vault`, so an agent can tell which behaviour it got on a given Vault.
- Gated on MCP write mode, like every other Vault control.
- Returns once the turn is admitted, matching `POST /api/v1/vaults/{vault_id}/refresh`.
- Deliberately **not** added to the collection-management predicate that lets a tool through while model setup is pending. That exemption is for tools which stay meaningful at zero enabled Vaults or on a registry needing recovery; an index turn cannot run without a configured search model. A test pins the difference against `sync_vault`, which is exempt.

## Validation

Run from the repository root:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (959 passed)
- `cargo test --all --all-features` (965 + 8 + 5 + 1 passed)
- `node scripts/check-module-map.mjs`
- `node scripts/check-docs-freshness.mjs --validate-table`
- `just docs-freshness`, all four named notes read, then `just docs-freshness-ack`

Live acceptance against a running dev server over the real `/mcp` endpoint (`just dev-start`, clean and messy Vault fixtures):

| Case | Result |
| --- | --- |
| Enabled, browsable Vault | `queued`, and an index turn ran for that Vault (log-correlated on an idle queue) |
| Second request while a turn is pending | `coalesced`, including under genuine contention behind a long running turn |
| Write mode off | not advertised; refused with the same message `sync_vault` gives |
| Vault with no usable local Markdown | `capability_unavailable`, `retryable: true` |
| `vault_id: "all"` / malformed | `invalid_vault_id` |
| Unknown but well-formed ID | `vault_not_found` |
| Disabled Vault | `vault_disabled` |
| Unexpected extra property | JSON-RPC `-32602` |
| `tools/list` | annotations and one-property schema as specified, `outputSchema` present |
| `batch` containing `refresh_vault` | rejected up front, the following `create_note` never executed |

## Documentation

`MCP tools reference` (new `refresh_vault` section, plus the pending-setup callout corrected for the exception this branch introduces and a pre-existing tool-count off-by-one fixed), the starter Vault's `Agent Guide` and `Agent Skill` (a "Stale collection reads" section in each), and the module map's MCP adapter and Vault collection management sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
