### PR TITLE
fix: map the caret against the source line it actually landed on (#284)

### DIFF
--- a/frontend/src/components/note-page/inlineEditing.test.tsx
+++ b/frontend/src/components/note-page/inlineEditing.test.tsx
@@ -54,6 +54,35 @@ function setCaret(at: number): void {
   view.dispatch({ selection: { anchor: at } });
 }
 
+/**
+ * Makes the browser report `node`/`offset` for any point, the way it does over
+ * a real glyph. jsdom implements neither caret API, so the click path cannot
+ * otherwise reach the code that reads them.
+ */
+const stubbed: string[] = [];
+
+function stubCaretApi(
+  name: "caretPositionFromPoint" | "caretRangeFromPoint",
+  node: Node,
+  offset: number,
+): void {
+  const reported =
+    name === "caretPositionFromPoint"
+      ? { offsetNode: node, offset }
+      : { startContainer: node, startOffset: offset };
+  Object.defineProperty(document, name, {
+    configurable: true,
+    value: () => reported,
+  });
+  stubbed.push(name);
+}
+
+afterEach(() => {
+  for (const name of stubbed.splice(0)) {
+    delete (document as unknown as Record<string, unknown>)[name];
+  }
+});
+
 /** Replaces the block's whole text, as typing over a selection would. */
 function setEditorValue(text: string): void {
   const view = editorView();
@@ -997,34 +1026,6 @@ describe("the caret a click enters at (#269)", () => {
   // block-wide reading maps onto the W in the source.
   const OFFSET_IN_NODE = 5;
 
-  /**
-   * Makes the browser report `node`/`offset` for any point, the way it does
-   * over a real glyph. jsdom implements neither caret API, so the click path
-   * cannot otherwise reach the code that reads them.
-   */
-  function stubCaretApi(
-    name: "caretPositionFromPoint" | "caretRangeFromPoint",
-    node: Node,
-    offset: number,
-  ): void {
-    const reported =
-      name === "caretPositionFromPoint"
-        ? { offsetNode: node, offset }
-        : { startContainer: node, startOffset: offset };
-    Object.defineProperty(document, name, {
-      configurable: true,
-      value: () => reported,
-    });
-    stubbed.push(name);
-  }
-
-  const stubbed: string[] = [];
-  afterEach(() => {
-    for (const name of stubbed.splice(0)) {
-      delete (document as unknown as Record<string, unknown>)[name];
-    }
-  });
-
   /** The ` TAILWORD here.` text node, which is what a click on the W hits. */
   function tailNode(): Node {
     const block = screen.getByText(/TAILWORD/);
@@ -1088,5 +1089,125 @@ describe("the caret a click enters at (#269)", () => {
     fireEvent.click(block, { clientX: 10, clientY: 10, bubbles: true });
 
     expect(caretPos()).toBe("See **alias** TAILWORD here.".length);
+  });
+});
+
+describe("the caret a click enters at in a multi-line block (#284)", () => {
+  /** The text node a click on a rendered line hits. */
+  function textOf(element: HTMLElement): Node {
+    const text = element.firstChild;
+    if (!text) {
+      throw new Error("the rendered line has no text node");
+    }
+    return text;
+  }
+
+  function clickInto(element: HTMLElement, offsetInNode: number): void {
+    stubCaretApi("caretPositionFromPoint", textOf(element), offsetInNode);
+    fireEvent.click(element, { clientX: 10, clientY: 10, bubbles: true });
+  }
+
+  it("lands on the first word of a wrapped list item's continuation line", () => {
+    render(<NoteHarness initialContent={"- first line\n  continues here\n"} />);
+
+    clickInto(screen.getByText("continues here"), 0);
+
+    // 2 is the c of continues; 0 would sit in the indent, which renders as
+    // nothing at all.
+    expect(editorValue()).toBe("  continues here");
+    expect(caretPos()).toBe(2);
+  });
+
+  it("lands on it just the same when the list is nested and the indent wider", () => {
+    render(
+      <NoteHarness
+        initialContent={"- top\n    - first line\n      continues here\n"}
+      />,
+    );
+
+    clickInto(screen.getByText("continues here"), 0);
+
+    expect(editorValue()).toBe("      continues here");
+    expect(caretPos()).toBe(6);
+  });
+
+  // Correct before the change: a callout body line is addressed on its own and
+  // the old rule already stripped a single `> `. Here to hold that.
+  it("lands on the clicked word of a multi-line callout's body line", () => {
+    render(
+      <NoteHarness
+        initialContent={"> [!note] Title\n> body continues here\n"}
+      />,
+    );
+
+    // Offset 5 in the rendered `body continues here` is the c of continues.
+    clickInto(screen.getByText("body continues here"), 5);
+
+    expect(editorValue()).toBe("> body continues here");
+    expect(caretPos()).toBe(7);
+  });
+
+  it("lands on the clicked word of a quote spanning two source lines", () => {
+    render(
+      <NoteHarness initialContent={"> first line\n> second line\n"} />,
+    );
+
+    // Offset 11 across the rendered quote is the s of second.
+    clickInto(screen.getByText(/second line/), 11);
+
+    expect(editorValue()).toBe("> first line\n> second line");
+    expect(caretPos()).toBe(15);
+  });
+
+  // Correct before the change: a newline is one character on both sides and
+  // there is no indent to skip. Here to hold that.
+  it("leaves an unindented wrapped paragraph where it already landed", () => {
+    render(<NoteHarness initialContent={"one two three\nfour five six\n"} />);
+
+    // Offset 14 across the block is the f of four, on the second source line.
+    clickInto(screen.getByText(/four five six/), 14);
+
+    expect(editorValue()).toBe("one two three\nfour five six");
+    expect(caretPos()).toBe(14);
+  });
+
+  it("skips the indent of a wrapped paragraph's continuation line", () => {
+    render(
+      <NoteHarness initialContent={"one two three\n    four five six\n"} />,
+    );
+
+    clickInto(screen.getByText(/four five six/), 14);
+
+    expect(editorValue()).toBe("one two three\n    four five six");
+    expect(caretPos()).toBe(18);
+  });
+
+  it("lands on the clicked character of a fenced code block", () => {
+    render(<NoteHarness initialContent={"```javascript\nlet x = 1;\n```\n"} />);
+
+    // Offset 4 in `let x = 1;` is the x. The language label and the Copy
+    // button sit in the same block wrapper and must add nothing to that.
+    clickInto(screen.getByText(/let x = 1;/), 4);
+
+    expect(editorValue()).toBe("```javascript\nlet x = 1;\n```");
+    expect(caretPos()).toBe(18);
+  });
+
+  it("lands on it just the same behind a shorter language name", () => {
+    render(<NoteHarness initialContent={"```rust\nlet x = 1;\n```\n"} />);
+
+    clickInto(screen.getByText(/let x = 1;/), 4);
+
+    expect(editorValue()).toBe("```rust\nlet x = 1;\n```");
+    expect(caretPos()).toBe(12);
+  });
+
+  it("lands on it in a fenced block that names no language", () => {
+    render(<NoteHarness initialContent={"```\nlet x = 1;\n```\n"} />);
+
+    clickInto(screen.getByText(/let x = 1;/), 4);
+
+    expect(editorValue()).toBe("```\nlet x = 1;\n```");
+    expect(caretPos()).toBe(8);
   });
 });

--- a/frontend/src/lib/caretMap.test.ts
+++ b/frontend/src/lib/caretMap.test.ts
@@ -93,3 +93,120 @@ describe("sourceOffsetForRenderedOffset inside an escaped wikilink", () => {
     );
   });
 });
