### PR TITLE
fix: put the caret where the click was in a block that holds a link (#269)

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -3082,6 +3082,7 @@ escalation), Markdown/heading/search/state tests,
 - `frontend/src/hooks/useWriteMode.ts`
 - `frontend/src/lib/blockOps.ts`
 - `frontend/src/lib/caretMap.ts`
+- `frontend/src/lib/caretPoint.ts`
 - `frontend/src/lib/editHistory.ts`
 - `frontend/src/lib/imageUpload.ts`
 - `frontend/src/lib/linePrefix.ts`
@@ -3176,10 +3177,10 @@ is still settling behind a wikilink resolve.
 **Validation:** write API (`writeApi.test.ts`, including the demo_read_only
 code-carrying cases), editor, action dialog, upload, draft, path,
 frontmatter, conflict, and autocomplete tests; `blockOps`, `sourceMap`,
-`caretMap`, `editHistory`, `linePrefix`, `useNoteAutosave`, `attachmentDrop`,
-`inlineEditing`, and `properties` tests; `useNoteActions.test.tsx` (#152);
-plus `App.write-mode.test.tsx`, `App.demo-mode.test.tsx` (#152), and full
-frontend checks.
+`caretMap`, `caretPoint`, `editHistory`, `linePrefix`, `useNoteAutosave`,
+`attachmentDrop`, `inlineEditing`, and `properties` tests;
+`useNoteActions.test.tsx` (#152); plus `App.write-mode.test.tsx`,
+`App.demo-mode.test.tsx` (#152), and full frontend checks.
 
 ### Graph
 

--- a/frontend/src/components/note-page/EditableBlock.tsx
+++ b/frontend/src/components/note-page/EditableBlock.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { sourceOffsetForRenderedOffset } from "../../lib/caretMap";
+import { sourceOffsetForCaretPoint } from "../../lib/caretPoint";
 import { blockRange, type LineRange } from "../../lib/sourceMap";
 import { BlockInput, type UnitType } from "./BlockInput";
 import { useInlineEditor } from "./inlineEditorContext";
@@ -19,39 +19,54 @@ function sameRange(a: LineRange | null, b: LineRange): boolean {
   return a !== null && a.startLine === b.startLine && a.endLine === b.endLine;
 }
 
+/** A caret position as the browser reports it: an offset inside one text node. */
+type CaretPoint = { node: Node | null; offset: number };
+
+/** What the browser makes of a point, in the one shape the two APIs share. */
+function caretPointAt(clientX: number, clientY: number): CaretPoint | null {
+  const doc = document as Document & {
+    caretPositionFromPoint?: (
+      x: number,
+      y: number,
+    ) => { offsetNode: Node | null; offset: number } | null;
+    caretRangeFromPoint?: (
+      x: number,
+      y: number,
+    ) => { startContainer: Node | null; startOffset: number } | null;
+  };
+
+  const position = doc.caretPositionFromPoint?.(clientX, clientY);
+  if (position) {
+    return { node: position.offsetNode, offset: position.offset };
+  }
+  // WebKit spells it differently.
+  const range = doc.caretRangeFromPoint?.(clientX, clientY);
+  return range
+    ? { node: range.startContainer, offset: range.startOffset }
+    : null;
+}
+
 /**
  * The source offset under a pointer, or null when the browser cannot say.
  *
  * Approximate by design (D9): markdown syntax has no rendered counterpart, so
  * landing a few characters out is fine. Landing always at 0, or always at the
  * end, is not.
+ *
+ * The reported node travels with the offset because both APIs measure inside
+ * the text node under the pointer, and `caretMap` measures across the whole
+ * block. `sourceOffsetForCaretPoint` is what reconciles the two.
  */
 function caretOffsetAtPoint(
+  root: Element | null,
   clientX: number,
   clientY: number,
   source: string,
 ): number | null {
-  const doc = document as Document & {
-    caretPositionFromPoint?: (
-      x: number,
-      y: number,
-    ) => { offset: number } | null;
-    caretRangeFromPoint?: (
-      x: number,
-      y: number,
-    ) => { startOffset: number } | null;
-  };
-
-  const position = doc.caretPositionFromPoint?.(clientX, clientY);
-  if (position) {
-    return sourceOffsetForRenderedOffset(source, position.offset);
-  }
-  // WebKit spells it differently.
-  const range = doc.caretRangeFromPoint?.(clientX, clientY);
-  if (range) {
-    return sourceOffsetForRenderedOffset(source, range.startOffset);
-  }
-  return null;
+  const point = caretPointAt(clientX, clientY);
+  return point
+    ? sourceOffsetForCaretPoint(root, point.node, point.offset, source)
+    : null;
 }
 
 /**
@@ -143,7 +158,12 @@ export function EditableBlock({
     }
     editor.enterBlock(
       range,
-      caretOffsetAtPoint(clientX, clientY, editor.sourceOf(range)),
+      caretOffsetAtPoint(
+        elementRef.current,
+        clientX,
+        clientY,
+        editor.sourceOf(range),
+      ),
     );
   };
 

--- a/frontend/src/components/note-page/inlineEditing.test.tsx
+++ b/frontend/src/components/note-page/inlineEditing.test.tsx
@@ -988,3 +988,105 @@ describe("multi-line list items are addressed per line (D25a)", () => {
     expect(screen.queryByRole("textbox")).toBeNull();
   });
 });
+
+describe("the caret a click enters at (#269)", () => {
+  const SPLIT = "See **alias** TAILWORD here.\n";
+  const PLAIN = "See alias TAILWORD here.\n";
+  // Offset 5 in " TAILWORD here." is the W the pointer is over. Across the
+  // whole rendered block that same character is offset 14, and only the
+  // block-wide reading maps onto the W in the source.
+  const OFFSET_IN_NODE = 5;
+
+  /**
+   * Makes the browser report `node`/`offset` for any point, the way it does
+   * over a real glyph. jsdom implements neither caret API, so the click path
+   * cannot otherwise reach the code that reads them.
+   */
+  function stubCaretApi(
+    name: "caretPositionFromPoint" | "caretRangeFromPoint",
+    node: Node,
+    offset: number,
+  ): void {
+    const reported =
+      name === "caretPositionFromPoint"
+        ? { offsetNode: node, offset }
+        : { startContainer: node, startOffset: offset };
+    Object.defineProperty(document, name, {
+      configurable: true,
+      value: () => reported,
+    });
+    stubbed.push(name);
+  }
+
+  const stubbed: string[] = [];
+  afterEach(() => {
+    for (const name of stubbed.splice(0)) {
+      delete (document as unknown as Record<string, unknown>)[name];
+    }
+  });
+
+  /** The ` TAILWORD here.` text node, which is what a click on the W hits. */
+  function tailNode(): Node {
+    const block = screen.getByText(/TAILWORD/);
+    const tail = block.lastChild;
+    if (!tail) {
+      throw new Error("the rendered block has no trailing text node");
+    }
+    return tail;
+  }
+
+  it("measures the reported node across the block, not within it", () => {
+    render(<NoteHarness initialContent={SPLIT} />);
+    const block = screen.getByText(/TAILWORD/);
+    stubCaretApi("caretPositionFromPoint", tailNode(), OFFSET_IN_NODE);
+
+    fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
+
+    // 18 is the W of TAILWORD in `See **alias** TAILWORD here.`; the
+    // node-relative 5 would have landed on the first * of the bold markers.
+    expect(caretPos()).toBe(18);
+  });
+
+  it("measures it the same way on the WebKit caret API", () => {
+    render(<NoteHarness initialContent={SPLIT} />);
+    const block = screen.getByText(/TAILWORD/);
+    stubCaretApi("caretRangeFromPoint", tailNode(), OFFSET_IN_NODE);
+
+    fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
+
+    expect(caretPos()).toBe(18);
+  });
+
+  it("leaves a single-text-node block where it already landed", () => {
+    render(<NoteHarness initialContent={PLAIN} />);
+    const block = screen.getByText(/TAILWORD/);
+    stubCaretApi("caretPositionFromPoint", tailNode(), 14);
+
+    fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
+
+    expect(caretPos()).toBe(14);
+  });
+
+  it("takes no caret preference from a node in another block", () => {
+    render(<NoteHarness initialContent={`Elsewhere.\n\n${SPLIT}`} />);
+    const block = screen.getByText(/TAILWORD/);
+    const elsewhere = screen.getByText("Elsewhere.").firstChild;
+    stubCaretApi("caretPositionFromPoint", elsewhere!, 3);
+
+    fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
+
+    // No preference opens the block with the default caret, at the end.
+    expect(caretPos()).toBe("See **alias** TAILWORD here.".length);
+  });
+
+  it("takes no caret preference from an element node", () => {
+    render(<NoteHarness initialContent={SPLIT} />);
+    const block = screen.getByText(/TAILWORD/);
+    // On an element the offset counts children, not characters.
+    stubCaretApi("caretPositionFromPoint", block, 1);
+
+    fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
+
+    expect(caretPos()).toBe("See **alias** TAILWORD here.".length);
+  });
+});

--- a/frontend/src/lib/caretPoint.test.ts
+++ b/frontend/src/lib/caretPoint.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { sourceOffsetForCaretPoint } from "./caretPoint";
+
+/**
+ * Builds a block whose rendered text is `See alias TAILWORD here.`, with
+ * `alias` inside `wrapper`, and returns the block plus its text nodes.
+ *
+ * Every inline construct the map knows about renders to this same shape: three
+ * child nodes where a plain paragraph has one. That is the whole defect, so one
+ * builder covers every row of the table.
+ */
+function splitBlock(wrapper: HTMLElement): {
+  root: HTMLElement;
+  inner: Text;
+  tail: Text;
+} {
+  const root = document.createElement("p");
+  const lead = document.createTextNode("See ");
+  const inner = document.createTextNode("alias");
+  const tail = document.createTextNode(" TAILWORD here.");
+  wrapper.append(inner);
+  root.append(lead, wrapper, tail);
+  return { root, inner, tail };
+}
+
+function anchor(): HTMLElement {
+  const element = document.createElement("a");
+  element.setAttribute("href", "/notes/some-note");
+  return element;
+}
+
+describe("sourceOffsetForCaretPoint", () => {
+  // Clicking between TAIL and WORD is offset 5 in the trailing text node and
+  // offset 14 across the block. Feeding the map 5 lands inside the link's
+  // target; 14 lands on the W that was clicked.
+  const CLICK_IN_TAIL = 5;
+
+  it("counts the text before a wikilink's own node", () => {
+    const { root, tail } = splitBlock(anchor());
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See [[Some Note|alias]] TAILWORD here.",
+      ),
+    ).toBe(28);
+  });
+
+  it("counts the text before an escaped wikilink's own node", () => {
+    const { root, tail } = splitBlock(anchor());
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See [[Some Note\\|alias]] TAILWORD here.",
+      ),
+    ).toBe(29);
+  });
+
+  it("counts the text before a markdown link's own node", () => {
+    const { root, tail } = splitBlock(anchor());
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See [alias](/target) TAILWORD here.",
+      ),
+    ).toBe(25);
+  });
+
+  it("counts the text before a bold run", () => {
+    const { root, tail } = splitBlock(document.createElement("strong"));
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See **alias** TAILWORD here.",
+      ),
+    ).toBe(18);
+  });
+
+  it("counts the text before an italic run", () => {
+    const { root, tail } = splitBlock(document.createElement("em"));
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See *alias* TAILWORD here.",
+      ),
+    ).toBe(16);
+  });
+
+  it("counts the text before an inline code span", () => {
+    const { root, tail } = splitBlock(document.createElement("code"));
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See `alias` TAILWORD here.",
+      ),
+    ).toBe(16);
+  });
+
+  it("descends through nested inline elements", () => {
+    const strong = document.createElement("strong");
+    const { root, tail } = splitBlock(strong);
+    const em = document.createElement("em");
+    em.append(document.createTextNode("alias"));
+    strong.replaceChildren(em);
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        tail,
+        CLICK_IN_TAIL,
+        "See ***alias*** TAILWORD here.",
+      ),
+    ).toBe(20);
+  });
+
+  it("maps a click inside a link's own text onto the alias, not the target", () => {
+    const { root, inner } = splitBlock(anchor());
+    // Rendered offset 2 within "alias" is the i.
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        inner,
+        2,
+        "See [[Some Note|alias]] TAILWORD here.",
+      ),
+    ).toBe(18);
+  });
+
+  it("leaves a single-text-node block exactly as it was", () => {
+    const root = document.createElement("p");
+    const only = document.createTextNode("See alias TAILWORD here.");
+    root.append(only);
+    expect(
+      sourceOffsetForCaretPoint(root, only, 14, "See alias TAILWORD here."),
+    ).toBe(14);
+  });
+
+  it("has no preference when the node belongs to another block", () => {
+    const { tail } = splitBlock(anchor());
+    const other = document.createElement("p");
+    other.append(document.createTextNode("Another block."));
+    expect(
+      sourceOffsetForCaretPoint(other, tail, CLICK_IN_TAIL, "Another block."),
+    ).toBeNull();
+  });
+
+  it("has no preference when the reported node is an element", () => {
+    const { root } = splitBlock(anchor());
+    // On an element node the offset counts children, not characters.
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        root,
+        1,
+        "See [[Some Note|alias]] TAILWORD here.",
+      ),
+    ).toBeNull();
+  });
+
+  it("has no preference without a block root or without a node", () => {
+    const { root, tail } = splitBlock(anchor());
+    expect(sourceOffsetForCaretPoint(null, tail, 0, "See alias")).toBeNull();
+    expect(sourceOffsetForCaretPoint(root, null, 0, "See alias")).toBeNull();
+  });
+});

