### PR TITLE
Bake the source commit into nightly version strings; bump to 2.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "hatchdoor"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "ahash",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hatchdoor"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 default-run = "hatchdoor"
 license = "AGPL-3.0-only"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY docs/starter-vault ./docs/starter-vault
-RUN cargo build --release --bin hatchdoor
+ARG GIT_SHA=""
+RUN HATCHDOOR_GIT_SHA=$GIT_SHA cargo build --release --bin hatchdoor
 
 FROM docker.io/library/node:26-slim AS frontend-builder
 WORKDIR /app/frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-markdown": "^6.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,17 @@ use tracing_subscriber::EnvFilter;
 
 use crate::vault_runtime::VaultSource;
 
+/// The version reported to clients and logs. Nightly images bake the source
+/// commit in through the `HATCHDOOR_GIT_SHA` compile-time env var (fed by the
+/// Docker build arg of the same name); release builds leave it unset and
+/// report the plain crate version.
+pub fn version_string() -> String {
+    match option_env!("HATCHDOOR_GIT_SHA") {
+        Some(sha) if !sha.is_empty() => format!("{} (dev {sha})", env!("CARGO_PKG_VERSION")),
+        _ => env!("CARGO_PKG_VERSION").to_string(),
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum LegacyVaultEnvironmentKeyKind {
     DeploymentPath,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use dotenvy::dotenv;
 use tracing::{error, info};
 
-use hatchdoor::config::init_logging;
+use hatchdoor::config::{init_logging, version_string};
 use hatchdoor::embed::FastembedEmbedder;
 use hatchdoor::server::run_server;
 
@@ -39,7 +39,10 @@ async fn main() {
 
     let args: Vec<String> = std::env::args().collect();
     match parse_run_mode(&args) {
-        RunMode::Serve => run_server().await,
+        RunMode::Serve => {
+            info!("Hatchdoor {}", version_string());
+            run_server().await
+        }
         RunMode::PrefetchEmbedder => run_prefetch(),
         RunMode::Healthcheck => run_healthcheck(),
         RunMode::Unknown(flag) => {

--- a/src/mcp/adapter.rs
+++ b/src/mcp/adapter.rs
@@ -83,7 +83,10 @@ impl ServerHandler for HatchdoorMcpHandler {
             // Preferred revision for clients that request one we no longer
             // serve: the newest legacy revision, not the modern one.
             .with_protocol_version(rmcp::model::ProtocolVersion::V_2025_11_25)
-            .with_server_info(Implementation::new("hatchdoor", env!("CARGO_PKG_VERSION")))
+            .with_server_info(Implementation::new(
+                "hatchdoor",
+                crate::config::version_string(),
+            ))
             .with_instructions(instructions)
     }
 

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -744,7 +744,10 @@ mod tests {
 
         assert_eq!(result["protocolVersion"], "2025-11-25");
         assert_eq!(result["serverInfo"]["name"], "hatchdoor");
-        assert_eq!(result["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            result["serverInfo"]["version"],
+            crate::config::version_string()
+        );
         assert!(result["capabilities"]["tools"].is_object());
         assert_eq!(
             result["capabilities"]["tools"]["listChanged"], false,


### PR DESCRIPTION
Groundwork for the nightly dev-channel builds: images built from development all reported the bare crate version, so two nightlies were indistinguishable from inside the container.

- The Dockerfile accepts a `GIT_SHA` build arg (the build context excludes `.git`, so the sha cannot be derived inside the build) and feeds it to the compile as `HATCHDOOR_GIT_SHA`.
- New `config::version_string()` appends it as `2.6.1 (dev abc123)` in MCP serverInfo and a startup log line. Release builds leave the arg unset and report the plain version, byte-for-byte identical to today.
- Version bumped to 2.6.1 in all four version files, so nightlies additionally read ahead of the released 2.6.0.

Validation: `cargo fmt`, `cargo clippy --all-targets -D warnings`, config/mcp/main test suites green, docs-freshness reviewed and acknowledged (no flagged note documents the version format or build internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg