### PR TITLE
fix(vault): keep the form a backlink was written in on rename and move (#235)

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -853,6 +853,10 @@ write API/types, and configuration for archive or upload limits.
 - All HTTP and MCP mutations use this shared layer (ADR-03).
 - Optimistic concurrency uses the expected content hash.
 - Delete is recoverable trash; archive is move-based (ADR-11).
+- A rewritten backlink keeps the form its author wrote, and a link that
+  resolved before a move still resolves after it: the bare-title form is used
+  only while the new title names exactly one note, and falls back to the full
+  path otherwise (#235).
 - Paths remain within the canonical vault root.
 - Layer marker and excluded/noise writes remain protected at adapter and domain
   boundaries as applicable.

--- a/docs/user-vault/03 Reference/MCP tools reference.md
+++ b/docs/user-vault/03 Reference/MCP tools reference.md
@@ -207,6 +207,8 @@ Every tool below requires `HATCHDOOR_MCP_WRITE_ENABLED=true` and takes `vault_id
 | `rename_attachment` | `source_relative_path`, `new_filename` | Rename an attachment in place and rewrite every note reference to it. |
 | `delete_attachment` | `source_relative_path` | Trash an attachment under `.hatchdoor-trash` and rewrite every note reference to it. |
 
+A backlink to a note that `rename_note`, `move_note`, `move_rename_note` or `archive_note` retargets keeps the form it was written in. A link written as a bare title, `[[Some Note]]`, stays a bare title and picks up the note's new title; a link written as a full path picks up the new full path. The one exception is a new title that another note already carries, where the link falls back to the full path so it keeps pointing at the note that moved. A move that does not change the note's title therefore leaves bare-title links alone entirely, and `rewritten_notes` counts only the notes that actually changed.
+
 An asset travels with a note only when it already lives inside that note's own folder, or a subfolder of it. An asset the note merely points at from somewhere else, such as a shared `_system/` or `Attachments/` folder sitting beside the note's folder, stays exactly where it is: `rename_note`, `move_note`, `move_rename_note`, `archive_note` and `delete_note` leave it alone and rewrite the moved note's own link so it still resolves from the note's new home. Other notes pointing at it are left untouched too, since nothing about it changed. `moved_assets` in the response counts only the assets that actually moved.
 
 > [!note]

--- a/src/vault/write/rewrites.rs
+++ b/src/vault/write/rewrites.rs
@@ -2,17 +2,28 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use crate::vault::types::VaultIndex;
+use crate::vault::paths::{normalize_link_target, normalize_title};
+use crate::vault::types::{NoteEntry, VaultIndex};
 
 use super::types::{TextRewrite, WriteError};
 
+/// Retarget every backlink to the moved note, keeping the form its author wrote.
+///
+/// A link written as a bare title stays a bare title, a path-qualified link
+/// gets the new full path, and `new_target: None` removes the link entirely
+/// (delete). The bare form is only safe while the new title names exactly one
+/// note, so a title another note already carries falls back to the full path:
+/// a link that resolved before the move must still resolve after it (#235).
 pub(super) fn backlink_rewrite_plan(
     index: &VaultIndex,
     moved_slug: &str,
     new_target: Option<&str>,
 ) -> Result<Vec<TextRewrite>, WriteError> {
+    let entries = index.ordered_entries();
+    let bare_new_target =
+        new_target.and_then(|target| unambiguous_bare_title(&entries, moved_slug, target));
     let mut rewrites = Vec::new();
-    for entry in index.ordered_entries() {
+    for entry in entries {
         if entry.slug == moved_slug {
             continue;
         }
@@ -23,13 +34,18 @@ pub(super) fn backlink_rewrite_plan(
             ))
         })?;
         let rewritten = transform_wikilinks(&content, |target| {
-            let should_change = index
-                .resolve_wikilink(target)
-                .is_some_and(|candidate| candidate.slug == moved_slug);
-            if !should_change {
+            let Some(candidate) = index.resolve_wikilink(target) else {
+                return Some(target.to_string());
+            };
+            if candidate.slug != moved_slug {
                 return Some(target.to_string());
             }
-            new_target.map(ToOwned::to_owned)
+            match bare_new_target.as_deref() {
+                Some(bare) if target_is_the_moved_notes_bare_title(target, &candidate.title) => {
+                    Some(bare.to_string())
+                }
+                _ => new_target.map(ToOwned::to_owned),
+            }
         });
         if rewritten != content {
             rewrites.push(TextRewrite {
@@ -39,6 +55,39 @@ pub(super) fn backlink_rewrite_plan(
         }
     }
     Ok(rewrites)
+}
+
+/// The moved note's new bare title, when no *other* note in the pre-move index
+/// already carries it.
+///
+/// Only the moved note changes name, so the pre-move index answers the
+/// post-move question. `resolve_wikilink` tries `by_path_title` before
+/// `by_title`, but a bare title holds no `/` while a nested note's path key
+/// always does, so the only note a bare title can capture on the path pass is
+/// a root-level note whose relative path is its own title — which carries that
+/// title too, and so is already caught here.
+fn unambiguous_bare_title(
+    entries: &[NoteEntry],
+    moved_slug: &str,
+    new_target: &str,
+) -> Option<String> {
+    let bare = new_target.rsplit('/').next().unwrap_or(new_target);
+    let normalized = normalize_title(bare);
+    let taken_by_another_note = entries
+        .iter()
+        .any(|entry| entry.slug != moved_slug && normalize_title(&entry.title) == normalized);
+    (!taken_by_another_note).then(|| bare.to_string())
+}
+
+/// Whether this target is the moved note's own title, written bare.
+///
+/// A slug-form target (`[[some-note]]` for "Some Note") is machine-authored
+/// and takes the full path like any other non-title form; for a single-word
+/// title the two forms normalize alike, so the distinction only ever arises
+/// for multi-word titles.
+fn target_is_the_moved_notes_bare_title(target: &str, moved_title: &str) -> bool {
+    let normalized = normalize_link_target(target);
+    !normalized.contains('/') && normalize_title(&normalized) == normalize_title(moved_title)
 }
 
 pub(super) fn transform_wikilinks<F>(content: &str, transform_target: F) -> String

--- a/src/vault/write/tests.rs
+++ b/src/vault/write/tests.rs
@@ -891,7 +891,7 @@ fn move_note_rewrites_backlinks_and_moves_referenced_assets() {
     assert!(root.join("Archive/Renamed.md").exists());
     assert!(root.join("Archive/image.png").exists());
     let backlink = fs::read_to_string(root.join("Backlink.md")).expect("read");
-    assert!(backlink.contains("[[Archive/Renamed|Alias]]"));
+    assert!(backlink.contains("[[Renamed|Alias]]"));
     assert!(backlink.contains("![](Archive/image.png)"));
     assert!(backlink.contains("`[[Target]]`"));
     assert!(backlink.contains("```\n[[Target]]\n![](Notes/image.png)\n```"));
@@ -901,7 +901,7 @@ fn move_note_rewrites_backlinks_and_moves_referenced_assets() {
 }
 
 #[test]
-fn archive_note_moves_to_archive_prefix_and_rewrites_backlinks() {
+fn archive_note_moves_to_archive_prefix_and_leaves_a_bare_title_backlink_bare() {
     let tmp = TempDir::new().expect("tempdir");
     let root = tmp.path();
     fs::create_dir_all(root.join("40-reference")).expect("mkdir");
@@ -914,9 +914,31 @@ fn archive_note_moves_to_archive_prefix_and_rewrites_backlinks() {
         archive_note(root, &index, entry, "90-archive/", &content_hash("body")).expect("archive");
 
     assert_eq!(outcome.relative_path, Some("90-archive/Idea".to_string()));
-    assert_eq!(outcome.rewritten_notes, 1);
+    // The note keeps its title, so the bare-title link already reads true and
+    // no note needs rewriting at all (#235).
+    assert_eq!(outcome.rewritten_notes, 0);
     assert!(!root.join("40-reference/Idea.md").exists());
     assert!(root.join("90-archive/Idea.md").exists());
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "See [[Idea]]"
+    );
+}
+
+#[test]
+fn archive_note_rewrites_a_path_qualified_backlink_to_the_archived_path() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("40-reference")).expect("mkdir");
+    fs::write(root.join("40-reference/Idea.md"), "body").expect("target");
+    fs::write(root.join("Backlink.md"), "See [[40-reference/Idea]]").expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("idea").expect("idea");
+
+    let outcome =
+        archive_note(root, &index, entry, "90-archive/", &content_hash("body")).expect("archive");
+
+    assert_eq!(outcome.rewritten_notes, 1);
     assert_eq!(
         fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
         "See [[90-archive/Idea]]"
@@ -1073,7 +1095,7 @@ fn move_note_carries_a_sibling_asset_whose_bytes_are_not_valid_utf8() {
     );
     let backlink = fs::read_to_string(root.join("Backlink.md")).expect("backlink");
     assert!(backlink.contains("![](Archive/photo.jpg)"));
-    assert!(backlink.contains("[[Archive/Renamed]]"));
+    assert!(backlink.contains("[[Renamed]]"));
 }
 
 /// A note in `Notes/` holding one attachment whose bytes are not valid UTF-8.
@@ -1678,4 +1700,183 @@ fn every_path_a_planned_asset_move_hands_the_filesystem_is_accepted_by_the_move_
         super::fs_ops::move_file_no_follow(&asset_move.source, &asset_move.destination)
             .expect("the move primitive must accept every path the planner produced");
     }
+}
+
+#[test]
+fn rename_note_leaves_a_bare_title_backlink_bare() {
+    // #235: a vault written in Obsidian's shortest-path style must come back
+    // from a rename in that same style. The link's target is retargeted, its
+    // form is not.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("homelab/decisions")).expect("mkdir");
+    fs::write(root.join("homelab/decisions/Wayfinder Efforts.md"), "body").expect("target");
+    fs::write(root.join("Operating Rules.md"), "See [[Wayfinder Efforts]]").expect("backlink");
+    let index = build(root);
+    let entry = index
+        .find_by_slug("wayfinder-efforts")
+        .expect("wayfinder efforts");
+
+    move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "homelab/decisions/ADR Wayfinder Efforts.md",
+        &content_hash("body"),
+    )
+    .expect("rename");
+
+    assert_eq!(
+        fs::read_to_string(root.join("Operating Rules.md")).expect("backlink"),
+        "See [[ADR Wayfinder Efforts]]"
+    );
+}
+
+#[test]
+fn move_note_leaves_a_bare_title_backlink_untouched_when_the_title_does_not_change() {
+    // The sharper half of #235: nothing about the note's name changes, so a
+    // bare-title link has nothing to be rewritten to.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::write(root.join("Idea.md"), "body").expect("target");
+    fs::write(root.join("Backlink.md"), "See [[Idea]]").expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("idea").expect("idea");
+
+    move_or_rename_note(root, &index, entry, "Inbox/Idea.md", &content_hash("body")).expect("move");
+
+    assert!(root.join("Inbox/Idea.md").exists());
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "See [[Idea]]"
+    );
+}
+
+#[test]
+fn move_note_rewrites_a_path_qualified_backlink_to_the_new_full_path() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("mkdir");
+    fs::write(root.join("Notes/Target.md"), "body").expect("target");
+    fs::write(
+        root.join("Backlink.md"),
+        "See [[Notes/Target]], [[Notes/Target|Alias]], [[Notes/Target#Heading]] and ![[Notes/Target^block-id]]",
+    )
+    .expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Renamed.md",
+        &content_hash("body"),
+    )
+    .expect("move");
+
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "See [[Archive/Renamed]], [[Archive/Renamed|Alias]], [[Archive/Renamed#Heading]] and ![[Archive/Renamed^block-id]]"
+    );
+}
+
+#[test]
+fn move_note_falls_back_to_the_full_path_when_the_new_title_collides() {
+    // Two notes would carry the title "Renamed" after the move, and a bare
+    // title resolves through `by_title` to a deterministic first path. The
+    // full path is the only form that still names the moved note.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::create_dir_all(root.join("Other")).expect("other");
+    fs::write(root.join("Notes/Target.md"), "body").expect("target");
+    fs::write(root.join("Other/Renamed.md"), "unrelated").expect("collider");
+    fs::write(
+        root.join("Backlink.md"),
+        "See [[Target]], [[Target|Alias]], [[Target#Heading]] and ![[Target^block-id]]",
+    )
+    .expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    let outcome = move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Renamed.md",
+        &content_hash("body"),
+    )
+    .expect("move");
+
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "See [[Archive/Renamed]], [[Archive/Renamed|Alias]], [[Archive/Renamed#Heading]] and ![[Archive/Renamed^block-id]]"
+    );
+    let moved_slug = outcome.slug.expect("moved slug");
+    let after = build(root);
+    assert_eq!(
+        after
+            .resolve_wikilink("Archive/Renamed")
+            .expect("the rewritten link must still resolve")
+            .slug,
+        moved_slug,
+        "the fallback form must resolve to the moved note, not its same-titled neighbour"
+    );
+}
+
+#[test]
+fn a_preserved_bare_title_backlink_keeps_its_alias_anchor_and_embed_form() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::write(root.join("Notes/Target.md"), "body").expect("target");
+    fs::write(
+        root.join("Backlink.md"),
+        "[[Target|Alias]] [[Target#Heading]] [[Target^block-id]] ![[Target]] `[[Target]]`",
+    )
+    .expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("target").expect("target");
+
+    move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Renamed.md",
+        &content_hash("body"),
+    )
+    .expect("move");
+
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "[[Renamed|Alias]] [[Renamed#Heading]] [[Renamed^block-id]] ![[Renamed]] `[[Target]]`"
+    );
+}
+
+#[test]
+fn move_note_rewrites_a_slug_form_backlink_to_the_new_full_path() {
+    // Settled in triage on #235: a slug-form target is machine-authored, so it
+    // takes the full path like any other non-title form. No slug branch.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("Notes")).expect("notes");
+    fs::write(root.join("Notes/Some Note.md"), "body").expect("target");
+    fs::write(root.join("Backlink.md"), "See [[some-note]]").expect("backlink");
+    let index = build(root);
+    let entry = index.find_by_slug("some-note").expect("some note");
+
+    move_or_rename_note(
+        root,
+        &index,
+        entry,
+        "Archive/Some Note.md",
+        &content_hash("body"),
+    )
+    .expect("move");
+
+    assert_eq!(
+        fs::read_to_string(root.join("Backlink.md")).expect("backlink"),
+        "See [[Archive/Some Note]]"
+    );
 }


### PR DESCRIPTION
Closes #235.

## What changed

`backlink_rewrite_plan` took a single replacement target and substituted it into every matching link, so a vault written in Obsidian's shortest-path style came back from one rename with full paths: `[[Some Note]]` became `[[folder/subfolder/Some Note]]`. The links still resolved, but the prose got noisier on every rename and nothing rewrote it back.

The closure already had the original target in hand and discarded it. It now keeps it:

- A link written as the moved note's bare title takes the new bare title.
- A link written any other way, path-qualified or slug-form, takes the new full path, as before.
- The bare form is only used while the new title names exactly one note. `unambiguous_bare_title` checks the pre-move index for another note carrying that normalized title and falls back to the full path when one exists, so a link that resolved before the move still resolves after it.

Alias and anchor preservation, fenced-code skipping, link resolution (`index.rs`, `links.rs`) and the asset-travel rules are untouched. Delete (`new_target: None`) is unchanged.

## Interface-change checklist

- **Boundary:** Vault mutation (`src/vault/write/`). **Contract:** filesystem behaviour, the bytes a rename, move or archive writes into backlinking notes, plus `rewritten_notes` in every write response.
- **Old:** every backlink to the moved note was rewritten to its full vault-relative path. **New:** the authored form survives, with the full path as the fallback. **Behaviour-changing, not breaking:** every link that resolved before still resolves after.
- **Why the old contract could not carry the outcome:** the plan received one target and no notion of the form each link was written in.
- **Consumers:** none change. `backlink_rewrite_plan` is `pub(super)` and keeps its signature. Searched `src/` for the function, for rewritten-link assertions, and for `rewritten_notes`.
- **Invariants:** ADR-01 and ADR-03 untouched, writes still route through `src/vault/write/`. The new rule is recorded in the module map's Vault mutation section.
- **Docs:** the MCP tools reference states the link-form rule. `just docs-freshness` reading list read (both notes) and acknowledged.

## Existing tests updated, and why

Three tests encoded the old full-path rewrite:

- `move_note_rewrites_backlinks_and_moves_referenced_assets` and `move_note_carries_a_sibling_asset_whose_bytes_are_not_valid_utf8` both wrote `[[Target]]` and expected `[[Archive/Renamed]]`. That expectation is the defect; they now expect `[[Renamed]]`. Their asset assertions are unchanged.
- `archive_note_moves_to_archive_prefix_and_rewrites_backlinks` moved a note without changing its title, so its bare-title link now needs no rewrite at all and `rewritten_notes` drops from 1 to 0. Renamed to say so, and a new `archive_note_rewrites_a_path_qualified_backlink_to_the_archived_path` keeps the archive rewrite path covered.

Seven new tests cover the bare-title rename, the title-preserving move, the path-qualified rewrite, the collision fallback (asserting the rewritten link still resolves to the moved note), alias, anchor and embed preservation in all three forms, and the slug-form target.

## Validation

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all                     # 976 passed
cargo test --all --all-features      # 982 + 8 + 5 + 1 passed
node scripts/check-module-map.mjs    # OK, 205 files
just docs-freshness / -ack
```

Live acceptance against a local `just dev-start` server, driven through the MCP endpoint (`rename_note`, `move_note`, `move_rename_note`, `archive_note`, `delete_note`, `get_note`, `resolve_wikilink`) on a disposable dev vault, including the issue's own ADR repro: 8 of 8 acceptance checks passed, plus archive and delete spot checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