--- a/frontend/src/lib/caretPoint.ts
+++ b/frontend/src/lib/caretPoint.ts
@@ -1,0 +1,45 @@
+// Turns a browser caret position into an offset in the markdown source.
+//
+// `caretPositionFromPoint` and `caretRangeFromPoint` both report a position
+// inside the text node under the pointer, while `caretMap` maps an offset
+// measured across a block's whole rendered text. The two readings coincide only
+// when a block renders as a single text node, which is why plain prose has
+// always worked and anything holding a link, bold, italic, or inline code has
+// not. This module is the conversion between them.
+
+import { sourceOffsetForRenderedOffset } from "./caretMap";
+
+/**
+ * The source offset for a caret the browser reported at `offsetInNode`
+ * characters into `node`, or null when no offset can be trusted.
+ *
+ * Null rather than a guess in the three cases where the reported position says
+ * nothing about this block: no node at all, an element node, where the offset
+ * counts children rather than characters, and a node this block does not
+ * contain, which both browser APIs can report because they answer for the whole
+ * document and a click can land on padding or on a neighbour. The caller opens
+ * the block with its default caret instead.
+ */
+export function sourceOffsetForCaretPoint(
+  root: Element | null,
+  node: Node | null,
+  offsetInNode: number,
+  source: string,
+): number | null {
+  if (!root || !node || node.nodeType !== Node.TEXT_NODE) {
+    return null;
+  }
+
+  const walker = root.ownerDocument.createTreeWalker(
+    root,
+    NodeFilter.SHOW_TEXT,
+  );
+  let before = 0;
+  for (let text = walker.nextNode(); text; text = walker.nextNode()) {
+    if (text === node) {
+      return sourceOffsetForRenderedOffset(source, before + offsetInNode);
+    }
+    before += text.textContent?.length ?? 0;
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes #269.

## What was wrong

Click into a paragraph that renders as more than one node and the block opened with the caret in the wrong place. Click just after a wikilink and the caret landed inside the link's target instead of on the character you clicked.

`caretPositionFromPoint` and `caretRangeFromPoint` both report an offset **inside the text node under the pointer**. `caretMap` takes an offset measured **across the block's whole rendered text**. The two readings coincide only when a block is a single text node, which is why plain prose has always worked and anything holding a link, bold, italic or inline code has not.

`caretMap` is untouched. It was handed the wrong number, not following the wrong rule.

## The fix

`frontend/src/lib/caretPoint.ts` is the conversion between the two readings. It walks the block's text nodes in order, sums the rendered text in front of the reported node, and hands the block-wide offset to the map.

It returns no caret preference, so the block opens with its default caret, in the cases where the reported position says nothing about this block:

- no node at all;
- a node this block does not contain, which either browser API can report because both answer for the whole document and a click can land on padding or on a neighbour;
- an element node, whose offset counts children rather than characters.

## Tests

`caretPoint.test.ts` covers the conversion against a hand-built DOM, one case per inline construct. `inlineEditing.test.tsx` gains a `#269` block that stubs both caret APIs, which jsdom does not implement, so the click path itself is pinned rather than only the extracted function. Both sets fail against the old node-relative caller and pass now.

## Live acceptance

Real mouse clicks on the W of `TAILWORD` in `just dev-start`, reading back where the caret landed in the opened block:

| link form | caret lands | should be |
| --- | --- | --- |
| `[[Some Note\|alias]]` | 28 | 28 |
| `[[Some Note\\\|alias]]` | 29 | 29 |
| `[alias](/target)` | 25 | 25 |
| `**alias**` | 18 | 18 |
| `*alias*` | 16 | 16 |
| `` `alias` `` | 16 | 16 |
| plain prose | 14 | 14 |

Full frontend checks pass: lint, typecheck, 858 tests, build, plus `node scripts/check-module-map.mjs` for the added file and the docs-freshness review.

## Not in this change

Multi-line blocks are a separate defect the issue puts out of scope, and a fenced code block still gets an approximate answer for the same reason. `caretMap`'s own approximations are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DzvLcQ7xv5fERmJtvZUvT
