### PR TITLE
docs: promote the README what-is-next section and roadmap corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ under close human review, with tests and a documented safety model.
 - [What You Get](#what-you-get)
 - [Screenshots](#screenshots)
 - [Who It Is For](#who-it-is-for)
+- [What Is Next](#what-is-next)
 - [Quick Start With Docker](#quick-start-with-docker)
 - [Data And Safety Model](#data-and-safety-model)
 - [Configuration](#configuration)
@@ -123,6 +124,33 @@ semantic search, and local development.
 Hatchdoor is not a hosted sync service, not a multi-user collaboration platform,
 and not a replacement for Obsidian. It is a self-hosted companion for a Markdown
 vault you control.
+
+## What Is Next
+
+The next large feature is multi-account handling with permission scoping. Today
+Hatchdoor assumes a single trusted user on a private deployment, so whoever
+reaches the instance sees every vault it serves. The plan is to let several
+people and agents share one instance, each scoped to the vaults they are
+granted, with an admin role that manages the rest. A household or a small team
+could then run one Hatchdoor instead of one per person.
+
+v2.5.0 already made vaults independent, addressable things the product manages,
+including vault scoping for MCP agents. What is missing is the half that was
+deliberately deferred: accounts, authentication, and an access boundary the
+server enforces rather than the UI implies. Targeted at v3.
+
+Two other things are wanted but not slotted to a version yet:
+
+- **Agent provenance and undo.** Which agent changed a note, a before/after diff
+  beside the commit it produced, and one-click revert. Today git is the whole
+  answer, and reading a commit log is not the same as seeing what an agent did
+  to your note.
+- **Vault integrity checks.** A vault-scoped lint for orphaned notes, broken
+  wikilinks, and layer markers whose declaration has vanished, so a vault an
+  agent maintains unattended cannot quietly drift out of shape.
+
+The [product roadmap](docs/roadmap/product-roadmap.md) has the full set of
+workstreams and where each one stands.
 
 ## Quick Start With Docker
 

--- a/docs/roadmap/product-roadmap.md
+++ b/docs/roadmap/product-roadmap.md
@@ -25,9 +25,9 @@ Everything on this roadmap should advance at least one of these:
    attributable, and reversible; mistakes are contained.
 3. **Always available and easy to self-host.** The app starts and stays usable
    even while background work runs or optional capabilities fail.
-4. **Grows without losing itself.** From single-user/single-vault today toward
-   many vaults and, eventually, many users — without compromising the objectives
-   above.
+4. **Grows without losing itself.** From the single-user instance it is today
+   toward many users and agents sharing one, without compromising the objectives
+   above. Many vaults per instance shipped in v2.5.0.
 
 ## Workstreams
 
@@ -162,9 +162,11 @@ rather than only self-hosted single-tenant. Authentication, accounts,
 authorization, isolation, and audit must be designed explicitly, since it means
 serving mutually untrusted users and agents on shared infrastructure.
 
-_Horizon: **v3** (long-term). Depends on the multi-vault work in
-[vault lifecycle & multi-vault](vault-lifecycle.md) existing first — you can't
-scope access to vaults that aren't yet independent, addressable entities._
+_Horizon: **v3** (long-term). The multi-vault prerequisite is met. v2.5.0 made
+vaults independent, addressable entities with per-vault MCP scoping (see
+[vault lifecycle & multi-vault](vault-lifecycle.md)), so there is something to
+scope access to. What remains is the half deferred on purpose: accounts,
+authentication, authorization, isolation, and audit._
 
 ## How to Use This Roadmap
 

--- a/docs/roadmap/vault-lifecycle.md
+++ b/docs/roadmap/vault-lifecycle.md
@@ -309,7 +309,7 @@ is later intended to serve mutually untrusted users.
 Vault-level access scoping for multiple users/agents is tracked as its own
 initiative — see [Multi-user, network-exposed deployment](product-roadmap.md#multi-user-network-exposed-deployment)
 in the product roadmap — but this document's multi-vault work is a
-prerequisite for it.
+prerequisite for it, met as of v2.5.0.
 
 ## Decisions to Make Together
 


### PR DESCRIPTION
Promotes the docs work merged in #250 to `main`.

The README gains a **What Is Next** section, placed right after "Who It Is For" so the "not a multi-user collaboration platform" line gets its qualifier where readers actually decide whether Hatchdoor fits them. It leads with multi-account handling and per-vault permission scoping as the next large feature, then covers agent provenance and undo, and vault integrity checks.

It also corrects three places where the roadmap still treated the multi-vault work as a prerequisite yet to exist, when it shipped in v2.5.0.

Docs only, no version bump. No code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
