### PR TITLE
fix(git): carry commit_summary into the commit that records the write

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -109,6 +109,12 @@ that production inventory are still checked for stale paths and duplicates.
 - `VaultCollectionRuntime` reconstructs disposable background turns at startup
   and, on process shutdown, stops new work and waits only for active
   background-turn and foreground-mutation safe boundaries.
+  A `VaultControlBlock` also owns that Vault's `git::WriteLedger`, the one
+  per-Vault handle both the mutation core and its Git turn already hold
+  (#249). An in-place definition edit rotates the control block, and the
+  ledger moves to the replacement alongside `prior_git`: its records describe
+  writes already on disk and still uncommitted, so the rotation must not drop
+  them.
   `AppState::vault_registry`, `AppState::vaults`, and
   `AppState::legacy_migration_recovery` expose the authoritative definition
   store, activated per-Vault control blocks, and safe legacy-recovery state to
@@ -390,6 +396,9 @@ small public surface — no trait, no framework, no second execution lane.
     resets, or merges, so it deliberately takes neither the lease nor the
     mutation lock.
   - `Local`: no Git turn at all; returns without publishing anything.
+
+  Every branch that can commit is handed the Vault's `write_ledger()` so the
+  commit it makes is named by the writes it records (#249).
 
   Both locked paths hold the mutation lock for the whole blocking turn
   (coarser than the legacy single-Vault task's fine-grained per-phase locking
@@ -1067,8 +1076,13 @@ mutation lock; building the authoritative index off the async runtime;
 resolving the slug to an entry; refusing a write to a path this Vault's own
 exclusion patterns would make invisible; resolving the archive prefix from the
 Vault's own archive folder or the instance default; running the blocking write
-off the async runtime; and returning `NoteWriteOutcome` or a structured
-`VaultOperationError`. `NoteWriteOutcome` carries the note's resulting layer,
+off the async runtime; recording what that write did in the Vault's
+`git::WriteLedger`, so the commit that eventually records it can say so
+(#249); and returning `NoteWriteOutcome` or a structured
+`VaultOperationError`. `VaultMutation::with_commit_summary` carries the
+caller's one-line description of the change into that record; the private
+`RecordedWrite` trait is what lets `run_write` build the record once for all
+fifteen primitives instead of at each of them. `NoteWriteOutcome` carries the note's resulting layer,
 resolved from the `LayerMap` the write's own pre-write index build already
 holds rather than from a post-write rescan (#101). `VaultMutationCore` carries a one-shot form — gate, lock, write — for each of
 the fifteen primitives, which is what a standalone caller wants:
@@ -1494,11 +1508,15 @@ superseding ADR-05.
 
 **Public contract:** `GitMode` (`off`/`local`, carried only by the legacy
 first-boot import — the instance-wide runtime lane is gone, #185), `GitConfig`,
-write-record/message types, commit outcomes and errors (including
+write-record/message types (`WriteRecord`, `WriteLedger`,
+`build_commit_message`), commit outcomes and errors (including
 `GitError::ManualRecovery` for repository operations that cannot be proven
 Hatchdoor-owned), and the local repository operations `validate_repo`,
 `validate_local_repo`, `init_local_repo`, `commit_local`,
-`has_uncommitted_changes`, and `run_local_history_git_turn`. Only the last
+`has_uncommitted_changes`, and `run_local_history_git_turn`. Since #249
+`run_local_history_git_turn` takes the Vault's `&WriteLedger` and names its
+commit from the batch waiting there, restoring that batch when the turn finds
+nothing to commit. Only the last
 three are on a live path; `validate_repo`, `init_local_repo`, and
 `has_uncommitted_changes` lost their production callers with the settings
 lifecycle and the boot-time legacy validation in #185 and are retained
@@ -1545,7 +1563,10 @@ checks out, polls, pushes, or attempts automatic reacquisition/recovery.
 `ManagedSyncError`, and `synchronize_managed_checkout` form the next shared-core
 managed-checkout graph boundary. A caller that holds the checkout lease and
 serializes Vault writes supplies the already validated repository and contained
-Vault root. Pull-only refuses and preserves any local work or local-only
+Vault root, plus that Vault's `&WriteLedger`: a Two-way commit takes the
+pending batch at the moment it is certain to commit and builds its message
+from it (#249), restoring the batch if the commit itself fails, while
+Pull-only never commits and leaves the ledger alone. Pull-only refuses and preserves any local work or local-only
 history, then only fast-forwards a clean checkout. Two-way commits Vault-subtree
 work before every tree-changing graph operation, refuses unrelated repository
 work, fast-forwards remote-only advancement, creates a merge commit for clean
@@ -1560,6 +1581,18 @@ operator-owned `ExistingGit` checkout are outside this boundary and untouched.
 Public HTTPS makes no credential callback; supplied credentials are callback
 input only and remain redacted. This boundary does not acquire, delete,
 schedule, poll, persist status, or repair checkouts.
+
+`WriteRecord`, `WriteLedger`, and `build_commit_message` are what makes a
+commit say what happened. One Git turn coalesces every Vault write since the
+last one, so the record of each write waits in the Vault's ledger in between:
+the mutation core appends one `WriteRecord` per successful write, and the two
+functions that actually commit — `commit_vault_drift` (Two-way) and
+`commit_local` through `run_local_history_git_turn` (Local history) — take the
+whole batch and name the commit from it. Title: the first three operations and
+the unique file count. Body: one `- ` line per caller-supplied summary. A
+commit whose batch is empty, which is what drift from outside Hatchdoor
+produces, keeps the generic `hatchdoor: vault update`. The ledger is bounded
+(`WriteLedger::CAPACITY`) because a `Local` Vault has no Git turn to take it.
 
 `ManagedGitTurnConfig`, `ManagedGitOutcome`, `run_managed_git_turn`,
 `ManagedGitScheduler`, `GitPollingClock`, `spawn_scheduler_tick`,

--- a/docs/user-vault/02 Guides/How to set up a Git-backed Vault.md
+++ b/docs/user-vault/02 Guides/How to set up a Git-backed Vault.md
@@ -35,6 +35,8 @@ Open **Settings** → **Add a Vault**, then:
 | **Pull-only** | Also fetches from the remote on the sync schedule. Content flows in; Hatchdoor's own commits stay local and are never pushed. | Either |
 | **Two-way** | Also pushes Hatchdoor's own commits back to the remote. | Either |
 
+Hatchdoor commits on a schedule, not on every write, so one commit usually gathers several changes. The subject names the first few writes it recorded and how many files they touched, and the body carries whatever one-line summary each of those writes supplied. An agent connected over MCP can pass a summary on every write, which is what turns the history into an answer to "why did this note change?". Edits you make in the Vault folder yourself carry no summary, so a commit made up only of those keeps the generic `hatchdoor: vault update`.
+
 > [!warning]
 > Local history creates a hidden `.git` folder inside the Vault's own notes folder to hold its history, and that folder grows permanently: every image and PDF ever attached stays in it, even after you delete the file from the Vault. Don't reach for Local history on a Vault with large attachments unless you're prepared for that growth.
 

--- a/docs/user-vault/03 Reference/MCP tools reference.md
+++ b/docs/user-vault/03 Reference/MCP tools reference.md
@@ -216,7 +216,7 @@ An asset travels with a note only when it already lives inside that note's own f
 > [!note]
 > A note sitting in the Vault root has the whole Vault as its own folder, so every asset it references counts as living inside it and does travel with the note when it moves to another folder. A rename keeps the note where it is, so nothing travels. Keep notes that share an attachments folder in a folder of their own if you want that folder left alone.
 
-Every write tool accepts an optional `commit_summary` (a one-line string) used in the Git commit body for Vaults with versioning enabled.
+Every write tool accepts an optional `commit_summary`, a one-line string describing what the change was for. On a Vault with versioning enabled it reaches the body of the commit that records that write. One commit usually covers several writes, since Hatchdoor commits on a schedule rather than per call: the subject names the first few operations and how many files they touched, and the body lists one `- ` line per summary, in the order the writes happened. A write with no summary still shapes the subject. Pass one on every write and the Vault's history reads as a log of why each note changed.
 
 > [!warning]
 > No write tool can create, rename, or move a file named `.hatchdoor-layer` (the layer marker) — that call is rejected outright, since a marker silently changes how a whole folder is classified and is meant to be edited directly in the Vault. Writes are also rejected if the target path matches the Vault's own noise-exclusion patterns, since such a file would be written to disk but stay invisible to every read surface.

--- a/src/git/managed_sync.rs
+++ b/src/git/managed_sync.rs
@@ -8,6 +8,7 @@ use git2::{
 };
 
 use super::managed_checkout::ManagedHttpsCredentials;
+use super::message::WriteLedger;
 
 /// The two managed remote behaviors that share checkout synchronization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -114,13 +115,18 @@ const MAX_PUSH_RACE_ATTEMPTS: usize = 2;
 /// The caller retains the checkout lease and serializes this function with
 /// Vault writes. This boundary neither acquires a checkout nor schedules,
 /// polls, retries later, persists status, or repairs a failed checkout.
+///
+/// `ledger` is the Vault's pending batch of write records (issue #249). Only
+/// the Two-way graph ever commits, and it takes the batch at the moment it
+/// builds a commit message; a Pull-only checkout leaves it alone.
 pub fn synchronize_managed_checkout(
     config: &ManagedSyncConfig,
+    ledger: &WriteLedger,
 ) -> Result<ManagedSyncOutcome, ManagedSyncError> {
     let repository = open_validated_repository(config)?;
     match config.mode {
         ManagedSyncMode::PullOnly => synchronize_pull_only(&repository, config),
-        ManagedSyncMode::TwoWay => synchronize_two_way(&repository, config),
+        ManagedSyncMode::TwoWay => synchronize_two_way(&repository, config, ledger),
     }
 }
 
@@ -150,24 +156,26 @@ fn synchronize_pull_only(
 fn synchronize_two_way(
     repository: &Repository,
     config: &ManagedSyncConfig,
+    ledger: &WriteLedger,
 ) -> Result<ManagedSyncOutcome, ManagedSyncError> {
-    synchronize_two_way_with_push(repository, config, push)
+    synchronize_two_way_with_push(repository, config, ledger, push)
 }
 
 fn synchronize_two_way_with_push<F>(
     repository: &Repository,
     config: &ManagedSyncConfig,
+    ledger: &WriteLedger,
     mut push_operation: F,
 ) -> Result<ManagedSyncOutcome, ManagedSyncError>
 where
     F: FnMut(&Repository, &ManagedSyncConfig) -> Result<(), ManagedSyncError>,
 {
-    let mut committed = prepare_two_way_worktree(repository, config)?;
+    let mut committed = prepare_two_way_worktree(repository, config, ledger)?;
     let mut integrated = false;
 
     for attempt in 0..MAX_PUSH_RACE_ATTEMPTS {
         fetch(repository, config)?;
-        committed |= prepare_two_way_worktree(repository, config)?;
+        committed |= prepare_two_way_worktree(repository, config, ledger)?;
         let relation = graph(repository, config)?;
 
         if relation.behind > 0 {
@@ -319,6 +327,7 @@ fn dirty_worktree_error(files: Vec<PathBuf>) -> ManagedSyncError {
 fn prepare_two_way_worktree(
     repository: &Repository,
     config: &ManagedSyncConfig,
+    ledger: &WriteLedger,
 ) -> Result<bool, ManagedSyncError> {
     let vault_relative = vault_relative_path(repository, config)?;
     let files = changed_paths(repository)?;
@@ -333,7 +342,7 @@ fn prepare_two_way_worktree(
     if files.is_empty() {
         return Ok(false);
     }
-    commit_vault_drift(repository, config, &vault_relative)
+    commit_vault_drift(repository, config, &vault_relative, ledger)
 }
 
 fn changed_paths(repository: &Repository) -> Result<Vec<PathBuf>, ManagedSyncError> {
@@ -374,6 +383,7 @@ fn commit_vault_drift(
     repository: &Repository,
     config: &ManagedSyncConfig,
     vault_relative: &Path,
+    ledger: &WriteLedger,
 ) -> Result<bool, ManagedSyncError> {
     // Read the operator's on-disk index status *before* building this
     // commit's own in-memory index below: `has_staged_vault_changes` reads
@@ -414,16 +424,21 @@ fn commit_vault_drift(
 
     let signature = signature(config)?;
     let parents = parent.iter().collect::<Vec<_>>();
-    repository
-        .commit(
-            Some("HEAD"),
-            &signature,
-            &signature,
-            "hatchdoor: record local Vault changes",
-            &tree,
-            &parents,
-        )
-        .map_err(|_| ManagedSyncError::Validation)?;
+    // Reached only once this commit is certain, so a turn that found no drift
+    // has already returned above with the batch untouched (issue #249).
+    ledger.commit_batch(|message| {
+        repository
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                message,
+                &tree,
+                &parents,
+            )
+            .map(|_| true)
+            .map_err(|_| ManagedSyncError::Validation)
+    })?;
 
     // `commit` advances HEAD but does not update the on-disk index. Refresh
     // precisely the Vault subtree when it had no existing staging. If an
@@ -749,6 +764,7 @@ mod tests {
     use git2::{Repository, Signature};
     use tempfile::TempDir;
 
+    use super::super::message::WriteRecord;
     use super::*;
 
     fn commit(repository: &Repository, path: &str, contents: &str, message: &str) {
@@ -868,7 +884,8 @@ mod tests {
         let (_root, config) = fixture(ManagedSyncMode::PullOnly);
         std::fs::write(config.vault_path.join("Home.md"), "local edit\n").expect("local edit");
 
-        let error = synchronize_managed_checkout(&config).expect_err("dirty pull-only work");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("dirty pull-only work");
 
         assert!(matches!(error, ManagedSyncError::DirtyWorkingCopy { .. }));
         assert_eq!(
@@ -887,7 +904,8 @@ mod tests {
             .expect("head")
             .target();
 
-        let outcome = synchronize_managed_checkout(&config).expect("pull-only sync");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("pull-only sync");
 
         assert_eq!(outcome, ManagedSyncOutcome::PullOnlyFastForwarded);
         let checkout = Repository::open(&config.repository_path).expect("checkout");
@@ -901,8 +919,8 @@ mod tests {
         let checkout = Repository::open(&config.repository_path).expect("checkout");
         commit(&checkout, "vault/Local.md", "local\n", "local-only commit");
 
-        let error =
-            synchronize_managed_checkout(&config).expect_err("local history is unsupported");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("local history is unsupported");
 
         assert!(matches!(error, ManagedSyncError::LocalCommits { ahead: 1 }));
         let remote = Repository::open_bare(root.path().join("remote.git")).expect("remote");
@@ -925,7 +943,8 @@ mod tests {
         let (root, config) = fixture(ManagedSyncMode::TwoWay);
         std::fs::write(config.vault_path.join("Home.md"), "two-way local\n").expect("local edit");
 
-        let outcome = synchronize_managed_checkout(&config).expect("two-way sync");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("two-way sync");
 
         assert_eq!(
             outcome,
@@ -939,12 +958,89 @@ mod tests {
     }
 
     #[test]
+    fn a_two_way_commit_is_named_by_the_writes_it_records() {
+        let (_root, config) = fixture(ManagedSyncMode::TwoWay);
+        // Longer than the committed content on purpose: git2's status check
+        // trusts the index stat cache, and a same-size rewrite in the same
+        // second reads as unchanged.
+        std::fs::write(config.vault_path.join("Home.md"), "# Home\n\ntightened\n")
+            .expect("local edit");
+        let ledger = WriteLedger::new();
+        ledger.record(WriteRecord {
+            op: "update".to_string(),
+            target: "Home".to_string(),
+            affected_paths: vec![config.vault_path.join("Home.md")],
+            summary: Some("tighten the intro".to_string()),
+        });
+
+        synchronize_managed_checkout(&config, &ledger).expect("two-way sync");
+
+        let checkout = Repository::open(&config.repository_path).expect("checkout");
+        let head = checkout
+            .head()
+            .expect("head")
+            .peel_to_commit()
+            .expect("commit");
+        let message = head.message().expect("commit message");
+        assert_eq!(
+            message,
+            "hatchdoor: update \"Home\" (1 file)\n\n- tighten the intro"
+        );
+        assert!(
+            ledger.take().is_empty(),
+            "the committed batch is not carried into the next commit"
+        );
+    }
+
+    #[test]
+    fn a_two_way_turn_with_no_drift_leaves_the_batch_for_the_turn_that_commits() {
+        let (_root, config) = fixture(ManagedSyncMode::TwoWay);
+        let ledger = WriteLedger::new();
+        ledger.record(WriteRecord {
+            op: "update".to_string(),
+            target: "Home".to_string(),
+            affected_paths: vec![config.vault_path.join("Home.md")],
+            summary: Some("not committed yet".to_string()),
+        });
+
+        synchronize_managed_checkout(&config, &ledger).expect("two-way sync");
+
+        let batch = ledger.take();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].summary.as_deref(), Some("not committed yet"));
+    }
+
+    #[test]
+    fn a_commit_recording_no_agent_writes_keeps_the_generic_message() {
+        let (_root, config) = fixture(ManagedSyncMode::TwoWay);
+        std::fs::write(
+            config.vault_path.join("Home.md"),
+            "# Home\n\nedited by hand\n",
+        )
+        .expect("local edit");
+
+        synchronize_managed_checkout(&config, &WriteLedger::new()).expect("two-way sync");
+
+        let checkout = Repository::open(&config.repository_path).expect("checkout");
+        let head = checkout
+            .head()
+            .expect("head")
+            .peel_to_commit()
+            .expect("commit");
+        assert_eq!(
+            head.message().expect("commit message"),
+            "hatchdoor: vault update"
+        );
+    }
+
+    #[test]
     fn two_way_merges_diverged_histories_and_pushes_the_merge() {
         let (root, config) = fixture(ManagedSyncMode::TwoWay);
         remote_commit(root.path(), "vault/Remote.md", "remote\n", "remote change");
         std::fs::write(config.vault_path.join("Local.md"), "local\n").expect("local edit");
 
-        let outcome = synchronize_managed_checkout(&config).expect("diverged sync");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("diverged sync");
 
         assert_eq!(
             outcome,
@@ -971,13 +1067,18 @@ mod tests {
         let checkout = Repository::open(&config.repository_path).expect("checkout");
         let mut injected_race = false;
 
-        let outcome = synchronize_two_way_with_push(&checkout, &config, |repository, config| {
-            if !injected_race {
-                injected_race = true;
-                remote_commit(root.path(), "vault/Race.md", "race\n", "push race");
-            }
-            push(repository, config)
-        })
+        let outcome = synchronize_two_way_with_push(
+            &checkout,
+            &config,
+            &WriteLedger::new(),
+            |repository, config| {
+                if !injected_race {
+                    injected_race = true;
+                    remote_commit(root.path(), "vault/Race.md", "race\n", "push race");
+                }
+                push(repository, config)
+            },
+        )
         .expect("bounded replay resolves one push race");
 
         assert!(injected_race);
@@ -1004,7 +1105,8 @@ mod tests {
         );
         std::fs::write(config.vault_path.join("Home.md"), "local change\n").expect("local edit");
 
-        let error = synchronize_managed_checkout(&config).expect_err("merge conflict");
+        let error =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect_err("merge conflict");
 
         assert!(matches!(error, ManagedSyncError::Conflict { .. }));
         let checkout = Repository::open(&config.repository_path).expect("checkout");
@@ -1021,7 +1123,8 @@ mod tests {
         std::fs::write(&outside, "outside\n").expect("outside edit");
         std::fs::write(config.vault_path.join("Home.md"), "inside\n").expect("inside edit");
 
-        let error = synchronize_managed_checkout(&config).expect_err("outside dirty work");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("outside dirty work");
 
         assert!(matches!(error, ManagedSyncError::DirtyWorkingCopy { .. }));
         assert_eq!(
@@ -1056,7 +1159,8 @@ mod tests {
             .remote_set_url("origin", "https://private-token@example.test/vault.git")
             .expect("tamper origin");
 
-        let error = synchronize_managed_checkout(&config).expect_err("unsafe origin");
+        let error =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect_err("unsafe origin");
 
         assert_eq!(error, ManagedSyncError::Validation);
         assert!(!error.to_string().contains("private-token"));
@@ -1070,7 +1174,8 @@ mod tests {
             .remote("backup", "https://private-token@example.test/vault.git")
             .expect("secondary remote");
 
-        let outcome = synchronize_managed_checkout(&config).expect("configured remote");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("configured remote");
 
         assert_eq!(outcome, ManagedSyncOutcome::UpToDate);
         assert!(!format!("{config:?}").contains("private-token"));
@@ -1124,7 +1229,8 @@ mod tests {
             .push(&["refs/heads/master:refs/heads/master"], None)
             .expect("push replacement");
 
-        let error = synchronize_managed_checkout(&config).expect_err("invalid Vault root");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("invalid Vault root");
 
         assert_eq!(error, ManagedSyncError::Validation);
     }
@@ -1137,7 +1243,8 @@ mod tests {
             .remote_set_url("origin", "https://example.test/not valid.git")
             .expect("tamper origin");
 
-        let error = synchronize_managed_checkout(&config).expect_err("malformed origin");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("malformed origin");
 
         assert_eq!(error, ManagedSyncError::Validation);
     }
@@ -1154,7 +1261,8 @@ mod tests {
             .expect("operator remote");
         std::fs::write(config.vault_path.join("Home.md"), "selected remote\n").expect("local edit");
 
-        let outcome = synchronize_managed_checkout(&config).expect("two-way sync");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("two-way sync");
 
         assert_eq!(
             outcome,
@@ -1175,7 +1283,8 @@ mod tests {
             .remote("duplicate", &config.repository_url)
             .expect("duplicate remote");
 
-        let error = synchronize_managed_checkout(&config).expect_err("ambiguous remote");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("ambiguous remote");
 
         assert_eq!(error, ManagedSyncError::Validation);
     }
@@ -1188,7 +1297,8 @@ mod tests {
             .remote_set_pushurl("origin", Some("ssh://git@example.test/operator.git"))
             .expect("push URL");
 
-        let error = synchronize_managed_checkout(&config).expect_err("unsafe push URL");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("unsafe push URL");
 
         assert_eq!(error, ManagedSyncError::Validation);
     }
@@ -1230,7 +1340,8 @@ mod tests {
         std::fs::write(config.vault_path.join("Home.md"), "working tree content\n")
             .expect("working tree edit after staging");
 
-        let outcome = synchronize_managed_checkout(&config).expect("two-way sync");
+        let outcome =
+            synchronize_managed_checkout(&config, &WriteLedger::new()).expect("two-way sync");
 
         assert_eq!(
             outcome,
@@ -1278,7 +1389,8 @@ mod tests {
             "remote outside change",
         );
 
-        let error = synchronize_managed_checkout(&config).expect_err("outside conflict");
+        let error = synchronize_managed_checkout(&config, &WriteLedger::new())
+            .expect_err("outside conflict");
 
         assert!(matches!(error, ManagedSyncError::Conflict { .. }));
         let checkout = Repository::open(&config.repository_path).expect("checkout");

--- a/src/git/managed_task.rs
+++ b/src/git/managed_task.rs
@@ -30,6 +30,7 @@ use super::managed_sync::{
     ManagedSyncConfig, ManagedSyncError, ManagedSyncMode, ManagedSyncOutcome,
     synchronize_managed_checkout,
 };
+use super::message::WriteLedger;
 
 /// The default interval a managed Vault waits before its next scheduled Git
 /// turn after a success or non-retryable failure, absent an explicitly
@@ -150,6 +151,7 @@ pub enum ManagedGitOutcome {
 pub fn run_managed_git_turn(
     config: &ManagedGitTurnConfig,
     lease: &ManagedCheckoutLease,
+    ledger: &WriteLedger,
 ) -> Result<ManagedGitOutcome, VaultWorkError> {
     let sync_mode = match config.mode {
         VaultGitMode::PullOnly => ManagedSyncMode::PullOnly,
@@ -192,7 +194,8 @@ pub fn run_managed_git_turn(
         author_name: config.author_name.clone(),
         author_email: config.author_email.clone(),
     };
-    let outcome = synchronize_managed_checkout(&sync_config).map_err(classify_sync_error)?;
+    let outcome =
+        synchronize_managed_checkout(&sync_config, ledger).map_err(classify_sync_error)?;
     Ok(match outcome {
         ManagedSyncOutcome::UpToDate => ManagedGitOutcome::UpToDate,
         ManagedSyncOutcome::PullOnlyFastForwarded
@@ -237,6 +240,7 @@ pub fn run_existing_git_remote_turn(
     credentials: Option<HttpsCredentials>,
     author_name: String,
     author_email: String,
+    ledger: &WriteLedger,
 ) -> Result<ManagedGitOutcome, VaultWorkError> {
     let Some(repository_url) = repository_url else {
         return Err(classify_sync_error(ManagedSyncError::Validation));
@@ -284,7 +288,8 @@ pub fn run_existing_git_remote_turn(
         author_name,
         author_email,
     };
-    let outcome = synchronize_managed_checkout(&sync_config).map_err(classify_sync_error)?;
+    let outcome =
+        synchronize_managed_checkout(&sync_config, ledger).map_err(classify_sync_error)?;
     Ok(match outcome {
         ManagedSyncOutcome::UpToDate => ManagedGitOutcome::UpToDate,
         ManagedSyncOutcome::PullOnlyFastForwarded
@@ -1069,7 +1074,8 @@ mod tests {
         let lease = ManagedCheckoutLease::acquire(config.state_directory.clone(), config.vault_id)
             .expect("lease");
 
-        let outcome = run_managed_git_turn(&config, &lease).expect("first turn acquires and syncs");
+        let outcome = run_managed_git_turn(&config, &lease, &WriteLedger::new())
+            .expect("first turn acquires and syncs");
 
         assert_eq!(outcome, ManagedGitOutcome::UpToDate);
         assert!(
@@ -1093,7 +1099,7 @@ mod tests {
         // held.
         let lease = ManagedCheckoutLease::acquire(config.state_directory.clone(), config.vault_id)
             .expect("lease");
-        run_managed_git_turn(&config, &lease).expect("first turn");
+        run_managed_git_turn(&config, &lease, &WriteLedger::new()).expect("first turn");
 
         let repository_root = config
             .state_directory
@@ -1102,8 +1108,8 @@ mod tests {
             .join("repository");
         std::fs::write(repository_root.join("vault/Local.md"), "local\n").expect("local edit");
 
-        let outcome =
-            run_managed_git_turn(&config, &lease).expect("second turn reuses the checkout");
+        let outcome = run_managed_git_turn(&config, &lease, &WriteLedger::new())
+            .expect("second turn reuses the checkout");
 
         assert_eq!(outcome, ManagedGitOutcome::Synchronized);
     }
@@ -1119,7 +1125,8 @@ mod tests {
         let lease = ManagedCheckoutLease::acquire(scratch.path().to_path_buf(), config.vault_id)
             .expect("scratch lease");
 
-        let error = run_managed_git_turn(&config, &lease).expect_err("Local history has no remote");
+        let error = run_managed_git_turn(&config, &lease, &WriteLedger::new())
+            .expect_err("Local history has no remote");
 
         assert_eq!(error.code(), "managed_git_not_remote");
         assert!(!error.retryable());
@@ -1864,7 +1871,7 @@ mod tests {
         let lease = scheduler
             .take_or_acquire_checkout_lease(config.state_directory.clone(), config.vault_id)
             .expect("first turn acquires a fresh lease");
-        run_managed_git_turn(&config, &lease).expect("first turn");
+        run_managed_git_turn(&config, &lease, &WriteLedger::new()).expect("first turn");
         scheduler.keep_checkout_lease(config.vault_id, lease);
 
         // Between turns — exactly the gap the old, turn-scoped lease used
@@ -1892,8 +1899,8 @@ mod tests {
         let lease = scheduler
             .take_or_acquire_checkout_lease(config.state_directory.clone(), config.vault_id)
             .expect("second turn reuses the held lease");
-        let outcome =
-            run_managed_git_turn(&config, &lease).expect("second turn reuses the checkout");
+        let outcome = run_managed_git_turn(&config, &lease, &WriteLedger::new())
+            .expect("second turn reuses the checkout");
         assert_eq!(outcome, ManagedGitOutcome::Synchronized);
         scheduler.keep_checkout_lease(config.vault_id, lease);
 

--- a/src/git/message.rs
+++ b/src/git/message.rs
@@ -11,6 +11,99 @@ pub struct WriteRecord {
     pub summary: Option<String>,
 }
 
+/// The per-Vault batch of writes waiting for their Git turn.
+///
+/// A write lands on disk long before the Vault's Git turn commits it, and one
+/// turn coalesces every write since the last one. This is where the record of
+/// each write waits in between: the Vault mutation core appends one entry per
+/// successful write ([`WriteLedger::record`]), and the commit that records
+/// those writes takes the whole batch ([`WriteLedger::take`]) to build its
+/// message. A turn that ends up committing nothing puts the batch back
+/// ([`WriteLedger::restore`]) so the next turn still has it.
+///
+/// A record waits for a real commit rather than for a turn, so a write that
+/// produces no Git drift — a path the checkout's own `.gitignore` covers —
+/// keeps its line until the next commit that does happen, and lands there.
+/// The alternative is dropping the line on a turn that committed nothing,
+/// which loses the summaries of every write made between two commits.
+///
+/// Bounded at [`WriteLedger::CAPACITY`] entries, oldest dropped first. A Vault
+/// with no Git turn at all (a `Local` source) never has its ledger taken, so
+/// without the bound its entries would accumulate for the life of the process.
+/// Over the bound the commit message loses its oldest lines, which is the
+/// cheapest thing to lose.
+#[derive(Debug, Default)]
+pub struct WriteLedger {
+    records: std::sync::Mutex<std::collections::VecDeque<WriteRecord>>,
+}
+
+impl WriteLedger {
+    /// How many pending records one Vault keeps. Far above any real debounce
+    /// window: a turn that has not run in this many writes has a problem the
+    /// commit message is not going to fix.
+    pub const CAPACITY: usize = 200;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one write to the batch, dropping the oldest entry when the
+    /// ledger is already full.
+    pub fn record(&self, record: WriteRecord) {
+        let mut records = self.lock();
+        if records.len() >= Self::CAPACITY {
+            records.pop_front();
+        }
+        records.push_back(record);
+    }
+
+    /// Name a commit from the pending batch and make it.
+    ///
+    /// The one place the batch's lifecycle lives, so both commit paths obey
+    /// the same rule: `commit` receives the message built from the batch and
+    /// reports whether it committed, and the batch is consumed only if it
+    /// did. A turn that finds nothing to commit, or fails, leaves the writes
+    /// for the turn that does record them.
+    pub fn commit_batch<E>(&self, commit: impl FnOnce(&str) -> Result<bool, E>) -> Result<bool, E> {
+        let batch = self.take();
+        let result = commit(&build_commit_message(&batch));
+        if !matches!(result, Ok(true)) {
+            self.restore(batch);
+        }
+        result
+    }
+
+    /// Take the whole pending batch, leaving the ledger empty.
+    pub fn take(&self) -> Vec<WriteRecord> {
+        self.lock().drain(..).collect()
+    }
+
+    /// Put a taken batch back at the front, ahead of anything recorded since.
+    /// Used by a turn that took the batch and then did not commit, so those
+    /// writes still reach the message of whichever turn does.
+    pub fn restore(&self, batch: Vec<WriteRecord>) {
+        if batch.is_empty() {
+            return;
+        }
+        let mut records = self.lock();
+        for record in batch.into_iter().rev() {
+            records.push_front(record);
+        }
+        while records.len() > Self::CAPACITY {
+            records.pop_front();
+        }
+    }
+
+    /// Recover from a poisoned lock rather than propagating a panic into a
+    /// Vault write or a Git turn: this guards a commit message, and a message
+    /// is never worth failing a write for.
+    fn lock(&self) -> std::sync::MutexGuard<'_, std::collections::VecDeque<WriteRecord>> {
+        self.records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
 /// Build a commit message from a batch of write records.
 /// Title summarizes ops + file count; body lists agent-supplied summaries.
 pub fn build_commit_message(records: &[WriteRecord]) -> String {
@@ -68,6 +161,72 @@ mod tests {
             affected_paths: paths.iter().map(PathBuf::from).collect(),
             summary: summary.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn ledger_hands_a_turn_every_write_recorded_since_the_last_one() {
+        let ledger = WriteLedger::new();
+        ledger.record(record(
+            "create",
+            "Meeting",
+            &["/v/Meeting.md"],
+            Some("first"),
+        ));
+        ledger.record(record(
+            "update",
+            "Meeting",
+            &["/v/Meeting.md"],
+            Some("second"),
+        ));
+
+        let batch = ledger.take();
+
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].summary.as_deref(), Some("first"));
+        assert_eq!(batch[1].summary.as_deref(), Some("second"));
+        assert!(
+            ledger.take().is_empty(),
+            "a taken batch is not handed out twice"
+        );
+    }
+
+    #[test]
+    fn a_restored_batch_stays_ahead_of_writes_recorded_during_the_turn() {
+        let ledger = WriteLedger::new();
+        ledger.record(record("create", "A", &["/v/A.md"], Some("before")));
+        let batch = ledger.take();
+        ledger.record(record("create", "B", &["/v/B.md"], Some("during")));
+
+        ledger.restore(batch);
+
+        let summaries: Vec<_> = ledger
+            .take()
+            .into_iter()
+            .filter_map(|entry| entry.summary)
+            .collect();
+        assert_eq!(summaries, vec!["before".to_string(), "during".to_string()]);
+    }
+
+    #[test]
+    fn a_vault_that_never_commits_keeps_a_bounded_ledger() {
+        let ledger = WriteLedger::new();
+        for index in 0..WriteLedger::CAPACITY + 5 {
+            ledger.record(record(
+                "update",
+                "Home",
+                &["/v/Home.md"],
+                Some(&index.to_string()),
+            ));
+        }
+
+        let batch = ledger.take();
+
+        assert_eq!(batch.len(), WriteLedger::CAPACITY);
+        assert_eq!(
+            batch[0].summary.as_deref(),
+            Some("5"),
+            "oldest entries drop first"
+        );
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -19,7 +19,7 @@ pub use managed_task::{
     ManagedGitScheduler, ManagedGitTurnConfig, run_existing_git_remote_turn, run_managed_git_turn,
     spawn_scheduler_tick,
 };
-pub use message::{WriteRecord, build_commit_message};
+pub use message::{WriteLedger, WriteRecord, build_commit_message};
 pub use sync::{
     CommitOutcome, GitError, commit_local, has_uncommitted_changes, init_local_repo,
     run_local_history_git_turn, validate_local_repo, validate_repo,

--- a/src/git/sync.rs
+++ b/src/git/sync.rs
@@ -4,7 +4,7 @@ use git2::{Repository, Signature};
 
 use super::config::{GitConfig, GitMode};
 use super::managed_task::ManagedGitOutcome;
-use super::message::build_commit_message;
+use super::message::WriteLedger;
 use crate::vault_work::VaultWorkError;
 
 /// Result of the local commit phase: whether a new commit was created.
@@ -155,10 +155,25 @@ pub fn validate_local_repo(config: &GitConfig) -> Result<(), GitError> {
 /// caller here needs only the Vault's resolved path and commit identity —
 /// not the full settings-derived `GitConfig` the retired single-Vault lane
 /// built from `HATCHDOOR_GIT_*` configuration.
+///
+/// `ledger` is the Vault's pending batch of write records (issue #249): the
+/// batch names this commit, and goes back to the ledger untouched when the
+/// turn finds nothing to commit.
+///
+/// Unlike the Two-way graph, this turn runs without the Vault's mutation
+/// lock, which leaves a narrow window between taking the batch and
+/// `commit_local` staging the working tree. A write landing inside it has its
+/// content committed by this turn while its summary waits for the next one,
+/// so that line arrives one commit late. Deliberately not closed by taking
+/// the mutation lock: this turn commits already-settled drift and must not
+/// park foreground writes behind itself (ADR-18). A late line is the cheaper
+/// cost, and it is why `WriteLedger::restore` puts a batch back ahead of
+/// anything recorded since rather than overwriting it.
 pub fn run_local_history_git_turn(
     vault_path: PathBuf,
     author_name: String,
     author_email: String,
+    ledger: &WriteLedger,
 ) -> Result<ManagedGitOutcome, VaultWorkError> {
     let config = GitConfig {
         vault_path,
@@ -172,9 +187,12 @@ pub fn run_local_history_git_turn(
         author_email,
     };
     validate_local_repo(&config).map_err(classify_local_history_error)?;
-    let message = build_commit_message(&[]);
-    let outcome = commit_local(&config, &[], &message).map_err(classify_local_history_error)?;
-    Ok(if outcome.committed {
+    let committed = ledger
+        .commit_batch(|message| {
+            commit_local(&config, &[], message).map(|outcome| outcome.committed)
+        })
+        .map_err(classify_local_history_error)?;
+    Ok(if committed {
         ManagedGitOutcome::Synchronized
     } else {
         ManagedGitOutcome::UpToDate
@@ -516,6 +534,7 @@ fn stage_vault_drift(
 
 #[cfg(test)]
 mod tests {
+    use super::super::message::WriteRecord;
     use super::*;
     use git2::Repository;
     use std::fs;
@@ -644,6 +663,77 @@ mod tests {
         );
     }
 
+    /// Issue #249: a Local-history commit is named by the writes it records,
+    /// and an idle turn leaves the batch alone rather than swallowing it.
+    #[test]
+    fn run_local_history_git_turn_names_its_commit_from_the_pending_write_batch() {
+        let root = tempfile::tempdir().expect("repository root");
+        let repo = Repository::init(root.path()).expect("init repository");
+        fs::write(root.path().join("README.md"), "root readme").expect("root readme");
+        commit_all(&repo, "initial commit");
+
+        let vault_path = root.path().join("notes");
+        fs::create_dir(&vault_path).expect("notes directory");
+        fs::write(vault_path.join("Idea.md"), "# idea\n").expect("drift note");
+
+        let ledger = WriteLedger::new();
+        ledger.record(WriteRecord {
+            op: "create".to_string(),
+            target: "Idea".to_string(),
+            affected_paths: vec![vault_path.join("Idea.md")],
+            summary: Some("capture the idea".to_string()),
+        });
+
+        let outcome = run_local_history_git_turn(
+            vault_path.clone(),
+            "Test".to_string(),
+            "test@example.invalid".to_string(),
+            &ledger,
+        )
+        .expect("local history turn succeeds");
+        assert_eq!(outcome, ManagedGitOutcome::Synchronized);
+
+        let head = repo.head().expect("head").peel_to_commit().expect("commit");
+        assert_eq!(
+            head.message().expect("commit message"),
+            "hatchdoor: create \"Idea\" (1 file)\n\n- capture the idea"
+        );
+        assert!(ledger.take().is_empty(), "a committed batch is consumed");
+    }
+
+    #[test]
+    fn a_local_history_turn_with_nothing_to_commit_keeps_the_batch() {
+        let root = tempfile::tempdir().expect("repository root");
+        let repo = Repository::init(root.path()).expect("init repository");
+        let vault_path = root.path().join("notes");
+        fs::create_dir(&vault_path).expect("notes directory");
+        fs::write(vault_path.join("Idea.md"), "# idea\n").expect("note");
+        commit_all(&repo, "initial commit");
+
+        let ledger = WriteLedger::new();
+        ledger.record(WriteRecord {
+            op: "create".to_string(),
+            target: "Idea".to_string(),
+            affected_paths: vec![vault_path.join("Idea.md")],
+            summary: Some("already committed by someone else".to_string()),
+        });
+
+        let outcome = run_local_history_git_turn(
+            vault_path,
+            "Test".to_string(),
+            "test@example.invalid".to_string(),
+            &ledger,
+        )
+        .expect("local history turn succeeds");
+
+        assert_eq!(outcome, ManagedGitOutcome::UpToDate);
+        assert_eq!(
+            ledger.take().len(),
+            1,
+            "an idle turn must not swallow writes the next commit still owes a line to"
+        );
+    }
+
     /// `run_local_history_git_turn` is `dispatch_git_turn_with`'s
     /// `ExistingGit` + `VaultGitMode::LocalHistory` counterpart to
     /// `run_managed_git_turn`. The composed `vault_runtime` test exercises it
@@ -674,6 +764,7 @@ mod tests {
             vault_path.clone(),
             "Test".to_string(),
             "test@example.invalid".to_string(),
+            &WriteLedger::new(),
         )
         .expect("local history turn succeeds");
         assert_eq!(outcome, ManagedGitOutcome::Synchronized);
@@ -712,6 +803,7 @@ mod tests {
             vault_path,
             "Test".to_string(),
             "test@example.invalid".to_string(),
+            &WriteLedger::new(),
         )
         .expect("second local history turn succeeds");
         assert_eq!(second, ManagedGitOutcome::UpToDate);
@@ -739,6 +831,7 @@ mod tests {
             vault_path,
             "Test".to_string(),
             "test@example.invalid".to_string(),
+            &WriteLedger::new(),
         )
         .expect("local history turn succeeds");
         assert_eq!(outcome, ManagedGitOutcome::Synchronized);
@@ -777,6 +870,7 @@ mod tests {
             vault_path,
             "Test".to_string(),
             "test@example.invalid".to_string(),
+            &WriteLedger::new(),
         )
         .expect_err("bare repository has no working tree to version");
         assert_eq!(error.code(), "existing_git_local_history_validation_failed");

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -2904,6 +2904,49 @@ mod tests {
         );
     }
 
+    /// Issue #249: the `commit_summary` every write tool advertises has to
+    /// leave this surface, not stop at deserialization. Proved at the ledger
+    /// the Vault's Git turn reads, because that is the only thing between the
+    /// tool call and the commit message.
+    #[tokio::test]
+    async fn a_write_tools_commit_summary_reaches_the_vaults_pending_write_batch() {
+        let (state, _tmp) = write_state();
+        let hash = crate::cache::parse::content_hash("# Home\nalpha token\n[[Plan]]");
+        let edited = call_tool(
+            &state,
+            "edit_note",
+            json!({
+                "slug": "home",
+                "old_string": "alpha",
+                "new_string": "ALPHA",
+                "expected_content_hash": hash,
+                "commit_summary": "shout the token"
+            }),
+        )
+        .await;
+        assert_eq!(edited["result"]["structuredContent"]["ok"], true);
+
+        let vault_id = match state.vault_registry.load().expect("load registry") {
+            crate::vault_registry::VaultRegistryState::Ready(snapshot) => snapshot
+                .definitions()
+                .next()
+                .expect("test definition")
+                .vault_id(),
+            crate::vault_registry::VaultRegistryState::Recovery(_) => panic!("test recovery"),
+        };
+        let batch = state
+            .vaults
+            .runtime(vault_id)
+            .expect("Vault runtime")
+            .write_ledger()
+            .take();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].op, "edit");
+        assert_eq!(batch[0].target, "Home");
+        assert_eq!(batch[0].summary.as_deref(), Some("shout the token"));
+    }
+
     #[tokio::test]
     async fn rename_note_returns_new_slug() {
         let (state, _tmp) = write_state();

--- a/src/mcp/tools/write.rs
+++ b/src/mcp/tools/write.rs
@@ -18,9 +18,11 @@
 //! `get_attachment`, `get_frontmatter`) moved to `read.rs` in #188, once the
 //! read core took over the gating those helpers provided.
 
-// The deserialization-only scope and retired legacy commit-summary fields are
-// intentionally retained until every old client gets a structured invalid
-// parameter response instead of silently accepting an ambiguous payload.
+// Every argument struct below deserializes `vault_id` it never reads: the
+// Vault is resolved from the raw arguments before any of them are parsed, and
+// `deny_unknown_fields` would reject the field if it were dropped. Kept as a
+// declared field rather than ignored, so an old client sending it still gets a
+// structured invalid-parameter response for anything genuinely unrecognized.
 #![allow(dead_code)]
 
 use serde::Deserialize;
@@ -54,17 +56,20 @@ pub(super) struct McpVault {
 }
 
 impl McpVault {
-    /// The mutation core's view of this Vault. `scoped_vault` has already
-    /// gated it and applied the core's own `ensure_mutable`, and the
-    /// dispatcher holds its mutation lock (`mod.rs` for the length of one
-    /// tool call, `batch.rs` for the length of a whole batch), which is why
-    /// the operations below never re-take it.
-    fn mutation(&self) -> VaultMutation {
+    /// The mutation core's view of this Vault, carrying this call's
+    /// `commit_summary` so the write it runs reaches the body of the commit
+    /// that records it (#249). `scoped_vault` has already gated it and
+    /// applied the core's own `ensure_mutable`, and the dispatcher holds its
+    /// mutation lock (`mod.rs` for the length of one tool call, `batch.rs`
+    /// for the length of a whole batch), which is why the operations below
+    /// never re-take it.
+    fn mutation(&self, commit_summary: Option<String>) -> VaultMutation {
         VaultMutation::gated(
             self.vault_id,
             self.control.clone(),
             Arc::clone(&self.settings),
         )
+        .with_commit_summary(commit_summary)
     }
 }
 
@@ -101,7 +106,7 @@ pub(super) async fn acquire_mutation(
     vault: &McpVault,
 ) -> Result<tokio::sync::OwnedMutexGuard<()>, JsonRpcFailure> {
     vault
-        .mutation()
+        .mutation(None)
         .acquire_mutation()
         .await
         .map_err(mutation_error)
@@ -226,7 +231,7 @@ pub(super) async fn create_note_tool(
     })?;
     let relative_path = non_empty_argument("relative_path", args.relative_path)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .create_note(
             &relative_path,
             &args.content,
@@ -247,7 +252,7 @@ pub(super) async fn update_note_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .update_note(&slug, &args.content, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -264,7 +269,7 @@ pub(super) async fn update_frontmatter_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .update_frontmatter(&slug, args.frontmatter, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -282,7 +287,7 @@ pub(super) async fn append_to_note_tool(
     let slug = non_empty_argument("slug", args.slug)?;
     let content = non_empty_argument("content", args.content)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .append_to_note(&slug, &content, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -299,7 +304,7 @@ pub(super) async fn edit_note_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .edit_note(
             &slug,
             &args.old_string,
@@ -333,7 +338,7 @@ pub(super) async fn replace_section_tool(
         }
     };
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .replace_section(
             &slug,
             &heading,
@@ -365,7 +370,7 @@ pub(super) async fn rename_note_tool(
         ));
     }
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .rename_note(&slug, &new_title, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -382,7 +387,7 @@ pub(super) async fn move_note_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .move_note(&slug, &args.target_folder, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -401,7 +406,7 @@ pub(super) async fn move_rename_note_tool(
     let target_relative_path =
         non_empty_argument("target_relative_path", args.target_relative_path)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .move_rename_note(&slug, &target_relative_path, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -418,7 +423,7 @@ pub(super) async fn archive_note_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .archive_note(&slug, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -435,7 +440,7 @@ pub(super) async fn delete_note_tool(
     })?;
     let slug = non_empty_argument("slug", args.slug)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .delete_note(&slug, &args.expected_content_hash)
         .await
         .map_err(mutation_error)?;
@@ -491,7 +496,7 @@ pub(super) async fn import_attachment_tool(
         })?;
 
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .import_attachment(
             &target_relative_path,
             bytes,
@@ -516,7 +521,7 @@ pub(super) async fn move_attachment_tool(
     let target_relative_path =
         non_empty_argument("target_relative_path", args.target_relative_path)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .move_attachment(&source_relative_path, &target_relative_path)
         .await
         .map_err(mutation_error)?;
@@ -535,7 +540,7 @@ pub(super) async fn rename_attachment_tool(
         non_empty_argument("source_relative_path", args.source_relative_path)?;
     let new_filename = non_empty_argument("new_filename", args.new_filename)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .rename_attachment(&source_relative_path, &new_filename)
         .await
         .map_err(mutation_error)?;
@@ -553,7 +558,7 @@ pub(super) async fn delete_attachment_tool(
     let source_relative_path =
         non_empty_argument("source_relative_path", args.source_relative_path)?;
     let outcome = vault
-        .mutation()
+        .mutation(args.commit_summary)
         .delete_attachment(&source_relative_path)
         .await
         .map_err(mutation_error)?;

--- a/src/vault_executor.rs
+++ b/src/vault_executor.rs
@@ -622,6 +622,7 @@ where
     F: FnOnce(
             &ManagedGitTurnConfig,
             &ManagedCheckoutLease,
+            &crate::git::WriteLedger,
         ) -> Result<ManagedGitOutcome, VaultWorkError>
         + Send
         + 'static,
@@ -774,10 +775,15 @@ where
     F: FnOnce(
             &ManagedGitTurnConfig,
             &ManagedCheckoutLease,
+            &crate::git::WriteLedger,
         ) -> Result<ManagedGitOutcome, VaultWorkError>
         + Send
         + 'static,
 {
+    // Every Git turn that can commit names its commit from this Vault's
+    // pending write records (#249). Cloned once here so each branch below can
+    // move it into its own blocking closure.
+    let write_ledger = control_block.write_ledger();
     match control_block.definition().source() {
         // An existing checkout under Local-history versioning has no remote
         // to sync: flush whatever Vault-subtree drift has accumulated into a
@@ -795,7 +801,12 @@ where
                 holds_mutation_lock: false,
                 panic_code: "existing_git_local_history_task_panicked",
                 work: GitTurnWork::Unleased(Box::new(move || {
-                    crate::git::run_local_history_git_turn(vault_path, author_name, author_email)
+                    crate::git::run_local_history_git_turn(
+                        vault_path,
+                        author_name,
+                        author_email,
+                        &write_ledger,
+                    )
                 })),
             }))
         }
@@ -833,6 +844,7 @@ where
                         credentials,
                         author_name,
                         author_email,
+                        &write_ledger,
                     )
                 })),
             }))
@@ -865,7 +877,7 @@ where
                 panic_code: "managed_git_task_panicked",
                 work: GitTurnWork::Leased {
                     state_directory,
-                    run: Box::new(move |lease| execute(&config, lease)),
+                    run: Box::new(move |lease| execute(&config, lease, &write_ledger)),
                 },
             }))
         }

--- a/src/vault_executor/tests.rs
+++ b/src/vault_executor/tests.rs
@@ -1275,7 +1275,7 @@ async fn dispatch_git_turn_with_publishes_a_real_failure_through_the_full_async_
                 "Hatchdoor",
                 "hatchdoor@example.test",
                 request,
-                |_config, _lease| Ok(crate::git::ManagedGitOutcome::UpToDate),
+                |_config, _lease, _ledger| Ok(crate::git::ManagedGitOutcome::UpToDate),
             )
         })
         .await
@@ -1308,7 +1308,7 @@ async fn dispatch_git_turn_with_publishes_a_real_failure_through_the_full_async_
                 "Hatchdoor",
                 "hatchdoor@example.test",
                 request,
-                |_config, _lease| {
+                |_config, _lease, _ledger| {
                     Err(VaultWorkError::new(
                         "managed_git_remote_unreachable",
                         "simulated remote outage",
@@ -1403,7 +1403,7 @@ async fn a_managed_git_turn_waits_for_a_concurrent_foreground_mutation_to_releas
             "Hatchdoor",
             "hatchdoor@example.test",
             request,
-            |_config, _lease| Ok(crate::git::ManagedGitOutcome::UpToDate),
+            |_config, _lease, _ledger| Ok(crate::git::ManagedGitOutcome::UpToDate),
         )
     });
     tokio::pin!(dispatch);
@@ -2277,7 +2277,7 @@ async fn a_managed_git_vault_keeps_polling_on_its_configured_interval() {
                 "Hatchdoor",
                 "hatchdoor@example.test",
                 request,
-                |_config, _lease| Ok(crate::git::ManagedGitOutcome::UpToDate),
+                |_config, _lease, _ledger| Ok(crate::git::ManagedGitOutcome::UpToDate),
             )
         })
         .await
@@ -2312,7 +2312,7 @@ async fn a_managed_git_vault_keeps_polling_on_its_configured_interval() {
                 "Hatchdoor",
                 "hatchdoor@example.test",
                 request,
-                |_config, _lease| Ok(crate::git::ManagedGitOutcome::UpToDate),
+                |_config, _lease, _ledger| Ok(crate::git::ManagedGitOutcome::UpToDate),
             )
         })
         .await

--- a/src/vault_mutation.rs
+++ b/src/vault_mutation.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use crate::app_state::AppState;
 use crate::cache::SqliteCache;
+use crate::git::WriteRecord;
 use crate::runtime_config::ConfigSnapshot;
 use crate::vault::{
     AttachmentOutcome, ExcludeMatcher, LayerMap, NoteEntry, SectionMode, VaultIndex, WriteError,
@@ -455,11 +456,65 @@ pub fn write_operation_error(vault_id: VaultId, error: WriteError) -> VaultOpera
     VaultOperationError::new(code, message, Some(vault_id), retryable)
 }
 
+/// What a `vault/write` outcome must expose for its write to be recorded in
+/// the Vault's write ledger: which files it touched, and where the write
+/// landed. Two implementors, one caller ([`VaultMutation::run_write`]) — it
+/// exists so the ledger entry is built once for every mutation rather than
+/// fifteen times, and so a new mutation cannot quietly skip it.
+trait RecordedWrite {
+    /// Absolute paths this operation created, modified, or removed.
+    fn affected_paths(&self) -> &[std::path::PathBuf];
+    /// The path to record this write against, when the outcome names a
+    /// better one than the caller did — a slug is lowercased, and a create
+    /// carries the `.md` the record should not. `None` falls back to what the
+    /// caller addressed.
+    fn written_path(&self) -> Option<&str>;
+}
+
+impl RecordedWrite for WriteOutcome {
+    fn affected_paths(&self) -> &[std::path::PathBuf] {
+        &self.affected_paths
+    }
+
+    fn written_path(&self) -> Option<&str> {
+        // Always `Some` in practice, a delete included: `delete_note` reports
+        // the path the note was deleted *from*, and reports where it went
+        // separately as `trashed_path`.
+        self.relative_path.as_deref()
+    }
+}
+
+impl RecordedWrite for AttachmentOutcome {
+    fn affected_paths(&self) -> &[std::path::PathBuf] {
+        &self.affected_paths
+    }
+
+    fn written_path(&self) -> Option<&str> {
+        // A trashed attachment reports its path *inside* the trash folder,
+        // and trash is bookkeeping rather than a destination anyone chose
+        // (ADR-11), so record the path the caller deleted instead — the same
+        // path a deleted note reports. An archive, a move, and a rename all
+        // keep reporting where the file went, because there the destination
+        // is the point of the operation.
+        if self.trashed_path.is_some() {
+            return None;
+        }
+        Some(&self.attachment.relative_path)
+    }
+}
+
 /// One gated, capability-checked Vault, ready to mutate.
 pub struct VaultMutation {
     vault_id: VaultId,
     control: VaultControlBlock,
     settings: Arc<ConfigSnapshot>,
+    /// The caller's one-line description of the change, carried into the
+    /// commit message of whichever Git turn ends up recording this write
+    /// (#249). Set per operation, because that is the grain the MCP
+    /// `commit_summary` argument arrives at: one summary describes one write,
+    /// and a batch supplies a different one per item. `None` from a surface
+    /// that has no such argument, which is every HTTP write route.
+    commit_summary: Option<String>,
 }
 
 impl VaultMutation {
@@ -479,7 +534,16 @@ impl VaultMutation {
             vault_id,
             control,
             settings,
+            commit_summary: None,
         }
+    }
+
+    /// Attach the caller's summary of this change. It reaches the body of the
+    /// commit that records the write, one `- ` line per summary in the batch
+    /// that commit coalesces (`git::build_commit_message`).
+    pub fn with_commit_summary(mut self, summary: Option<String>) -> Self {
+        self.commit_summary = summary.filter(|summary| !summary.trim().is_empty());
+        self
     }
 
     /// Take this Vault's mutation lock. The guard is owned, so a caller may
@@ -520,11 +584,11 @@ impl VaultMutation {
         let catalog = self.authoritative_catalog().await?;
         let layers = catalog.layers.clone();
         let vault_path = self.control.vault_path().to_path_buf();
-        let relative_path = relative_path.to_string();
+        let target_path = relative_path.to_string();
         let content = content.to_string();
         let outcome = self
-            .run_write(move || {
-                create_note(&vault_path, &relative_path, &content, overwrite, &catalog)
+            .run_write("create", relative_path, move || {
+                create_note(&vault_path, &target_path, &content, overwrite, &catalog)
             })
             .await?;
         Ok(NoteWriteOutcome::resolve(&layers, outcome))
@@ -542,7 +606,9 @@ impl VaultMutation {
         let content = content.to_string();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || update_note(&entry, &content, &expected_content_hash))
+            .run_write("update", slug, move || {
+                update_note(&entry, &content, &expected_content_hash)
+            })
             .await?;
         Ok(NoteWriteOutcome::resolve(&index.layers, outcome))
     }
@@ -559,7 +625,9 @@ impl VaultMutation {
         let content = content.to_string();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || append_note(&entry, &content, &expected_content_hash))
+            .run_write("append", slug, move || {
+                append_note(&entry, &content, &expected_content_hash)
+            })
             .await?;
         Ok(NoteWriteOutcome::resolve(&index.layers, outcome))
     }
@@ -579,7 +647,7 @@ impl VaultMutation {
         let new_string = new_string.to_string();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || {
+            .run_write("edit", slug, move || {
                 edit_note(
                     &entry,
                     &old_string,
@@ -607,7 +675,7 @@ impl VaultMutation {
         let content = content.to_string();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || {
+            .run_write("replace section in", slug, move || {
                 replace_section(&entry, &heading, mode, &content, &expected_content_hash)
             })
             .await?;
@@ -625,7 +693,9 @@ impl VaultMutation {
         let entry = self.note_entry(&index, slug)?;
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || update_note_frontmatter(&entry, frontmatter, &expected_content_hash))
+            .run_write("update frontmatter of", slug, move || {
+                update_note_frontmatter(&entry, frontmatter, &expected_content_hash)
+            })
             .await?;
         Ok(NoteWriteOutcome::resolve(&index.layers, outcome))
     }
@@ -640,8 +710,15 @@ impl VaultMutation {
         let index = self.authoritative_index().await?;
         let entry = self.note_entry(&index, slug)?;
         let target_relative_path = renamed_note_path(&entry.relative_path, new_title);
-        self.move_entry(index, entry, target_relative_path, expected_content_hash)
-            .await
+        self.move_entry(
+            "rename",
+            slug,
+            index,
+            entry,
+            target_relative_path,
+            expected_content_hash,
+        )
+        .await
     }
 
     /// Move one note into another folder, keeping its filename. An empty
@@ -660,8 +737,15 @@ impl VaultMutation {
         } else {
             format!("{target_folder}/{}", file_name_of(&entry.relative_path))
         };
-        self.move_entry(index, entry, target_relative_path, expected_content_hash)
-            .await
+        self.move_entry(
+            "move",
+            slug,
+            index,
+            entry,
+            target_relative_path,
+            expected_content_hash,
+        )
+        .await
     }
 
     /// Move and rename one note in a single operation.
@@ -674,6 +758,8 @@ impl VaultMutation {
         let index = self.authoritative_index().await?;
         let entry = self.note_entry(&index, slug)?;
         self.move_entry(
+            "move",
+            slug,
             index,
             entry,
             target_relative_path.to_string(),
@@ -701,7 +787,7 @@ impl VaultMutation {
         let vault_path = self.control.vault_path().to_path_buf();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || {
+            .run_write("archive", slug, move || {
                 archive_note(
                     &vault_path,
                     &index,
@@ -726,7 +812,9 @@ impl VaultMutation {
         let vault_path = self.control.vault_path().to_path_buf();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || delete_note(&vault_path, &index, &entry, &expected_content_hash))
+            .run_write("delete", slug, move || {
+                delete_note(&vault_path, &index, &entry, &expected_content_hash)
+            })
             .await?;
         Ok(NoteWriteOutcome::resolve(&layers, outcome))
     }
@@ -736,6 +824,8 @@ impl VaultMutation {
     /// reduce to.
     async fn move_entry(
         &self,
+        label: &'static str,
+        addressed: &str,
         index: VaultIndex,
         entry: NoteEntry,
         target_relative_path: String,
@@ -746,7 +836,7 @@ impl VaultMutation {
         let vault_path = self.control.vault_path().to_path_buf();
         let expected_content_hash = expected_content_hash.to_string();
         let outcome = self
-            .run_write(move || {
+            .run_write(label, addressed, move || {
                 move_or_rename_note(
                     &vault_path,
                     &index,
@@ -775,15 +865,9 @@ impl VaultMutation {
         self.reject_marker_write(target_relative_path)?;
         self.reject_noise_write(target_relative_path)?;
         let vault_path = self.control.vault_path().to_path_buf();
-        let target_relative_path = target_relative_path.to_string();
-        self.run_write(move || {
-            import_attachment_bytes(
-                &vault_path,
-                &target_relative_path,
-                &bytes,
-                max_bytes,
-                overwrite,
-            )
+        let target_path = target_relative_path.to_string();
+        self.run_write("import attachment", target_relative_path, move || {
+            import_attachment_bytes(&vault_path, &target_path, &bytes, max_bytes, overwrite)
         })
         .await
     }
@@ -800,15 +884,10 @@ impl VaultMutation {
         self.reject_noise_write(target_relative_path)?;
         let index = self.authoritative_index().await?;
         let vault_path = self.control.vault_path().to_path_buf();
-        let source_relative_path = source_relative_path.to_string();
-        let target_relative_path = target_relative_path.to_string();
-        self.run_write(move || {
-            move_attachment(
-                &vault_path,
-                &index,
-                &source_relative_path,
-                &target_relative_path,
-            )
+        let source_path = source_relative_path.to_string();
+        let target_path = target_relative_path.to_string();
+        self.run_write("move attachment", source_relative_path, move || {
+            move_attachment(&vault_path, &index, &source_path, &target_path)
         })
         .await
     }
@@ -825,10 +904,10 @@ impl VaultMutation {
         self.reject_noise_write(&sibling_path(source_relative_path, new_filename))?;
         let index = self.authoritative_index().await?;
         let vault_path = self.control.vault_path().to_path_buf();
-        let source_relative_path = source_relative_path.to_string();
+        let source_path = source_relative_path.to_string();
         let new_filename = new_filename.to_string();
-        self.run_write(move || {
-            rename_attachment(&vault_path, &index, &source_relative_path, &new_filename)
+        self.run_write("rename attachment", source_relative_path, move || {
+            rename_attachment(&vault_path, &index, &source_path, &new_filename)
         })
         .await
     }
@@ -847,9 +926,11 @@ impl VaultMutation {
         self.reject_noise_write(source_relative_path)?;
         let index = self.authoritative_index().await?;
         let vault_path = self.control.vault_path().to_path_buf();
-        let source_relative_path = source_relative_path.to_string();
-        self.run_write(move || delete_attachment(&vault_path, &index, &source_relative_path))
-            .await
+        let source_path = source_relative_path.to_string();
+        self.run_write("delete attachment", source_relative_path, move || {
+            delete_attachment(&vault_path, &index, &source_path)
+        })
+        .await
     }
 
     // -----------------------------------------------------------------
@@ -980,12 +1061,22 @@ impl VaultMutation {
         Ok(())
     }
 
-    /// Runs a synchronous `vault/write` primitive on the blocking pool.
+    /// Runs a synchronous `vault/write` primitive on the blocking pool, then
+    /// records what it did in this Vault's write ledger.
+    ///
     /// Moves rewrite every backlinking note, which must not stall a tokio
     /// worker; a panic maps to a `write_failed` error instead of unwinding
     /// through the adapter. Both surfaces offload, because the core does.
-    async fn run_write<T: Send + 'static>(
+    ///
+    /// The recording is here rather than in each operation above so that no
+    /// mutation can be added without it: `label` names the operation for the
+    /// commit title, `addressed` is what the caller named, and the outcome
+    /// supplies the resulting path and the files actually touched. A write
+    /// that failed records nothing, because nothing changed on disk.
+    async fn run_write<T: RecordedWrite + Send + 'static>(
         &self,
+        label: &'static str,
+        addressed: &str,
         op: impl FnOnce() -> Result<T, WriteError> + Send + 'static,
     ) -> Result<T, VaultOperationError> {
         let result = tokio::task::spawn_blocking(op)
@@ -993,7 +1084,14 @@ impl VaultMutation {
             .unwrap_or_else(|join_error| {
                 Err(WriteError::Io(format!("write task panicked: {join_error}")))
             });
-        result.map_err(|error| write_operation_error(self.vault_id, error))
+        let outcome = result.map_err(|error| write_operation_error(self.vault_id, error))?;
+        self.control.write_ledger().record(WriteRecord {
+            op: label.to_string(),
+            target: outcome.written_path().unwrap_or(addressed).to_string(),
+            affected_paths: outcome.affected_paths().to_vec(),
+            summary: self.commit_summary.clone(),
+        });
+        Ok(outcome)
     }
 
     fn internal(&self, message: impl Into<String>) -> VaultOperationError {
@@ -1167,6 +1265,28 @@ mod tests {
             )
         }
 
+        /// This Vault's pending write records, taken from the same ledger the
+        /// Vault's Git turn takes them from.
+        fn pending_writes(&self) -> Vec<crate::git::WriteRecord> {
+            self.vaults
+                .runtime(self.vault_id)
+                .expect("Vault runtime")
+                .write_ledger()
+                .take()
+        }
+
+        /// A gated mutation target carrying `summary`, the way the MCP write
+        /// tools build one from their `commit_summary` argument.
+        fn summarized(&self, summary: &str) -> super::VaultMutation {
+            let control = self.vaults.runtime(self.vault_id).expect("Vault runtime");
+            super::VaultMutation::gated(
+                self.vault_id,
+                control,
+                std::sync::Arc::clone(&self.settings),
+            )
+            .with_commit_summary(Some(summary.to_string()))
+        }
+
         fn read(&self, relative_path: &str) -> String {
             std::fs::read_to_string(self.vault_path.join(relative_path)).expect("read note")
         }
@@ -1197,6 +1317,92 @@ mod tests {
 
     fn assert_code(error: &VaultOperationError, code: &str) {
         assert_eq!(error.code, code, "unexpected error: {error:?}");
+    }
+
+    /// Issue #249: `commit_summary` is what an agent spends tokens composing on
+    /// every write, and it has to survive as far as the batch the Vault's next
+    /// commit is named from.
+    #[tokio::test]
+    async fn a_summarized_write_reaches_the_batch_its_commit_will_be_named_from() {
+        let workspace = workspace(Fixture::new(&[("Home.md", "# Home\n")]));
+
+        workspace
+            .summarized("tighten the intro")
+            .update_note("home", "# Home\n\nrewritten\n", &hash("# Home\n"))
+            .await
+            .expect("update");
+
+        let batch = workspace.pending_writes();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].op, "update");
+        assert_eq!(batch[0].target, "Home");
+        assert_eq!(batch[0].summary.as_deref(), Some("tighten the intro"));
+        assert_eq!(
+            batch[0].affected_paths,
+            vec![workspace.vault_path.join("Home.md")]
+        );
+    }
+
+    /// A burst of writes is what one debounced commit coalesces, so the batch
+    /// has to keep every summary in the order they were written.
+    #[tokio::test]
+    async fn every_write_in_a_burst_keeps_its_own_summary() {
+        let workspace = workspace(Fixture::new(&[("Home.md", "# Home\n")]));
+
+        workspace
+            .summarized("first")
+            .append_to_note("home", "one\n", &hash("# Home\n"))
+            .await
+            .expect("append");
+        workspace
+            .summarized("second")
+            .create_note("Second.md", "# Second\n", false)
+            .await
+            .expect("create");
+
+        let summaries: Vec<_> = workspace
+            .pending_writes()
+            .into_iter()
+            .filter_map(|record| record.summary)
+            .collect();
+        assert_eq!(summaries, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    /// A write from a surface with no `commit_summary` argument — every HTTP
+    /// route — still shapes the commit title, it just adds no body line.
+    #[tokio::test]
+    async fn an_unsummarized_write_still_reaches_the_batch() {
+        let workspace = workspace(Fixture::new(&[("Home.md", "# Home\n")]));
+
+        workspace
+            .core()
+            .delete_note(workspace.vault_id, "home", &hash("# Home\n"))
+            .await
+            .expect("delete");
+
+        let batch = workspace.pending_writes();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].op, "delete");
+        assert_eq!(
+            batch[0].target, "Home",
+            "a delete is recorded where it was, not in the trash"
+        );
+        assert_eq!(batch[0].summary, None);
+    }
+
+    /// A refused write changed nothing on disk, so there is nothing for a
+    /// commit message to claim.
+    #[tokio::test]
+    async fn a_refused_write_records_nothing() {
+        let workspace = workspace(Fixture::new(&[("Home.md", "# Home\n")]));
+
+        workspace
+            .summarized("never happened")
+            .update_note("home", "# Home\n\nrewritten\n", &hash("stale"))
+            .await
+            .expect_err("stale hash is refused");
+
+        assert!(workspace.pending_writes().is_empty());
     }
 
     #[tokio::test]

--- a/src/vault_runtime.rs
+++ b/src/vault_runtime.rs
@@ -449,6 +449,12 @@ pub struct VaultControlBlock {
     cancellation: tokio::sync::watch::Sender<bool>,
     revisions: CollectionRevisionPublisher,
     watcher: Arc<RwLock<Option<VaultWatcherHandle>>>,
+    /// This Vault's writes waiting to be named by their Git commit. The
+    /// mutation core appends one record per successful write; the Vault's
+    /// next Git turn takes the batch to build its commit message (#249).
+    /// Lives here because those two are the only things that touch it and
+    /// this is the one per-Vault handle both already hold.
+    write_ledger: Arc<crate::git::WriteLedger>,
 }
 
 impl VaultControlBlock {
@@ -459,6 +465,11 @@ impl VaultControlBlock {
         snapshot_cache: Option<&SqliteCache>,
         revisions: CollectionRevisionPublisher,
         prior_git: Option<(VaultGitStatus, Option<VaultRuntimeError>)>,
+        // The retiring block's write ledger when this activation replaces a
+        // live control block, so writes already on disk and still waiting for
+        // a commit keep their summaries across the rotation (#249). `None`
+        // for a genuinely new or re-enabled Vault, which has none.
+        prior_writes: Option<Arc<crate::git::WriteLedger>>,
     ) -> Self {
         let mut snapshot = activation_snapshot(&definition, &vault_path, snapshot_cache, prior_git);
         let watcher = if snapshot.activation == VaultActivationStatus::Active {
@@ -516,6 +527,7 @@ impl VaultControlBlock {
             cancellation,
             revisions,
             watcher: Arc::new(RwLock::new(watcher)),
+            write_ledger: prior_writes.unwrap_or_else(|| Arc::new(crate::git::WriteLedger::new())),
         }
     }
 
@@ -525,6 +537,13 @@ impl VaultControlBlock {
 
     pub fn vault_path(&self) -> &Path {
         &self.vault_path
+    }
+
+    /// This Vault's pending write records. Cloned rather than borrowed so a
+    /// Git turn can carry it into `spawn_blocking` without borrowing the
+    /// control block there.
+    pub fn write_ledger(&self) -> Arc<crate::git::WriteLedger> {
+        Arc::clone(&self.write_ledger)
     }
 
     /// Build an authoritative index for an exact read. Collection projections
@@ -1032,12 +1051,21 @@ impl VaultCollectionRuntime {
                         // transient failure) the retiring control block
                         // actually had. See `activation_snapshot`'s doc
                         // comment.
-                        let prior_git =
+                        //
+                        // The retiring block's pending write records move
+                        // across for the same reason: they describe writes
+                        // already on disk and still uncommitted, so dropping
+                        // them here would lose exactly the commit-message
+                        // lines #249 exists to deliver.
+                        let (prior_git, prior_writes) =
                             if let Some(VaultCollectionEntry::Active(runtime)) = previous_entry {
                                 let prior_snapshot = runtime.snapshot();
-                                Some((prior_snapshot.git, prior_snapshot.git_error.clone()))
+                                (
+                                    Some((prior_snapshot.git, prior_snapshot.git_error.clone())),
+                                    Some(runtime.write_ledger()),
+                                )
                             } else {
-                                None
+                                (None, None)
                             };
                         VaultCollectionEntry::Active(VaultControlBlock::activate(
                             definition,
@@ -1046,6 +1074,7 @@ impl VaultCollectionRuntime {
                             self.snapshot_cache.as_deref(),
                             revision_publisher.clone(),
                             prior_git,
+                            prior_writes,
                         ))
                     }
                 }

--- a/src/vault_runtime/tests.rs
+++ b/src/vault_runtime/tests.rs
@@ -554,6 +554,84 @@ fn editing_a_non_identity_field_preserves_the_vaults_actual_prior_git_status() {
     );
 }
 
+/// Issue #249: an in-place edit rotates the control block, and the pending
+/// write records describe writes that are already on disk and still
+/// uncommitted. Dropping them on the rotation would lose exactly the commit
+/// message lines the ledger exists to deliver, with nothing to say so.
+#[test]
+fn editing_a_non_identity_field_carries_the_vaults_pending_write_records_across() {
+    let directory = tempdir().expect("temporary state directory");
+    let registry = VaultRegistryStore::new(directory.path().join("state/vaults.json"));
+    let empty = match registry.load().expect("load empty registry") {
+        crate::vault_registry::VaultRegistryState::Ready(snapshot) => snapshot,
+        crate::vault_registry::VaultRegistryState::Recovery(_) => panic!("registry recovery"),
+    };
+    let committed = registry
+        .add(
+            empty.revision(),
+            NewVaultDefinition {
+                name: "Remote notes".to_string(),
+                enabled: true,
+                source: RegistryVaultSource::ManagedGit {
+                    repository_url: "https://example.test/owner/notes.git".to_string(),
+                    branch: None,
+                    vault_subdirectory: None,
+                    mode: VaultGitMode::TwoWay,
+                    poll_interval_secs: DEFAULT_MANAGED_GIT_POLL_INTERVAL_SECS,
+                },
+                exclude_patterns: Vec::new(),
+                https_credentials: None,
+                archive_folder: None,
+                commit_identity: None,
+            },
+        )
+        .expect("add managed Vault");
+    let vault_id = vault_id_named(&committed, "Remote notes");
+    let collection = VaultCollectionRuntime::new();
+    collection.reconcile(&registry, &committed);
+    collection
+        .runtime(vault_id)
+        .expect("active runtime")
+        .write_ledger()
+        .record(crate::git::WriteRecord {
+            op: "update".to_string(),
+            target: "Home".to_string(),
+            affected_paths: vec![std::path::PathBuf::from("/v/Home.md")],
+            summary: Some("written before the edit".to_string()),
+        });
+
+    let edited = registry
+        .edit(
+            committed.revision(),
+            vault_id,
+            VaultDefinitionEdit {
+                name: "Renamed notes".to_string(),
+                source: RegistryVaultSource::ManagedGit {
+                    repository_url: "https://example.test/owner/notes.git".to_string(),
+                    branch: None,
+                    vault_subdirectory: None,
+                    mode: VaultGitMode::TwoWay,
+                    poll_interval_secs: DEFAULT_MANAGED_GIT_POLL_INTERVAL_SECS,
+                },
+                exclude_patterns: Vec::new(),
+                https_credentials: HttpsCredentialUpdate::Keep,
+                confirm_identity_change: false,
+                archive_folder: None,
+                commit_identity: None,
+            },
+        )
+        .expect("rename the Vault");
+    collection.reconcile(&registry, &edited);
+
+    let batch = collection
+        .runtime(vault_id)
+        .expect("Vault remains active after a non-identity edit")
+        .write_ledger()
+        .take();
+    assert_eq!(batch.len(), 1, "the pending write survived the rotation");
+    assert_eq!(batch[0].summary.as_deref(), Some("written before the edit"));
+}
+
 /// Complements
 /// `editing_a_non_identity_field_preserves_the_vaults_actual_prior_git_status`:
 /// a Vault that goes disabled then re-enabled again is not an in-place edit


### PR DESCRIPTION
Closes #249.

`commit_summary` was advertised by every write tool, documented in the MCP reference, and asked for on every write by the vault's operating rules. It was deserialised and dropped. No commit ever carried one.

## What was missing

`build_commit_message` already did the right thing and was unit-tested. Nothing called it with anything: `WriteRecord` had no production construction site, `sync.rs` passed a hardcoded `&[]`, and the two-way path never called it at all, committing a fixed literal every turn.

What did not exist was somewhere for a write to wait between landing on disk and being committed, since one debounced turn coalesces many writes.

## What this adds

`git::WriteLedger` is that place. The mutation core appends one record per successful write; the commit that records those writes takes the batch and names itself from it.

- Both commit paths go through `WriteLedger::commit_batch`, which takes the batch only when a commit actually happens and restores it otherwise. An idle or failed turn does not swallow lines the next commit still owes.
- The ledger lives on `VaultControlBlock` — the one per-Vault handle both the mutation core and its Git turn already hold — and moves across an in-place definition edit alongside `prior_git`, for the same reason that one does.
- It is bounded, because a `Local` Vault has no Git turn to take it.
- Recording sits in `run_write`, not in each of the fifteen primitives, so a mutation added later cannot skip it.
- A write from a surface with no such argument (every HTTP route) still shapes the commit title; only the body line is absent. Drift from outside Hatchdoor keeps the generic `hatchdoor: vault update`.

The issue offered the opposite fix — dropping `commit_summary` from the schemas. Its own evidence argues against that: the machinery exists, the docs promise the behaviour, and the summaries are already being composed.

## Interface change

```
Interface change: Git commit message is built from the Vault's pending write records
Producer boundary: Git synchronization (src/git/**)
Kind: additive (new type, new parameters) + behaviour-changing (commit message text)
Old contract: synchronize_managed_checkout(&config); run_local_history_git_turn(path, name, email);
  run_write(op); commit messages were two hardcoded literals
New contract: each of the above also takes the Vault's &WriteLedger / an operation label and
  addressed path; commit messages come from build_commit_message over the pending batch
Consumer boundaries: Vault work execution (src/vault_executor.rs), Vault collection runtime
  (src/vault_runtime.rs), Vault-qualified mutation core (src/vault_mutation.rs), MCP adapter
  (src/mcp/tools/write.rs). No external consumers: no wire, HTTP, or MCP schema changed —
  the MCP schema already advertised commit_summary.
Compatibility/migration: none required. A client that never sent commit_summary sees a more
  descriptive commit title and no body.
Rollout/rollback: no ordering constraint; the ledger is in-memory and disposable.
Evidence: see below.
```

Invariants checked: ADR-03 (writes stay in `vault/write/`, no write logic moved into the git layer), ADR-18 (no new sync task or execution lane; no change to which turns hold the mutation lock), ADR-19 (the ledger append happens in the core, the adapter only maps), ADR-13 (the one new trait, `RecordedWrite`, is private with two implementors and one caller, and exists so the record is built once rather than fifteen times). ADR-01, ADR-05, auth/token posture: N/A, untouched.

## Validation

```
cargo fmt --all -- --check                                  clean
cargo clippy --all-targets --all-features -- -D warnings    clean
cargo test --all                                            1017 passed
cargo test --all --all-features                             1032 passed
node scripts/check-module-map.mjs                           205 files, one assignment each
just docs-freshness / docs-freshness-ack                    8 notes reviewed, 2 updated
```

Live acceptance, managed two-way Vault against an HTTPS remote, driven through the real MCP endpoint. Two summarised writes coalesced into one commit:

```
hatchdoor: create "Acceptance", append "Home" (2 files)

- add the acceptance note
- link the acceptance note from Home
```

A later write then committed with only its own line, confirming the batch is consumed rather than replayed, and Hatchdoor pushed both to the remote.

## Separate bug found while testing

A `local_history` Vault only ever gets a Git turn at activation — `sync_vault` refuses it for having no remote, and the scheduler does not track it. Notes written after startup stay uncommitted until the process restarts. Pre-existing and untouched by this change, but it caps how far this fix reaches on that one mode. Not yet filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xWZBQZdeoufp4jXE1aEMg