+
+describe("blocks whose source spans more than one line (#284)", () => {
+  // A wrapped list item is addressed one source line at a time (D25a), so its
+  // continuation line reaches the map alone, indent and all.
+  it("skips the indent of a continuation line that arrives on its own", () => {
+    expect(sourceOffsetForRenderedOffset("  continues here", 0)).toBe(2);
+  });
+
+  it("skips a wider indent, which is what nesting a list produces", () => {
+    expect(sourceOffsetForRenderedOffset("      continues here", 0)).toBe(6);
+  });
+
+  it("skips the indent of a continuation line within a whole item", () => {
+    // Rendered "first line\ncontinues here"; offset 11 is the c of continues.
+    expect(
+      sourceOffsetForRenderedOffset("- first line\n  continues here", 11),
+    ).toBe(15);
+  });
+
+  it("skips the wider indent of a nested item's continuation line", () => {
+    expect(
+      sourceOffsetForRenderedOffset("  - first line\n    continues here", 11),
+    ).toBe(19);
+  });
+
+  it("leaves an unindented wrapped paragraph where it already landed", () => {
+    // Correct before the change: a newline is one character on both sides and
+    // there is no indent to skip.
+    expect(
+      sourceOffsetForRenderedOffset("one two three\nfour five six", 14),
+    ).toBe(14);
+  });
+
+  it("skips the indent of a wrapped paragraph's continuation line", () => {
+    expect(
+      sourceOffsetForRenderedOffset("one two three\n    four five six", 14),
+    ).toBe(18);
+  });
+
+  it("strips the quote arrow of every line, not only the first", () => {
+    // Rendered "first line\nsecond line"; offset 11 is the s of second.
+    expect(
+      sourceOffsetForRenderedOffset("> first line\n> second line", 11),
+    ).toBe(15);
+  });
+
+  it("strips nested quote arrows, which the map's own copy of the rule did not", () => {
+    expect(sourceOffsetForRenderedOffset("> > deep", 0)).toBe(4);
+  });
+
+  it("puts a caret on the soft break at the end of the line it closes", () => {
+    expect(sourceOffsetForRenderedOffset("one two\nnext", 7)).toBe(7);
+  });
+});
+
+describe("fenced code blocks (#284)", () => {
+  // Offset 4 in the rendered code is the x of `let x = 1;`.
+  const CODE_CLICK = 4;
+
+  it("skips the opening fence and its language", () => {
+    expect(
+      sourceOffsetForRenderedOffset("```javascript\nlet x = 1;\n```", CODE_CLICK),
+    ).toBe(18);
+  });
+
+  it("skips a shorter language name by exactly its width", () => {
+    expect(
+      sourceOffsetForRenderedOffset("```rust\nlet x = 1;\n```", CODE_CLICK),
+    ).toBe(12);
+  });
+
+  it("skips a tilde fence too", () => {
+    expect(
+      sourceOffsetForRenderedOffset("~~~js\nlet x = 1;\n~~~", CODE_CLICK),
+    ).toBe(10);
+  });
+
+  it("counts the newline between two code lines", () => {
+    // Rendered "first\nsecond"; offset 6 is the s of second.
+    expect(sourceOffsetForRenderedOffset("```\nfirst\nsecond\n```", 6)).toBe(10);
+  });
+
+  it("treats a code line's indentation as text, because it is", () => {
+    expect(sourceOffsetForRenderedOffset("```\n  indented\n```", 0)).toBe(4);
+  });
+
+  it("treats markdown syntax inside code as text, because it is", () => {
+    // Rendered "**not bold**"; offset 2 is the n.
+    expect(sourceOffsetForRenderedOffset("```\n**not bold**\n```", 2)).toBe(6);
+  });
+
+  it("lands at the end of the code when the click is past it", () => {
+    expect(sourceOffsetForRenderedOffset("```js\nab\n```", 99)).toBe(8);
+  });
+
+  it("maps a block whose closing fence has not been typed yet", () => {
+    expect(sourceOffsetForRenderedOffset("```js\nab", 1)).toBe(7);
+  });
+
+  it("strips the container's indent from a fence written inside one", () => {
+    // Rendered "code"; the two spaces belong to the list item holding the
+    // fence, not to the code, so offset 0 is the c.
+    expect(sourceOffsetForRenderedOffset("  ```js\n  code\n  ```", 0)).toBe(10);
+  });
+
+  it("keeps a code line's own indent, past the container's", () => {
+    // Rendered "  deeper"; offset 0 is the first of the two spaces that are
+    // part of the code.
+    expect(
+      sourceOffsetForRenderedOffset("  ```js\n    deeper\n  ```", 0),
+    ).toBe(10);
+  });
+
+  it("puts the caret between the fences when there is no code yet", () => {
+    expect(sourceOffsetForRenderedOffset("```\n```", 0)).toBe(4);
+  });
+});

--- a/frontend/src/lib/caretMap.ts
+++ b/frontend/src/lib/caretMap.ts
@@ -5,29 +5,71 @@
 // in the rendered text, so there is no exact answer. Landing a few characters
 // off is acceptable; always landing at offset 0, or always at the end, is not.
 
-/** Line prefixes that produce no rendered text at all. */
-const LINE_PREFIX =
-  /^(\s*)(?:(?:[-*+]|\d+[.)])\s+(?:\[[ xX]\]\s+)?|#{1,6}\s+|>\s?)/;
+import { linePrefix } from "./linePrefix";
+
+/** Opens or closes a fenced code block. The whole line renders as nothing. */
+const FENCE = /^\s*(?:```|~~~)/;
 
 /**
  * The source offset corresponding to `renderedOffset` characters of rendered
- * text in the single source line `source`.
+ * text in the block `source`, which may span more than one line.
+ *
+ * Every line is measured against its own leading syntax. Indentation renders as
+ * nothing wherever it sits, and counting it as text put the caret short of the
+ * clicked character by the width of the indent, worse the deeper a list nests
+ * (#284).
  */
 export function sourceOffsetForRenderedOffset(
   source: string,
   renderedOffset: number,
 ): number {
   const target = Math.max(0, renderedOffset);
+  const lines = source.split("\n");
 
-  let index = 0;
-  const prefix = LINE_PREFIX.exec(source);
-  if (prefix) {
-    index = prefix[0].length;
+  if (FENCE.test(lines[0])) {
+    return codeBlockOffset(lines, target);
   }
 
   let rendered = 0;
-  while (index < source.length) {
-    const rest = source.slice(index);
+  let lineStart = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const walk = walkLine(line, target - rendered);
+    if (walk.hit !== null) {
+      return lineStart + walk.hit;
+    }
+    rendered += walk.rendered;
+    lineStart += line.length + 1;
+
+    if (i === lines.length - 1) {
+      break;
+    }
+    // The soft break between two lines of one block is one character on each
+    // side, so a caret that lands on it belongs at the end of the line it
+    // closes rather than at the front of the next one.
+    if (rendered >= target) {
+      return lineStart - 1;
+    }
+    rendered += 1;
+  }
+
+  return source.length;
+}
+
+type LineWalk = {
+  /** The offset within the line, or null when the target lies past its end. */
+  hit: number | null;
+  /** How many rendered characters the line carries, once `hit` is null. */
+  rendered: number;
+};
+
+/** Where `target` rendered characters land within the single line `line`. */
+function walkLine(line: string, target: number): LineWalk {
+  let index = invisiblePrefix(line).length;
+  let rendered = 0;
+
+  while (index < line.length) {
+    const rest = line.slice(index);
 
     // Emphasis, bold, and inline code carry no rendered characters, and are
     // consumed before the position check so a caret that lands exactly on a
@@ -54,7 +96,7 @@ export function sourceOffsetForRenderedOffset(
       const shown = pipe >= 0 ? body.slice(pipe + 1) : body;
       const shownStart = pipe >= 0 ? 2 + pipe + 1 : 2;
       if (target - rendered < shown.length) {
-        return index + shownStart + (target - rendered);
+        return { hit: index + shownStart + (target - rendered), rendered };
       }
       rendered += shown.length;
       index += wikilink[0].length;
@@ -65,13 +107,13 @@ export function sourceOffsetForRenderedOffset(
     const link = /^!?\[([^\]]*)\]\([^)]*\)/.exec(rest);
 
     if (rendered >= target) {
-      return link ? index + 1 : index;
+      return { hit: link ? index + 1 : index, rendered };
     }
 
     if (link) {
       const label = link[1];
       if (target - rendered < label.length) {
-        return index + 1 + (target - rendered);
+        return { hit: index + 1 + (target - rendered), rendered };
       }
       rendered += label.length;
       index += link[0].length;
@@ -82,5 +124,73 @@ export function sourceOffsetForRenderedOffset(
     index += 1;
   }
 
-  return source.length;
+  return { hit: null, rendered };
+}
+
+/**
+ * The leading source characters on `line` that render as nothing: its
+ * indentation, then any list marker, task box, heading hashes, or quote arrows
+ * behind it.
+ *
+ * Indentation counts on any line, not only the first one of a block. A wrapped
+ * list item is addressed one source line at a time (D25a), so its continuation
+ * line arrives here as a block of its own: indent at the front, no marker to
+ * hang it on, and none of it on screen.
+ *
+ * The indent is measured here rather than folded into `linePrefix`, which
+ * matches an indent only ahead of a list marker. `linePrefix` also decides what
+ * `BlockInput` hangs into the gutter, and widening it there would move the
+ * visible text of every indented line on entry, which is a different question
+ * from where a caret goes. The two therefore disagree on an indented heading or
+ * quote: this reads `  # h` as three invisible characters, the gutter reads it
+ * as none.
+ */
+function invisiblePrefix(line: string): string {
+  const indent = indentWidth(line);
+  return line.slice(0, indent) + linePrefix(line.slice(indent));
+}
+
+/**
+ * The source offset in a fenced block for `target` characters of code.
+ *
+ * The fences carry the delimiter and the language name and render nothing at
+ * all, so each is skipped whole, its newline with it. What is left is the code,
+ * which renders literally: its own backticks and brackets are not markdown and
+ * none of the line rules apply to it.
+ *
+ * The one thing stripped from a code line is the block's own indentation, up to
+ * the width the opening fence sits at. That is how the fence is written inside
+ * a list item or a callout, and those spaces belong to the container rather
+ * than to the code, so they never reach the screen.
+ */
+function codeBlockOffset(lines: string[], target: number): number {
+  const closing =
+    lines.length > 1 && FENCE.test(lines[lines.length - 1])
+      ? lines.length - 1
+      : lines.length;
+  const container = indentWidth(lines[0]);
+
+  let start = lines[0].length + 1;
+  // With no code at all, the spot between the two fences.
+  let end = start;
+  let rendered = 0;
+  for (let i = 1; i < closing; i += 1) {
+    const line = lines[i];
+    const stripped = Math.min(container, indentWidth(line));
+    const shown = line.length - stripped;
+    if (target - rendered <= shown) {
+      return start + stripped + (target - rendered);
+    }
+    rendered += shown + 1;
+    end = start + line.length;
+    start += line.length + 1;
+  }
+
+  // Past the last character of the code: the end of its final line.
+  return end;
+}
+
+/** How many characters of leading indentation `line` opens with. */
+function indentWidth(line: string): number {
+  return /^[ \t]*/.exec(line)?.[0].length ?? 0;
 }

--- a/frontend/src/lib/caretPoint.test.ts
+++ b/frontend/src/lib/caretPoint.test.ts
@@ -174,3 +174,74 @@ describe("sourceOffsetForCaretPoint", () => {
     expect(sourceOffsetForCaretPoint(root, null, 0, "See alias")).toBeNull();
   });
 });
+
+/**
+ * The DOM a fenced code block renders as: the block editor's wrapper, the
+ * renderer's language label and Copy button, then the code itself.
+ */
+function codeBlock(
+  language: string,
+  code: string,
+): { root: HTMLElement; codeText: Text } {
+  const root = document.createElement("div");
+  const block = document.createElement("div");
+  block.className = "code-block";
+  const head = document.createElement("div");
+  head.className = "code-block-head";
+  const label = document.createElement("span");
+  label.className = "code-lang";
+  label.append(document.createTextNode(language));
+  const copy = document.createElement("button");
+  copy.append(document.createTextNode("Copy"));
+  head.append(label, copy);
+  const pre = document.createElement("pre");
+  const codeEl = document.createElement("code");
+  const codeText = document.createTextNode(code);
+  codeEl.append(codeText);
+  pre.append(codeEl);
+  block.append(head, pre);
+  root.append(block);
+  return { root, codeText };
+}
+
+describe("a fenced code block's chrome (#284)", () => {
+  // Offset 4 in `let x = 1;` is the x.
+  const CODE_CLICK = 4;
+
+  it("counts neither the language label nor the Copy button", () => {
+    const { root, codeText } = codeBlock("javascript", "let x = 1;");
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        codeText,
+        CODE_CLICK,
+        "```javascript\nlet x = 1;\n```",
+      ),
+    ).toBe(18);
+  });
+
+  it("is unmoved by a language name of a different length", () => {
+    const { root, codeText } = codeBlock("rust", "let x = 1;");
+    expect(
+      sourceOffsetForCaretPoint(
+        root,
+        codeText,
+        CODE_CLICK,
+        "```rust\nlet x = 1;\n```",
+      ),
+    ).toBe(12);
+  });
+
+  it("still measures a list item's own text when the item holds a code block", () => {
+    // Narrowing to the `pre` under the block rather than from the caret's own
+    // node up would answer for the code here, or refuse outright.
+    const root = document.createElement("li");
+    const own = document.createTextNode("see this");
+    const pre = document.createElement("pre");
+    const codeEl = document.createElement("code");
+    codeEl.append(document.createTextNode("x"));
+    pre.append(codeEl);
+    root.append(own, pre);
+    expect(sourceOffsetForCaretPoint(root, own, 4, "- see this")).toBe(6);
+  });
+});

--- a/frontend/src/lib/caretPoint.ts
+++ b/frontend/src/lib/caretPoint.ts
@@ -30,8 +30,9 @@ export function sourceOffsetForCaretPoint(
     return null;
   }
 
-  const walker = root.ownerDocument.createTreeWalker(
-    root,
+  const measured = measuredRoot(root, node);
+  const walker = measured.ownerDocument.createTreeWalker(
+    measured,
     NodeFilter.SHOW_TEXT,
   );
   let before = 0;
@@ -42,4 +43,27 @@ export function sourceOffsetForCaretPoint(
     before += text.textContent?.length ?? 0;
   }
   return null;
+}
+
+/**
+ * The rendered text the offset is counted across, given where the caret landed.
+ *
+ * A fenced code block is the one editable unit the block editor wraps rather
+ * than clones, and the renderer fills that wrapper with a language label and a
+ * Copy button sitting above the code. Neither has a source character behind it,
+ * so counting their text shifted every offset in the block by their combined
+ * width (#284). Inside a `pre`, the `pre` holds all the source there is.
+ *
+ * Narrowed from the caret's node upwards rather than by looking for a `pre`
+ * under the block: a list item that contains a code block still measures across
+ * its own text when the click landed on that text.
+ *
+ * A click on the chrome itself has no `pre` above it and still counts the label
+ * and the button, so it lands somewhere in the code rather than on the language
+ * name it hit. Left alone: the label and the Copy button are deliberately not
+ * text targets, and the answer stays inside the block's own source.
+ */
+function measuredRoot(root: Element, node: Node): Element {
+  const pre = node.parentElement?.closest("pre");
+  return pre && root.contains(pre) ? pre : root;
 }


### PR DESCRIPTION
Closes #284.

Clicking into the second line of a block put the caret short of the character you clicked. The map stripped a leading markdown marker once, anchored at the start of the block, so every later line's indentation was counted as text that renders. A wrapped list item was the one that bit in daily use, and it got worse the deeper the list nested.

## What changed

`sourceOffsetForRenderedOffset` now finds the source line the rendered offset falls on and measures within it, skipping that line's own indent and marker. A single-line block has exactly one line, so every answer it gave before is unchanged: all existing `caretMap` and `caretPoint` expectations pass without being edited.

A fenced code block had two errors pulling opposite ways and mostly cancelling, at a constant +3. Its offset arrived inflated by the language label and the Copy button, which have no source character behind them, and the map then read the opening fence as emphasis markers followed by the language name as text. Neither half could be fixed alone. The caret is now measured across the `pre` when it landed inside one, narrowed upward from the caret's own node so a list item holding a code block still measures across its own text. The fences are skipped whole, their newlines with them, and code renders literally, so no line rule applies to it beyond the container indent a fence written inside a list item or callout carries.

The map's private line-prefix regex is gone in favour of the shared `linePrefix`, which also handles the nested quote arrows the private copy did not.

## Measured through a real click in the browser

Chromium, `just dev-start`, clicking the glyph itself and reading back where the caret landed.

| block | before | after | on the clicked character |
| --- | --- | --- | --- |
| wrapped list item, 2-space indent | 0 | 2 | yes |
| nested list item, 6-space indent | 0 | 6 | yes |
| wrapped paragraph, 4-space indent | 14 | 18 | yes |
| quote over two source lines | 13 | 21 | yes |
| `javascript` fenced block | 21 | 18 | yes |
| `rust` fenced block | 15 | 12 | yes |
| `js` fence indented inside a list item | 12 | 14 | yes |
| callout body line | 10 | 10 | already correct |
| wrapped paragraph, no indent | 40 | 40 | already correct |

32 tests added across the three layers; 27 of them fail against the code before this change, and the 5 that pass are the shapes annotated in place as already correct.

## Interface change

Declared in the work packet: `sourceOffsetForRenderedOffset` keeps its signature and accepts a block rather than a single source line. Its producer and every consumer sit inside *Note editing and vault actions*, so the interface-change checklist is not triggered — saying so rather than skipping it silently. No production file was added, moved or deleted, so the module map is unchanged and `check-module-map.mjs` passes.

## Known limit, left alone

Clicking the language label or the Copy button has no `pre` above it, so it still counts the chrome and lands somewhere in the code rather than on the label. Neither is meant to be a text target, and the answer stays inside the block's own source.

## Validation

`npm run lint`, `npm run typecheck`, `npm test` (890 passing), `npm run build`, `node scripts/check-module-map.mjs`, and `just docs-freshness` reviewed and acknowledged — neither Web UI note drifted; "the caret lands roughly where you clicked" reads truer than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DzvLcQ7xv5fERmJtvZUvT
