### PR TITLE
fix(cache): stop indexing citation numbers and code hashtags as tags

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -799,7 +799,9 @@ is shared with the read core's contained-resource seam
 route or the MCP `get_attachment` tool would refuse.
 
 **Consumed dependencies:** filesystem traversal and parsing; `cache::parse`
-currently supplies content hashing to the index.
+currently supplies content hashing to the index and, since #248, the shared
+Markdown code-region scanner (`for_non_code_line`) the link reader uses to skip
+fenced code blocks and inline code spans.
 
 **Consumers:** cache population, handlers, MCP reads, write coordination,
 watching, and application startup.
@@ -837,7 +839,10 @@ watching, and application startup.
 shallow frontmatter merge (`update_note_frontmatter`), attachment
 operations, allowed attachment extensions, `WriteOutcome`, and `WriteError`.
 
-**Consumed dependencies:** vault index/types and the local filesystem.
+**Consumed dependencies:** vault index/types, the local filesystem, and
+`cache::parse` for content hashing, frontmatter span parsing, and the shared
+Markdown code-region scanner (`for_non_code_line`, `parse_fence_marker`) that
+keeps every rewriter's idea of a code block identical to the indexer's.
 
 **Consumers:** the Vault-qualified mutation core (`src/vault_mutation.rs`),
 which since #186 is the sole caller of every write primitive. The one
@@ -1275,7 +1280,19 @@ to answer that verdict under one acquisition with the publication it labels
 (issue #223). `parse` is currently public and
 also supplies parsing/hash behavior to vault indexing, and its
 `frontmatter_span`/`parse_frontmatter_metadata` parsing to the shared write
-layer's frontmatter merge. The crate-private
+layer's frontmatter merge. It is also the single home of the Markdown
+code-region scanner: the crate-private `for_non_code_line`, which walks the
+lines Markdown renders as prose, and `parse_fence_marker`, which recognizes a
+fence delimiter. The Vault link reader and the asset-reference rewriter consume
+`for_non_code_line`; the backlink, section, and asset-reference rewriters
+consume `parse_fence_marker` for their own line-rebuilding loops, which must
+preserve line endings and so cannot use the visiting form. It lives here
+because tag extraction, link extraction, and rewriting have to agree on what
+counts as code: an indexer that reads a hashtag inside a fenced block as a tag
+while a rewrite refuses to touch it makes a Vault-wide tag rename look
+half-applied (#248, unblocking #242). The copies merged here were behaviorally
+identical, so consolidating them changed nothing; the point is that the next
+correction lands in one place instead of three. The crate-private
 `is_recognized_legacy_cache` inspection seam owns the supported legacy schema
 fingerprint and opens existing files read-only for the one-time migration.
 `ReadSnapshot` is the crate-private pinned-read seam used where participant

--- a/docs/user-vault/03 Reference/Supported Markdown reference.md
+++ b/docs/user-vault/03 Reference/Supported Markdown reference.md
@@ -101,6 +101,22 @@ status: current
 
 Hatchdoor parses frontmatter and can show properties (tags, aliases, and arbitrary key/value pairs) separately from the note body, without them cluttering the rendered text.
 
+## Tags
+
+A note's tags come from two places. Anything listed under `tags:` in frontmatter counts, in whatever shape you write it, including plain words and numbers.
+
+In the body, only a namespaced hashtag counts: `#area/health` and `#type/reference/draft` are tags, a bare `#todo` or `#1177` is not. The namespace requirement is what keeps ordinary prose, issue numbers, and headings out of your tag list.
+
+Hashtags inside code are never tags, so a note that documents a tag convention does not get filed under it. That covers both a fenced block and an inline span written with backticks:
+
+````markdown
+```
+#not/a-tag
+```
+
+Write it as `#not/a-tag` in your note.
+````
+
 ---
 
 Related: [[MCP tools reference]] · [[HTTP API reference]]

--- a/src/cache/parse.rs
+++ b/src/cache/parse.rs
@@ -210,37 +210,130 @@ fn extract_frontmatter_tags(frontmatter: &str, tags: &mut HashSet<String>) {
     }
 }
 
-fn push_tag(raw: &str, tags: &mut HashSet<String>) {
-    let cleaned: String = raw
-        .chars()
+/// The leading run of tag characters in `raw` — the text that actually gets
+/// stored as a tag. Everything from the first character outside the tag
+/// charset onwards is dropped.
+fn tag_candidate(raw: &str) -> String {
+    raw.chars()
         .take_while(|ch| ch.is_alphanumeric() || matches!(ch, '-' | '_' | '/'))
-        .collect();
+        .collect()
+}
+
+fn push_tag(raw: &str, tags: &mut HashSet<String>) {
+    let cleaned = tag_candidate(raw);
     if !cleaned.is_empty() {
         tags.insert(cleaned.to_lowercase());
     }
 }
 
 fn extract_inline_tags(body: &str, tags: &mut HashSet<String>) {
-    for token in body.split_whitespace() {
-        let token = token.trim_matches(|ch: char| {
-            matches!(
-                ch,
-                ',' | '.' | ';' | ':' | '!' | '?' | ')' | '(' | '[' | ']' | '{' | '}'
-            )
-        });
-        let Some(tag) = token.strip_prefix('#') else {
-            continue;
-        };
-        if tag.is_empty() || tag.starts_with('#') || tag.chars().all(|ch| ch == '-') {
+    for_non_code_line(body, |line| {
+        for token in line.split_whitespace() {
+            let token = token.trim_matches(|ch: char| {
+                matches!(
+                    ch,
+                    ',' | '.' | ';' | ':' | '!' | '?' | ')' | '(' | '[' | ']' | '{' | '}'
+                )
+            });
+            let Some(tag) = token.strip_prefix('#') else {
+                continue;
+            };
+            // The namespace check has to run against the candidate that will be
+            // stored, not the raw whitespace token. A citation written as
+            // `#1177](https://example.com/x/1177)` is one token whose slash comes
+            // from the URL, and truncation drops it again before the tag is
+            // inserted — so the two used to disagree and a bare number got
+            // indexed (issue #248).
+            let candidate = tag_candidate(tag);
+            // Inline tags must be namespaced (e.g. #area/health), not free-form words or bare numbers.
+            let slash = candidate.find('/');
+            if !slash.is_some_and(|pos| pos > 0 && pos < candidate.len() - 1) {
+                continue;
+            }
+            tags.insert(candidate.to_lowercase());
+        }
+    });
+}
+
+/// Visit every line of `content` that Markdown renders as prose: fenced code
+/// blocks are skipped whole and inline code spans are blanked out of the lines
+/// that survive.
+///
+/// Shared with the Vault link reader and the asset-reference rewriter so that
+/// what the index treats as prose and what a rewrite is willing to edit cannot
+/// drift apart.
+pub(crate) fn for_non_code_line<F>(content: &str, mut visit: F)
+where
+    F: FnMut(&str),
+{
+    let mut fenced_marker: Option<(u8, usize)> = None;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if let Some((marker, min_len)) = fenced_marker {
+            if let Some((close_marker, close_len)) = parse_fence_marker(trimmed)
+                && close_marker == marker
+                && close_len >= min_len
+            {
+                fenced_marker = None;
+            }
             continue;
         }
-        // Inline tags must be namespaced (e.g. #area/health), not free-form words or bare numbers.
-        let slash = tag.find('/');
-        if !slash.is_some_and(|pos| pos > 0 && pos < tag.len() - 1) {
+        if let Some(marker) = parse_fence_marker(trimmed) {
+            fenced_marker = Some(marker);
             continue;
         }
-        push_tag(tag, tags);
+        let no_inline_code = strip_inline_code_segments(line);
+        visit(&no_inline_code);
     }
+}
+
+/// `line` with every inline code span removed, backticks included.
+fn strip_inline_code_segments(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut idx = 0usize;
+    let mut inline_marker_len = 0usize;
+    while idx < chars.len() {
+        if chars[idx] == '`' {
+            let mut marker_len = 1usize;
+            while idx + marker_len < chars.len() && chars[idx + marker_len] == '`' {
+                marker_len += 1;
+            }
+            if inline_marker_len == 0 {
+                inline_marker_len = marker_len;
+            } else if marker_len == inline_marker_len {
+                inline_marker_len = 0;
+            }
+            idx += marker_len;
+            continue;
+        }
+        if inline_marker_len == 0 {
+            out.push(chars[idx]);
+        }
+        idx += 1;
+    }
+    out
+}
+
+/// The fence character and its run length when `trimmed_line` opens or closes a
+/// fenced code block, otherwise `None`.
+pub(crate) fn parse_fence_marker(trimmed_line: &str) -> Option<(u8, usize)> {
+    let bytes = trimmed_line.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let marker = bytes[0];
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+
+    let mut len = 1usize;
+    while len < bytes.len() && bytes[len] == marker {
+        len += 1;
+    }
+
+    if len >= 3 { Some((marker, len)) } else { None }
 }
 
 pub fn build_fts_query(input: &str) -> Option<String> {
@@ -375,6 +468,49 @@ mod tests {
         assert!(!tags.contains("freeform"), "free-form inline tag rejected");
         assert!(!tags.contains("1"), "numeric inline tag rejected");
         assert!(!tags.contains("0599"), "numeric inline tag rejected");
+    }
+
+    #[test]
+    fn markdown_link_citation_numbers_are_not_inline_tags() {
+        // `#1177](https://.../1177)` is one whitespace token, so the slash that
+        // used to satisfy the namespace check came from the URL and was then
+        // truncated away before the tag was stored (issue #248).
+        let content = concat!(
+            "See [ebusd discussion #1177](https://github.com/john30/ebusd/discussions/1177)\n",
+            "and [thread #25433](https://example.com/t/25433) for details.\n",
+        );
+        let tags = extract_tags(content);
+        assert!(!tags.contains("1177"), "citation number rejected");
+        assert!(!tags.contains("25433"), "citation number rejected");
+        assert!(tags.is_empty(), "no tag at all from citations: {tags:?}");
+    }
+
+    #[test]
+    fn hashtags_inside_fenced_blocks_and_inline_code_are_not_tags() {
+        let content = concat!(
+            "Real #area/health in prose.\n",
+            "\n",
+            "```markdown\n",
+            "#fenced/tag\n",
+            "```\n",
+            "\n",
+            "~~~\n",
+            "#tilde/tag\n",
+            "~~~\n",
+            "\n",
+            "Documented as `#inline/tag` in a code span.\n",
+        );
+        let tags = extract_tags(content);
+        assert!(tags.contains("area/health"), "prose tag still indexed");
+        assert!(!tags.contains("fenced/tag"), "backtick-fenced tag skipped");
+        assert!(!tags.contains("tilde/tag"), "tilde-fenced tag skipped");
+        assert!(!tags.contains("inline/tag"), "inline code span skipped");
+    }
+
+    #[test]
+    fn multi_segment_inline_tags_are_still_accepted() {
+        let tags = extract_tags("nested #a/b/c here");
+        assert!(tags.contains("a/b/c"), "multi-segment inline tag accepted");
     }
 
     #[test]

--- a/src/vault/links.rs
+++ b/src/vault/links.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 
+use crate::cache::parse::for_non_code_line;
+
 use super::paths::{normalize_link_target, normalize_title, slugify};
 use super::types::NoteEntry;
 
@@ -79,30 +81,9 @@ fn sort_slug_links(links: &mut [String], by_slug: &HashMap<String, NoteEntry>) {
 
 fn extract_wikilink_targets(content: &str) -> Vec<String> {
     let mut targets = Vec::new();
-    let mut fenced_marker: Option<(u8, usize)> = None;
-
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-
-        if let Some((marker, min_len)) = fenced_marker {
-            if let Some((close_marker, close_len)) = parse_fence_marker(trimmed)
-                && close_marker == marker
-                && close_len >= min_len
-            {
-                fenced_marker = None;
-            }
-            continue;
-        }
-
-        if let Some(marker) = parse_fence_marker(trimmed) {
-            fenced_marker = Some(marker);
-            continue;
-        }
-
-        let no_inline_code = strip_inline_code_segments(line);
-        extract_line_wikilink_targets(&no_inline_code, &mut targets);
-    }
-
+    for_non_code_line(content, |line| {
+        extract_line_wikilink_targets(line, &mut targets);
+    });
     targets
 }
 
@@ -140,57 +121,6 @@ fn extract_line_wikilink_targets(line: &str, targets: &mut Vec<String>) {
 
         idx = end + 2;
     }
-}
-
-fn parse_fence_marker(trimmed_line: &str) -> Option<(u8, usize)> {
-    let bytes = trimmed_line.as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-
-    let marker = bytes[0];
-    if marker != b'`' && marker != b'~' {
-        return None;
-    }
-
-    let mut len = 1usize;
-    while len < bytes.len() && bytes[len] == marker {
-        len += 1;
-    }
-
-    if len >= 3 { Some((marker, len)) } else { None }
-}
-
-fn strip_inline_code_segments(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
-    let mut idx = 0usize;
-    let mut inline_marker_len = 0usize;
-
-    while idx < chars.len() {
-        if chars[idx] == '`' {
-            let mut marker_len = 1usize;
-            while idx + marker_len < chars.len() && chars[idx + marker_len] == '`' {
-                marker_len += 1;
-            }
-
-            if inline_marker_len == 0 {
-                inline_marker_len = marker_len;
-            } else if marker_len == inline_marker_len {
-                inline_marker_len = 0;
-            }
-
-            idx += marker_len;
-            continue;
-        }
-
-        if inline_marker_len == 0 {
-            out.push(chars[idx]);
-        }
-        idx += 1;
-    }
-
-    out
 }
 
 fn parse_wikilink_target(body: &str) -> String {

--- a/src/vault/write/assets.rs
+++ b/src/vault/write/assets.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
+use crate::cache::parse::{for_non_code_line, parse_fence_marker};
 use crate::vault::types::{NoteEntry, VaultIndex};
 
 use super::paths::{
@@ -9,7 +10,7 @@ use super::paths::{
     is_trashed_path, relative_link_target, resolve_reference_inside_root, same_existing_path,
     unique_trash_attachment_relative_path, vault_relative_dir,
 };
-use super::rewrites::{parse_fence_marker, rewrite_content_or_read};
+use super::rewrites::rewrite_content_or_read;
 use super::types::{AssetMove, TextRewrite, WriteError};
 
 pub(super) fn asset_move_plan(
@@ -378,58 +379,6 @@ where
         return body.to_string();
     };
     format!("{}{}", transform_target(&asset), &body[target_end..])
-}
-
-fn for_non_code_line<F>(content: &str, mut visit: F)
-where
-    F: FnMut(&str),
-{
-    let mut fenced_marker: Option<(u8, usize)> = None;
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        if let Some((marker, min_len)) = fenced_marker {
-            if let Some((close_marker, close_len)) = parse_fence_marker(trimmed)
-                && close_marker == marker
-                && close_len >= min_len
-            {
-                fenced_marker = None;
-            }
-            continue;
-        }
-        if let Some(marker) = parse_fence_marker(trimmed) {
-            fenced_marker = Some(marker);
-            continue;
-        }
-        let no_inline_code = strip_inline_code_segments(line);
-        visit(&no_inline_code);
-    }
-}
-
-fn strip_inline_code_segments(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
-    let mut idx = 0usize;
-    let mut inline_marker_len = 0usize;
-    while idx < chars.len() {
-        if chars[idx] == '`' {
-            let mut marker_len = 1usize;
-            while idx + marker_len < chars.len() && chars[idx + marker_len] == '`' {
-                marker_len += 1;
-            }
-            if inline_marker_len == 0 {
-                inline_marker_len = marker_len;
-            } else if marker_len == inline_marker_len {
-                inline_marker_len = 0;
-            }
-            idx += marker_len;
-            continue;
-        }
-        if inline_marker_len == 0 {
-            out.push(chars[idx]);
-        }
-        idx += 1;
-    }
-    out
 }
 
 fn extract_markdown_assets(line: &str, assets: &mut Vec<PathBuf>) {

--- a/src/vault/write/notes.rs
+++ b/src/vault/write/notes.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::cache::parse::content_hash;
+use crate::cache::parse::{content_hash, parse_fence_marker};
 use crate::vault::paths::{slugify, strip_md_extension};
 use crate::vault::types::{NoteEntry, VaultIndex};
 
@@ -13,7 +13,7 @@ use super::paths::{
     create_parent_dir_inside_root, normalize_note_relative_path, resolve_new_note_path,
     unique_trash_relative_path,
 };
-use super::rewrites::{backlink_rewrite_plan, merge_rewrites, parse_fence_marker};
+use super::rewrites::{backlink_rewrite_plan, merge_rewrites};
 use super::types::{AssetMove, MutationPhase, TextRewrite, WriteError, WriteOutcome};
 use crate::cache::parse::frontmatter_span;
 

--- a/src/vault/write/rewrites.rs
+++ b/src/vault/write/rewrites.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+use crate::cache::parse::parse_fence_marker;
 use crate::vault::paths::{normalize_link_target, normalize_title};
 use crate::vault::types::{NoteEntry, VaultIndex};
 
@@ -197,19 +198,6 @@ where
     }
     let suffix = &body[target_end..];
     transform_target(target).map(|new_target| format!("{new_target}{suffix}"))
-}
-
-pub(super) fn parse_fence_marker(trimmed_line: &str) -> Option<(u8, usize)> {
-    let bytes = trimmed_line.as_bytes();
-    let marker = *bytes.first()?;
-    if marker != b'`' && marker != b'~' {
-        return None;
-    }
-    let mut len = 1usize;
-    while len < bytes.len() && bytes[len] == marker {
-        len += 1;
-    }
-    if len >= 3 { Some((marker, len)) } else { None }
 }
 
 pub(super) fn merge_rewrites(left: Vec<TextRewrite>, right: Vec<TextRewrite>) -> Vec<TextRewrite> {

--- a/src/vault/write/tests.rs
+++ b/src/vault/write/tests.rs
@@ -2380,6 +2380,61 @@ fn a_wikilink_to_a_note_whose_title_contains_a_dot_is_not_an_asset() {
 }
 
 #[test]
+fn an_asset_reference_inside_code_is_not_collected_or_rewritten_by_a_move() {
+    // Pins this rewriter to the shared Markdown code-region scanner
+    // (`cache::parse::for_non_code_line`, consolidated in #248). An embed
+    // written inside a fenced block or an inline code span is documentation of
+    // syntax, not a live reference: it must not drag a file along on a move,
+    // and its text must survive the rewrite untouched.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("folder-x/media")).expect("media dir");
+    fs::write(root.join("folder-x/media/live.png"), BINARY_ASSET).expect("live asset");
+    fs::write(root.join("folder-x/media/fenced.png"), BINARY_ASSET).expect("fenced asset");
+    fs::write(root.join("folder-x/media/inline.png"), BINARY_ASSET).expect("inline asset");
+    let body = concat!(
+        "# B\n",
+        "![](./media/live.png)\n",
+        "\n",
+        "```markdown\n",
+        "![](./media/fenced.png)\n",
+        "```\n",
+        "\n",
+        "Write it as `![](./media/inline.png)` in your note.\n",
+    );
+    fs::write(root.join("folder-x/B.md"), body).expect("note");
+    let index = build(root);
+
+    let entry = index.find_by_slug("b").expect("b");
+    let outcome = move_or_rename_note(root, &index, entry, "folder-z/B.md", &content_hash(body))
+        .expect("move the note");
+
+    assert_eq!(outcome.moved_assets, 1, "only the live embed travels");
+    assert!(
+        root.join("folder-z/media/live.png").exists(),
+        "the live embed's file moved with the note"
+    );
+    assert!(
+        root.join("folder-x/media/fenced.png").exists(),
+        "an embed inside a fenced block is not a reference"
+    );
+    assert!(
+        root.join("folder-x/media/inline.png").exists(),
+        "an embed inside an inline code span is not a reference"
+    );
+
+    let moved = fs::read_to_string(root.join("folder-z/B.md")).expect("read moved note");
+    assert!(
+        moved.contains("![](./media/fenced.png)"),
+        "the fenced embed's text is left exactly as written: {moved}"
+    );
+    assert!(
+        moved.contains("`![](./media/inline.png)`"),
+        "the inline-code embed's text is left exactly as written: {moved}"
+    );
+}
+
+#[test]
 fn attachment_operations_refuse_a_symlink_that_leads_into_the_git_directory() {
     // Reading the path as written is not enough: a link named anything at all
     // can lead into `.git`, and only the filesystem's own view sees through it.


### PR DESCRIPTION
Fixes #248.

## What was wrong

The inline tag extractor checked for a namespace slash on the raw whitespace token, but stored only the leading run of tag characters. A citation written as `[discussion #1177](https://example.com/x/1177)` is a single token whose slash comes from the URL, and truncation dropped that slash again before the tag was inserted. So `1177` passed a check it should have failed, and a bare number got indexed as a tag. The check now runs against the same candidate that actually gets stored.

## Code awareness

Per the scope note on the issue, a hashtag inside a fenced code block or an inline code span is no longer a tag. A note that documents a tag convention stops being filed under it. Inline code spans escaped only by accident before, because the backtick stayed attached to the token.

That scanning already existed as behaviourally identical private copies in the Vault link reader and the write layer's rewriters. Rather than add a third copy, it moves to `cache::parse`, which vault indexing and the write layer already consume, and the copies are deleted. #242's Vault-wide tag rename needs reads and writes to agree on what counts as code, which is why the consolidation belongs with this fix rather than after it.

```markdown
Interface change: Markdown code-region scanner
Producer boundary: Cache and query read model (`src/cache/parse.rs`)
Kind: additive (new crate-private contract; no observable change to existing callers)
Old contract: `for_non_code_line` / `parse_fence_marker` / `strip_inline_code_segments` private to `vault/links.rs`, `vault/write/assets.rs`, `vault/write/rewrites.rs`
New contract: `for_non_code_line` and `parse_fence_marker` crate-private in `cache::parse`; `strip_inline_code_segments` stays private to it
Consumer boundaries: Vault read model (`vault/links.rs`), Vault mutation (`vault/write/assets.rs`, `notes.rs`, `rewrites.rs`). No external consumers; all three were private before.
Compatibility/migration: none needed. The copies were verified behaviourally identical against af948bb.
Rollout/rollback: N/A. No persisted format or wire shape changes. Tags are derived data, so a normal reindex recomputes them.
Evidence: see below.
```

## Validation

From the repository root:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --all-features` — 1004 / 8 / 5 / 1 passed, 0 failed
- `node scripts/check-module-map.mjs`
- `node scripts/check-docs-freshness.mjs --validate-table`, then `just docs-freshness-ack`

New tests: three in `src/cache/parse.rs` covering the citation pattern, fenced and inline code, and multi-segment tags. One in `src/vault/write/tests.rs` pinning the asset-reference rewriter to the shared scanner, so an embed written inside code is neither collected nor rewritten by a move.

## Live acceptance

`just dev-start messy`, driven through MCP at `127.0.0.1:42824/mcp`.

Adding a note carrying two markdown-link citations (`#9911`, `#9922`), a fenced hashtag, a tilde-fenced hashtag and an inline-code hashtag raised the Vault's tag count from 43 to 46: exactly the frontmatter tag plus the two namespaced prose tags. The old behaviour would have added 7. The cache confirms the note's stored tags are `zzacc/frontmatter`, `zzacc/multi/segment`, `zzacc/prose`, and that no bare-numeric tag exists in any Vault.

## Note for review

Three hand-rolled fence walks remain in `vault/write/{rewrites,assets,notes}.rs`. They rebuild content and must preserve line endings, so they cannot use the visiting form; they share the `parse_fence_marker` predicate but not the loop. Consolidating those is a separate job and was out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
