### PR TITLE
docs(roadmap): make the v2.6.0 horizons match what shipped

### DIFF
--- a/docs/roadmap/product-roadmap.md
+++ b/docs/roadmap/product-roadmap.md
@@ -86,7 +86,8 @@ _Horizon: unversioned ("at some point"). No implementation started._
 Direction: build a first-run onboarding flow, tracked as
 [#9](https://github.com/BattermanZ/Hatchdoor/issues/9).
 
-_Horizon: **v2.6.0**._
+_Horizon: unversioned ("at some point"); slipped past v2.6.0, which shipped
+without it. No implementation started._
 
 ### Vault lifecycle & multi-vault
 
@@ -116,13 +117,13 @@ removed; **Roots, Sampling, and Logging are deprecated**; server-initiated
 requests (elicitation, sampling) move to a request/retry pattern instead of
 being pushed mid-call. HTTP+SSE transport is now formally deprecated too.
 
-_Horizon: **v2.6.0** — landed on `development`. The boundary now runs on rmcp
+_Horizon: **v2.6.0** — shipped. The boundary now runs on rmcp
 (ADR-17) and advertises exactly `2026-07-28` and `2025-11-25`: stateless
 discovery with per-request `_meta`, a single opt-in `subscriptions/listen`
 stream, typed results with an `outputSchema` on every tool, and per-tool quotas
 with concurrency caps and `429 Retry-After`. The catalogue then grew from 35 to
-39 tools (`get_frontmatter`, `update_frontmatter`, `get_attachment`, `batch`),
-purely additively._
+40 tools (`get_frontmatter`, `update_frontmatter`, `get_attachment`, `batch`,
+and `refresh_vault` from #228), purely additively._
 
 ### User documentation, in-app and answerable by the agent
 
@@ -139,7 +140,12 @@ existing MCP interface**: the in-app agent adds the docs instance as an
 MCP-reachable source, so a user can ask a question ("how do I connect a Git
 vault?") and get an answer grounded in the docs without leaving the app.
 
-_Horizon: **v2.6.0**._
+_Horizon: partially shipped in **v2.6.0**. The end-user documentation exists as
+its own Hatchdoor Vault, served by a separate public instance, and the README
+links into it rather than duplicating it; the demo and documentation instances
+cross-link. The second half, making that instance queryable from inside the app
+through the existing MCP interface so the in-app agent can answer from the docs,
+is not started and remains unversioned._
 
 ### Multi-user, network-exposed deployment
 


### PR DESCRIPTION
Pre-merge checklist work for the v2.6.0 release. The [release runbook](docs/maintenance/release-runbook.md) requires `docs/roadmap/` to reflect reality before `development` merges into `main`, and three workstreams claimed a v2.6.0 horizon while only one was wholly true.

| Workstream | Claimed | Actually |
| --- | --- | --- |
| MCP protocol migration | v2.6.0, "landed on `development`" | Shipped. Catalogue is 40 tools, not the 39 the text stated: `refresh_vault` (#228) landed after that sentence was written. |
| Onboarding experience (#9) | v2.6.0 | Did not ship. Issue still open, no implementation started. |
| User documentation | v2.6.0 | Half shipped. The docs Vault and its public instance exist; making it queryable in-app over MCP is not started. |

Onboarding drops to unversioned rather than being reassigned to a version nobody has committed to, with a note that it slipped past v2.6.0 so the history survives. The documentation horizon is split so the unshipped half is not read as done.

Verified: `node scripts/check-module-map.mjs`, `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg