### PR TITLE
chore(release): bump to 2.6.0 and record the post-changelog work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v2.6.0 - 2026-09-01
+## v2.6.0 - 2026-09-03
 
-The MCP release. Agents get four new tools, a modern protocol revision, and a `get_tree` that no longer hands over the entire Vault when you asked about one folder. Everyone else gets a Git schedule that actually fires, and a read-only mount that actually mounts.
+The MCP release. Agents get five new tools, a modern protocol revision, and a `get_tree` that no longer hands over the entire Vault when you asked about one folder. Everyone else gets a Git schedule that actually fires, a read-only mount that actually mounts, and a write layer that stops refusing to rename a note because of the picture sitting next to it.
 
 ### ⚠️ Breaking changes — action required on upgrade
 - **`GET /api/index-status`, `GET /api/git-status` and `GET /api/vault-status` are gone**, and all three return `404`. Each described a single Vault back when there was only ever one. The two Settings consoles they fed, **Search index** and **Versioning**, leave the Settings page with them, along with their two-second polling. Each Vault's own settings page keeps its condition, its last error, and its **Sync now**, **Try again** and **Rebuild search index** buttons, and the scope zone and explorer still show a Vault as indexing.
@@ -18,9 +18,11 @@ The MCP release. Agents get four new tools, a modern protocol revision, and a `g
 
 ### Added
 - **Read and write a note's properties without touching its body.** `get_frontmatter` returns the tags, aliases and other keys alone; `update_frontmatter` merges keys in and leaves your Markdown byte-for-byte identical. [#175]
+- **`get_frontmatter` also hands back the note's `content_hash`.** Every hash-protected write wants one, and the only way to get one was to pull the whole note body over the wire. A migration over hundreds of notes no longer reads every body to learn a 16-character string. [#227]
 - **`get_attachment` pulls a file back out of a Vault**, the mirror image of importing one. A download URL by default, base64 inline for clients that cannot fetch out of band. [#176]
 - **`batch` runs up to 50 reads or 20 writes as one call and one commit.** Content hashes chain inside it, so an agent can create a note and edit it again later in the same batch without reading it back. Best-effort, no rollback. [#177]
 - **`get_tree` takes `folder`, `max_depth` and `include_notes`.** Asking about one folder used to cost you the whole Vault. On a 530-note Vault the orientation call is 13x smaller than the full tree. [#192], [#211]
+- **`refresh_vault` asks one Vault for its next index turn.** Collection reads have always said when they have fallen behind the Markdown, and an agent had no way to act on that: `sync_vault` and `retry_vault` both resolve a Git poll interval first and refuse any Vault without a remote, so a plain local Vault had no MCP path to a rebuild at all. It answers `queued` on an idle Vault and `coalesced` when a turn is already pending, so repeat requests cannot pile turns onto one Vault. [#228]
 - **Every MCP tool ships an `outputSchema`**, so a client can validate a result instead of inferring its shape. [#167]
 - **The MCP endpoint speaks protocol revision `2026-07-28`**: stateless discovery, no handshake, and one opt-in `subscriptions/listen` stream in place of SSE subscribe and unsubscribe. Clients on `2025-11-25` are unaffected. [#169], [#170]
 - **MCP now has rate limits.** 120 calls a minute per token, 8 concurrent calls and 2 concurrent searches, refused with `429` and a `Retry-After`. Set `HATCHDOOR_MCP_RATE_LIMITS_ENABLED=false` to switch them off. [#171]
@@ -31,9 +33,17 @@ The MCP release. Agents get four new tools, a modern protocol revision, and a `g
 - A Vault on a `:ro` Docker bind mount refused to come up at all, which is an awkward position for a product that supports read-only browsing. Read-only mounts answer the write probe with `EROFS`, and only "permission denied" counted as present but not writable. Such a Vault now activates read-only. [#178]
 - If you redeployed more often than your Git poll interval, a scheduled sync never fired once. Every process start re-armed the countdown from zero, so the only Git turns that ever ran were activations and manual syncs. The schedule was, in the strict sense, decorative. Each Vault now remembers when its last turn completed and resumes the countdown across a restart. [#200]
 - Straight after a restart, a Vault whose Git credentials were failing reported `pending` with no error, for up to a day on the default schedule. Activation now republishes the last known outcome, message included. [#200]
+- A Vault's read model could wedge permanently, and one new note was enough to do it. A slug comes from a filename alone, so two notes with the same stem in different folders compete for it, and the index build tried to give it to the arriving note while the departing one still held it. That failed the whole Index turn, and the next turn seeded from the same snapshot and failed at the same note, forever: `get_tree`, `get_graph` and `get_stats` reported `partial` at a frozen `collection_revision` while exact note reads stayed correct. The build now releases a moving slug before any note claims it, and a wedged cache recovers on its first turn with nothing deleted and no cache wiped. [#226]
+- An Index turn held the Vault's write lock for the whole turn, embedding included, so a write arriving during a multi-minute pass on a CPU-only host did not slow down, it parked. The caller's transport gave up on a write that then landed anyway, which is an at-least-once hazard the moment the caller retries. The lock now covers the turn's read phase only, and a Vault that took a write while it was released publishes itself stale rather than fresh and lets the watcher's catch-up turn sort it out. [#223]
+- A note holding a real image, PDF or archive could not be moved, renamed, archived or deleted, and neither could the file itself. The check run after an asset move read the file as text, so any byte that was not valid UTF-8 rolled the whole write back with "refusing to move unsafe source". The suite stayed green on this because every attachment fixture wrote the ASCII string `png` into a file named `.png`. The check now asserts an ordinary file and reads nothing. [#220]
+- A note referencing an asset outside its own folder could not be moved at all. The planner assumed every referenced asset was a sibling and built its destination by joining the reference onto the note's folder, so a link such as `../Attachments/image.png` carried its `..` all the way down to the move primitives, which refuse anything but plain names. An asset now travels with a note only when it already lives inside that note's own folder, or a subfolder of it. One kept elsewhere, such as the shared attachments folder of the usual Obsidian layout, stays exactly where it is; only the moving note's own link is repointed, and no other note is touched. A note in the Vault root has the whole Vault as its folder, so everything it references still travels when it moves. [#225], [#231]
+- `rename_note` refused any note that kept its picture beside it, and every note in the Vault root. A rename leaves the note in its folder, so an asset in that folder was already sitting at the destination computed for it, and the collision guard could not tell that apart from a genuine collision. A move to nowhere is now recognised as one: nothing moves, nothing is rewritten, and `moved_assets` reports `0`. A different file at an asset's destination still refuses, as before. [#238]
+- One rename could rewrite a Vault's prose out of the style it was written in. Every backlink to the moved note was retargeted to its full vault-relative path, so `[[Some Note]]` came back as `[[folder/subfolder/Some Note]]`. The links still resolved, but the prose got noisier on every rename and nothing rewrote it back. A backlink now keeps the form it was authored in, with the full path as the fallback where the new title is one another note already carries. Aliases, anchors and fenced code are untouched. [#235]
+- A writer saving faster than the watcher's quiet window deferred freshness for the whole burst. Every qualifying event restarted the 500 ms timer with no upper bound, so no Index turn was armed and the published snapshot could not advance until the writing stopped. The documented ceiling on that window is now enforced, and whichever of the two fires first wins. [#229]
 - An agent that edited a note was told Hatchdoor was still being set up, on instances that finished setting up months ago, and was then handed model-setup tools that could change nothing. Following that advice produced a second, differently wrong answer. The routine reindex behind the write was sharing one status field with first-run model setup. [#191]
 - After the backend restarted, the Vault list and its counts stopped updating until you reloaded the page. A new server counts revisions from zero again, and the client read that as stale. [#194]
 - Opening a Vault's settings page mid-refresh could leave it describing a Vault the Settings index disagreed with for the rest of the visit. [#194]
+- Dragging the sidebar resizer moved the note path in the topbar and left the pane itself where it was. The layout grid redeclared `--sidebar-width` at its 280px default, and a local declaration beats the live value inherited from the shell.
 - Asking for a folder that no Vault has picked one Vault at random and blamed it by id. The refusal now names none of them, because none is more at fault than the others. [#211]
 - Uploading a file called `.hatchdoor-layer` through the HTTP API silently reclassified a whole subtree as a demoted layer. It now returns `400 layer_marker_write`, as the MCP tools always did.
 - In demo mode, an attachment in a hidden layer was still served to anyone who knew its URL. Asset requests now go through the same browse surface as note reads.
@@ -80,6 +90,16 @@ No behaviour change in any of these, but they are why the list above is as short
 [#200]: https://github.com/BatterWorks/Hatchdoor/issues/200
 [#210]: https://github.com/BatterWorks/Hatchdoor/issues/210
 [#211]: https://github.com/BatterWorks/Hatchdoor/issues/211
+[#220]: https://github.com/BatterWorks/Hatchdoor/issues/220
+[#223]: https://github.com/BatterWorks/Hatchdoor/issues/223
+[#225]: https://github.com/BatterWorks/Hatchdoor/issues/225
+[#226]: https://github.com/BatterWorks/Hatchdoor/issues/226
+[#227]: https://github.com/BatterWorks/Hatchdoor/issues/227
+[#228]: https://github.com/BatterWorks/Hatchdoor/issues/228
+[#229]: https://github.com/BatterWorks/Hatchdoor/issues/229
+[#231]: https://github.com/BatterWorks/Hatchdoor/issues/231
+[#235]: https://github.com/BatterWorks/Hatchdoor/issues/235
+[#238]: https://github.com/BatterWorks/Hatchdoor/issues/238
 
 ## v2.5.0 - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The MCP release. Agents get five new tools, a modern protocol revision, and a `g
 - **MCP now has rate limits.** 120 calls a minute per token, 8 concurrent calls and 2 concurrent searches, refused with `429` and a `Retry-After`. Set `HATCHDOOR_MCP_RATE_LIMITS_ENABLED=false` to switch them off. [#171]
 - **The Vault asset route accepts an MCP bearer token**, so an agent can fetch the URL `get_attachment` hands it without also holding the web token. It spends the same quota and size limits as any MCP call. [#174]
 - **The public documentation Vault gained Guides, Concepts and a settings reference**, and the README links into it rather than duplicating it.
+- **The public demo and the documentation site link to each other now.** Each demo Vault points at the documentation page behind its layout, and the documentation's layout table links to the live Vault demonstrating each method.
 
 ### Fixed
 - A Vault on a `:ro` Docker bind mount refused to come up at all, which is an awkward position for a product that supports read-only browsing. Read-only mounts answer the write probe with `EROFS`, and only "permission denied" counted as present but not writable. Such a Vault now activates read-only. [#178]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "hatchdoor"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hatchdoor"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 default-run = "hatchdoor"
 license = "AGPL-3.0-only"

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ setup finishes.
 The image is published on [Docker Hub](https://hub.docker.com/r/battermanz/hatchdoor):
 
 ```text
-battermanz/hatchdoor:latest          # also version tags, e.g. 2.5.0
+battermanz/hatchdoor:latest          # also version tags, e.g. 2.6.0
 battermanz/hatchdoor:podman-latest   # for Podman users (podman-<version> too)
 ```
 
@@ -444,8 +444,8 @@ Build and publish the Docker image:
 
 ```bash
 docker build -t battermanz/hatchdoor:latest .
-docker tag battermanz/hatchdoor:latest battermanz/hatchdoor:2.5.0
-docker push battermanz/hatchdoor:2.5.0
+docker tag battermanz/hatchdoor:latest battermanz/hatchdoor:2.6.0
+docker push battermanz/hatchdoor:2.6.0
 docker push battermanz/hatchdoor:latest
 ```
 

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -21,17 +21,21 @@ flowchart LR
 
 Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent, make one deliberate change, and review it in the browser. These docs target Hatchdoor v2.6.0.
 
+Want to look before you install anything? The [public demo](https://hatchdoor.battercloud.cc) is a live, read-only Hatchdoor with four example Vaults in it. It is the same application these docs describe, running the same version.
+
 ## Before you start: what kind of notes app is this
 
 Hatchdoor is built for keeping a [[The Second Brain method (external reference)|second brain]] — a durable, external place for the things worth keeping — with one difference from most tools built for that: an MCP-connected agent can read and act on it too, not just you. See [[Why keep a second brain]] for what that changes about the ordinary capture-organize-distill-express rhythm.
 
 That still leaves how to lay out a Vault. Hatchdoor doesn't require any particular layout — pick whichever of these fits how you think, or mix them:
 
-| Method | What it optimizes | Reference |
-| --- | --- | --- |
-| **PARA** | Folders by how actionable a note is (Projects, Areas, Resources, Archives) | [[The PARA method (external reference)]] |
-| **Zettelkasten** | Dense links between atomic notes, little to no folder hierarchy | [[The Zettelkasten method (external reference)]] |
-| **LLM wiki** | An agent that builds and maintains an interlinked wiki for you | [[The LLM wiki pattern (external reference)]] |
+| Method | What it optimizes | Reference | See it live |
+| --- | --- | --- | --- |
+| **PARA** | Folders by how actionable a note is (Projects, Areas, Resources, Archives) | [[The PARA method (external reference)]] | [Home & Life](https://hatchdoor.battercloud.cc/v/919a41eb-a699-4d46-9857-eaa6db0a85c4/n/readme) |
+| **Zettelkasten** | Dense links between atomic notes, little to no folder hierarchy | [[The Zettelkasten method (external reference)]] | [Reading Notes](https://hatchdoor.battercloud.cc/v/7b6b865f-e5fa-4abd-8d1d-d5e75a7341f9/n/readme) |
+| **LLM wiki** | An agent that builds and maintains an interlinked wiki for you | [[The LLM wiki pattern (external reference)]] | [Research Wiki](https://hatchdoor.battercloud.cc/v/e1f02552-5a8a-4a5e-9b75-4e40dd1cf141/n/readme) |
+
+The [public demo](https://hatchdoor.battercloud.cc) runs those three side by side, plus a fourth Vault, [Team Docs](https://hatchdoor.battercloud.cc/v/ec49f950-6979-42e3-b31e-e1654e7716c5/n/readme), which uses no folder convention at all and leans on tags and search instead. Every note in them is fictional and the whole instance is read-only, so there is nothing there to break.
 
 They aren't mutually exclusive — see [[How to run an LLM wiki in Hatchdoor]] for one way to combine an LLM wiki with folder-based organization underneath it.
 

--- a/docs/user-vault/Home.md
+++ b/docs/user-vault/Home.md
@@ -19,7 +19,7 @@ flowchart LR
 
 ## Start here
 
-Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent, make one deliberate change, and review it in the browser. These docs target Hatchdoor v2.5.0.
+Follow [[Welcome to Hatchdoor]] to deploy Hatchdoor, connect your own agent, make one deliberate change, and review it in the browser. These docs target Hatchdoor v2.6.0.
 
 ## Before you start: what kind of notes app is this
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-markdown": "^6.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release prep for v2.6.0. No behaviour change: version strings, the changelog entry, and the GitHub draft release notes.

## Version

Bumped to `2.6.0` in `Cargo.toml`, `Cargo.lock`, `frontend/package.json` and its lockfile, matching the four files the 2.5.0 bump touched. The README's example image tags and the documentation Vault's "these docs target" line follow the release too, as they did last cycle.

## Changelog

The v2.6.0 entry was written on 2026-09-01 and eleven more merges landed after it. The entry is dated to today's release and brought level with the branch.

- Intro: five new tools rather than four, and a nod to the write-layer fixes.
- **Added:** `refresh_vault` (#228), the only MCP path to a rebuild on a Vault with no Git remote, and `get_frontmatter` returning `content_hash` (#227).
- **Fixed:** the permanently wedged read model from a slug collision (#226); the Index turn holding the write lock through the embedding pass, so a write parked and its caller gave up on a write that landed anyway (#223); binary attachment moves (#220); assets referenced outside the moving note's folder (#225, #231); `rename_note` refusing any note sitting beside its own asset (#238); backlink form preservation (#235); the watcher debounce ceiling (#229); and the sidebar resizer.

Each was checked against the `v2.5.0` tag rather than assumed. #225 and #238 look like they might be fixes to unreleased code from this same cycle, but both defects are in the shipped v2.5.0 planner: it computed each asset's destination as its own source, hit the collision guard, and failed the rename. Both are real user-facing fixes and are listed as such.

Not recorded: the docs-freshness surface fix for attachment mutations (4caa931), which is repository tooling with no user-facing behaviour.

## Draft release notes

The GitHub v2.6.0 draft carries the same additions in its own voice. Still a draft, still targeting `main`.

## Known staleness, deliberately left

`docs/roadmap/product-roadmap.md:124` says the catalogue "grew from 35 to 39 tools". It is 40 now with `refresh_vault`. The sentence is scoped to the MCP migration programme and `refresh_vault` was a separate ticket, so it is defensible as written, but it reads as a current count.

## Verification

- `cargo check` clean.
- `node scripts/check-docs-freshness.mjs --base development` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
