### PR TITLE
docs(mcp): state the folder rule for asset travel (#231)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -143,9 +143,9 @@ Copy this for a new record:
 
 - **Status:** Accepted
 - **Context:** Agents and the UI can delete or archive notes. Destructive deletes on user data are unacceptable.
-- **Decision:** Delete moves notes and their referenced assets into `.hatchdoor-trash` (excluded from indexing). Archive moves notes under `HATCHDOOR_ARCHIVE_PREFIX` (default `90-archive/`), which also drives archived-link styling.
+- **Decision:** Delete moves notes, and the referenced assets that live inside the note's own folder, into `.hatchdoor-trash` (excluded from indexing). A referenced asset kept elsewhere stays where it is. Archive moves notes under `HATCHDOOR_ARCHIVE_PREFIX` (default `90-archive/`), which also drives archived-link styling.
 - **Consequences:** Deletes are recoverable; nothing is unlinked from disk by Hatchdoor. The trash folder is skipped when deciding whether a vault is empty.
-- **Evidence:** README "Data and Safety Model"; `vault/write/`; `config.rs` (`archive_prefix`); CHANGELOG F-12.
+- **Evidence:** README "Data and Safety Model"; `vault/write/`; `config.rs` (`archive_prefix`); CHANGELOG F-12. Asset travel was narrowed to the note's own folder in #225 (`vault/write/assets.rs`, `asset_move_plan`).
 
 ## ADR-12 — Distroless, rootless, multi-stage container
 

--- a/src/mcp/tools/write.rs
+++ b/src/mcp/tools/write.rs
@@ -677,7 +677,7 @@ pub(super) fn write_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "rename_note",
-            "description": "Rename a note within its current folder, rewrite wikilink backlinks, move referenced assets with the note, and rewrite other asset references. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
+            "description": "Rename a note within its current folder, rewrite wikilink backlinks, carry along the assets that live inside the note's own folder, or a subfolder of it, and rewrite other notes' references to them. An asset kept elsewhere, such as a shared attachments folder, stays where it is and only this note's own link to it is repointed. A note sitting at the vault root has the whole Vault as its own folder, so every asset it references travels with it. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -693,7 +693,7 @@ pub(super) fn write_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "move_note",
-            "description": "Move a note to a target vault-relative folder, rewrite wikilink backlinks, move referenced assets with the note, and rewrite other asset references. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
+            "description": "Move a note to a target vault-relative folder, rewrite wikilink backlinks, carry along the assets that live inside the note's own folder, or a subfolder of it, and rewrite other notes' references to them. An asset kept elsewhere, such as a shared attachments folder, stays where it is and only this note's own link to it is repointed. A note sitting at the vault root has the whole Vault as its own folder, so every asset it references travels with it. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -709,7 +709,7 @@ pub(super) fn write_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "move_rename_note",
-            "description": "Move and rename a note to a target vault-relative Markdown path in one operation, rewrite wikilink backlinks, move referenced assets with the note, and rewrite other asset references. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
+            "description": "Move and rename a note to a target vault-relative Markdown path in one operation, rewrite wikilink backlinks, carry along the assets that live inside the note's own folder, or a subfolder of it, and rewrite other notes' references to them. An asset kept elsewhere, such as a shared attachments folder, stays where it is and only this note's own link to it is repointed. A note sitting at the vault root has the whole Vault as its own folder, so every asset it references travels with it. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -725,7 +725,7 @@ pub(super) fn write_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "archive_note",
-            "description": "Archive a note by moving it to Hatchdoor's configured archive folder, rewrite wikilink backlinks, move referenced assets with the note, and rewrite other asset references. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
+            "description": "Archive a note by moving it to Hatchdoor's configured archive folder, rewrite wikilink backlinks, carry along the assets that live inside the note's own folder, or a subfolder of it, and rewrite other notes' references to them. An asset kept elsewhere, such as a shared attachments folder, stays where it is and only this note's own link to it is repointed. A note sitting at the vault root has the whole Vault as its own folder, so every asset it references travels with it. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -740,7 +740,7 @@ pub(super) fn write_tools_list() -> Vec<Value> {
         }),
         json!({
             "name": "delete_note",
-            "description": "Trash a note by moving it to .hatchdoor-trash, remove wikilink backlinks to the deleted note, move referenced assets with it, and rewrite other asset references. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
+            "description": "Trash a note by moving it to .hatchdoor-trash, remove wikilink backlinks to the deleted note, trash the assets that live inside the note's own folder, or a subfolder of it, and rewrite other notes' references to them. An asset kept elsewhere, such as a shared attachments folder, stays where it is and only the trashed note's own link to it is repointed. A note sitting at the vault root has the whole Vault as its own folder, so every asset it references is trashed with it. Requires expected_content_hash from get_note, or from get_frontmatter when the body is not needed.",
             "inputSchema": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Closes #231.

#225 narrowed which assets travel with a note: an asset moves with it only when it already lives inside that note's own folder, or a subfolder of it. Two pieces of wording still promised the old unconditional behaviour, and both sat outside #225's owned paths.

## What changed

**The five note-mutation tool descriptions** (`rename_note`, `move_note`, `move_rename_note`, `archive_note`, `delete_note`). This is the text an agent reads to decide what a tool does, so a stale one is a live contract rather than a comment. Each now states the folder rule, that an asset kept elsewhere stays where it is with only the moving note's own link repointed, and that a note at the vault root has the whole Vault as its own folder, so everything it references travels. They match the wording already shipped in `docs/user-vault/03 Reference/MCP tools reference.md`.

**ADR-11's Decision sentence**, corrected in place.

## Why in place rather than an amending ADR

The acceptance criterion asks for this choice to be justified. ADR-11's decision is soft delete via recoverable trash, archive by move, and nothing hard-deleted by Hatchdoor. All of that is untouched, including the index row's binding constraint ("Don't hard-delete note or asset files"). What was stale is a descriptive clause about *which* assets accompany the note, which ADR-11 never decided and #225 settled. The append-only rule governs replacing an accepted decision with a new one, not correcting a fact the record got wrong about behaviour elsewhere, so an amending ADR would add a record without a decision in it.

To keep the history the append-only rule exists to protect, ADR-11's **Evidence** line now records that #225 narrowed asset travel, so the record shows the behaviour moved rather than silently reading as though it was always this way.

## Interface change

```
Interface change: note-mutation MCP tool descriptions
Producer boundary: src/mcp/ (tool catalogue)
Kind: additive (description text only)
Old contract: five descriptions promising "move referenced assets with the note"
New contract: same five stating the folder rule settled in #225
Consumer boundaries: MCP clients (external, unknown). No in-repository consumer reads these strings; no test asserts them.
Compatibility/migration: none required. No schema, parameter, result field or behaviour changed.
Rollout/rollback: N/A - text-only, no ordering constraint.
```

## Validation

All from the repository root, all passing:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` - 969 passed, 0 failed
- `cargo test --all --all-features` - 975 passed, 0 failed
- `node scripts/check-module-map.mjs` - OK, 205 files
- `just docs-freshness` / `just docs-freshness-ack` - the `mcp-tools` surface named three notes; all three read true (the two Get-started notes never describe asset travel, and the MCP tools reference already carries #225's wording). Reviewed and acknowledged.

## Live acceptance

Exercised through the real MCP endpoint on a dev Vault, not through tests.

`tools/list` returns all five corrected descriptions with no surviving unconditional claim. A `move_note` of a note from `Projects/` to `Archive/Deep/Nest/` returned `moved_assets: 2`: the asset in the note's own folder and the one in a subfolder of it both travelled, `_system/shared.png` stayed at the Vault root, and the moved note's own link to it was repointed from `../_system/shared.png` to `../../../_system/shared.png`. Moving a note that sits at the Vault root carried its referenced asset out of the root into the destination folder, confirming the root-note clause.

## Out of scope, found while verifying

`rename_note` fails with `Conflict("Destination asset already exists")` for any note referencing an asset inside its own folder, because a rename computes a destination asset path identical to the source. Confirmed pre-existing: it reproduces identically on the commit before #225 merged, so it is neither introduced nor changed here. Raised separately rather than fixed in a documentation branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
