### PR TITLE
fix: embed the search query before taking a cache reader slot

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1428,6 +1428,13 @@ and embedder identity/dimensions.
 - SQLite is rebuildable and never authoritative (ADR-01).
 - Keep embedded SQLite, FTS5, sqlite-vec, WAL, one writer, and pooled
   query-only reads (ADR-06).
+- The reader pool is a ceiling on live SQLite handles, not a load-shedding
+  policy. A caller at `MAX_READ_CONNECTIONS` waits up to `READ_LEASE_WAIT` for
+  a slot and only then reports the pool as exhausted, so no read holds a slot
+  across slow work that does not touch the database. Embedding in particular
+  runs before the search core takes its snapshot: holding a slot across the
+  embedder's inference lock let four concurrent searches starve every other
+  read. Waiters are woken one at a time and not in arrival order.
 - Schema or embedder identity mismatch rebuilds rather than mixing data.
 - A refresh commits a coherent new read snapshot.
 - Shared semantic vectors have one embedder identity and dimension; a mismatch
@@ -1530,6 +1537,12 @@ and future Vault-scoped MCP adapters.
   semantic ranking.
 - Participant metadata, note projections, and KNN/FTS hits for one search
   response come from one pinned SQLite generation.
+- A semantic query is embedded before that generation is pinned, never while
+  holding it. Inference is serialized behind the embedder's own lock, so a
+  reader slot held across it is a slot no other request can use. The order
+  costs an embedding on a query whose Vaults turn out not to participate, and
+  reports an unhealthy embedder ahead of a bad layer name or an unavailable
+  single Vault, both of which need the pinned generation to detect.
 - A structure-only frontend Search pilot must not modify these paths.
 
 **Validation:** `cargo test search`, focused Vault-scoped and cache query tests,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, Once};
+use std::sync::{Condvar, Mutex, MutexGuard, Once};
 
 use rusqlite::Connection;
 use rusqlite::OptionalExtension;
@@ -33,6 +33,19 @@ enum CacheSource {
 /// Upper bound on active file-backed read connections, including checked-out
 /// leases and connections retained idle for reuse.
 const MAX_READ_CONNECTIONS: usize = 4;
+
+/// How long a reader waits for a slot before giving up. [`MAX_READ_CONNECTIONS`]
+/// bounds how many SQLite handles exist at once; it is not a load-shedding
+/// policy, so a caller that would be served as soon as the request ahead of it
+/// finishes waits rather than taking an immediate error. Failing fast there
+/// turned an ordinary burst of UI requests into an outage. Matched to the
+/// `busy_timeout` every connection already carries.
+///
+/// Waiters are woken one at a time and are not queued in arrival order, so a
+/// thread can lose a freed slot to one arriving behind it. Reads hold a slot
+/// for microseconds, which makes the unfairness cheap; a sustained overload
+/// still resolves to this timeout rather than to a fair hand-off.
+const READ_LEASE_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub struct SqliteCache {
     /// The single writer connection. All mutations and transactions go through
@@ -53,6 +66,9 @@ pub struct SqliteCache {
     /// Active file-backed reader leases. Reserving before opening keeps bursts
     /// of concurrent reads from creating an unbounded number of SQLite handles.
     read_leases: Mutex<usize>,
+    /// Signalled whenever a reader lease is returned, so a caller queued at the
+    /// ceiling wakes as soon as a slot frees instead of polling.
+    read_lease_available: Condvar,
 }
 
 static SQLITE_VEC_INIT: Once = Once::new();
@@ -210,6 +226,7 @@ impl SqliteCache {
             vault_snapshot_attempts: Mutex::new(BTreeMap::new()),
             snapshot_model_epoch: Mutex::new(()),
             read_leases: Mutex::new(0),
+            read_lease_available: Condvar::new(),
         };
         cache.ensure_schema(embedding_dim)?;
         Ok(cache)
@@ -227,6 +244,7 @@ impl SqliteCache {
             vault_snapshot_attempts: Mutex::new(BTreeMap::new()),
             snapshot_model_epoch: Mutex::new(()),
             read_leases: Mutex::new(0),
+            read_lease_available: Condvar::new(),
         };
         cache.ensure_schema(embedding_dim)?;
         Ok(cache)
@@ -319,11 +337,17 @@ impl SqliteCache {
     }
 
     fn reserve_read_lease(&self) -> Result<(), String> {
-        let mut leases = self
+        let leases = self
             .read_leases
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *leases >= MAX_READ_CONNECTIONS {
+        let (mut leases, wait) = self
+            .read_lease_available
+            .wait_timeout_while(leases, READ_LEASE_WAIT, |leases| {
+                *leases >= MAX_READ_CONNECTIONS
+            })
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if wait.timed_out() {
             return Err(format!(
                 "SQLite read connection limit ({MAX_READ_CONNECTIONS}) reached; retry shortly"
             ));
@@ -332,13 +356,25 @@ impl SqliteCache {
         Ok(())
     }
 
-    fn release_read_lease(&self) {
-        let mut leases = self
+    /// How many file-backed read leases are currently checked out.
+    #[cfg(test)]
+    pub(crate) fn active_read_leases(&self) -> usize {
+        *self
             .read_leases
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        debug_assert!(*leases > 0, "file-backed read lease underflow");
-        *leases = leases.saturating_sub(1);
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn release_read_lease(&self) {
+        {
+            let mut leases = self
+                .read_leases
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            debug_assert!(*leases > 0, "file-backed read lease underflow");
+            *leases = leases.saturating_sub(1);
+        }
+        self.read_lease_available.notify_one();
     }
 
     pub fn set_metadata(&self, key: &str, value: &str) -> Result<(), String> {
@@ -432,6 +468,7 @@ fn quarantine_corrupt_cache(path: &Path) -> Result<PathBuf, String> {
 mod metadata_tests {
     use super::*;
     use std::sync::{Arc, Barrier, mpsc};
+    use std::time::Duration;
 
     use tempfile::tempdir;
 
@@ -519,13 +556,25 @@ mod metadata_tests {
             assert!(ready_rx.recv().expect("lease result"));
         }
 
-        let overload = match cache.read() {
-            Ok(_) => panic!("active lease ceiling must reject overload"),
-            Err(error) => error,
-        };
+        // A caller arriving at the ceiling queues for the next free slot
+        // rather than taking an immediate error; see READ_LEASE_WAIT.
+        let queued_cache = cache.clone();
+        let (queued_tx, queued_rx) = mpsc::channel();
+        let queued = std::thread::spawn(move || {
+            let lease = queued_cache.read();
+            queued_tx.send(lease.is_ok()).expect("report queued lease");
+        });
         assert!(
-            overload.contains("read connection limit"),
-            "overload should identify the bounded reader pool: {overload}"
+            matches!(
+                queued_rx.recv_timeout(Duration::from_millis(200)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "a caller at the ceiling must wait for a slot, not be served or rejected"
+        );
+        assert_eq!(
+            cache.active_read_leases(),
+            MAX_READ_CONNECTIONS,
+            "waiting must not push the handle count past the ceiling"
         );
 
         for release in release_txs {
@@ -534,6 +583,11 @@ mod metadata_tests {
         for worker in workers {
             worker.join().expect("reader worker");
         }
+        assert!(
+            queued_rx.recv().expect("queued lease result"),
+            "a released lease must hand off to the caller queued behind it"
+        );
+        queued.join().expect("queued reader");
 
         cache.read().expect("a released lease must be reusable");
     }

--- a/src/search/vault_scoped.rs
+++ b/src/search/vault_scoped.rs
@@ -122,17 +122,36 @@ impl<'a> VaultSearchCore<'a> {
         }
         let collection = self.vaults.snapshot();
         let selected = selected_vaults(&collection, request.scope)?;
+        // Resolved before the read lease because it decides whether this query
+        // needs vectors at all: a tag query is answered from structural rows,
+        // so a Vault without vectors is a full participant in it.
+        let tag_query = tag_prefix_query(&request.query);
+        let needs_vectors = tag_query.is_none() && request.mode == SearchMode::Semantic;
+        // Embed before checking out a read lease, never while holding one.
+        // Inference runs behind the embedder's own Mutex, so concurrent
+        // semantic searches queue on it one at a time. A lease held across
+        // that wait pins one of the cache's few reader slots while doing no
+        // database work at all: four typed-ahead searches were enough to hold
+        // every slot and answer `/tree` and `/recent` with an instant 503.
+        //
+        // Two things move ahead of the snapshot read as a result, both of
+        // them visible only when the embedder itself is unhealthy. A query
+        // whose Vaults turn out to have no participating snapshot is embedded
+        // anyway, and an unhealthy embedder now reports `search_unavailable`
+        // where a bad layer name or an unavailable single Vault would have
+        // been named first. Both need the snapshot to detect, so keeping that
+        // order would mean holding the lease across inference again.
+        let query_vector = if needs_vectors && request.limit > 0 && request.per_note_cap > 0 {
+            Some(embed_query(self.embedder, &request.query)?)
+        } else {
+            None
+        };
         let mut cache_snapshot = self
             .cache
             .read_snapshot()
             .map_err(|message| error(None, "search_unavailable", &message, true))?;
         let mut snapshots = BTreeMap::new();
         let mut participants = Vec::with_capacity(selected.len());
-        // Resolved before the participant loop because it decides whether this
-        // query needs vectors at all: a tag query is answered from structural
-        // rows, so a Vault without vectors is a full participant in it.
-        let tag_query = tag_prefix_query(&request.query);
-        let needs_vectors = tag_query.is_none() && request.mode == SearchMode::Semantic;
         for vault in selected {
             match SqliteCache::read_vault_snapshot_on(&cache_snapshot, vault.vault_id) {
                 Ok(Some(snapshot)) => {
@@ -192,13 +211,17 @@ impl<'a> VaultSearchCore<'a> {
             tag_results(&request, &snapshots, &tag)
         } else {
             match request.mode {
-                SearchMode::Semantic => semantic_results(
-                    &request,
-                    self.cache,
-                    &cache_snapshot,
-                    self.embedder,
-                    &snapshots,
-                )?,
+                SearchMode::Semantic => match &query_vector {
+                    Some(query_vector) => semantic_results(
+                        &request,
+                        self.cache,
+                        &cache_snapshot,
+                        query_vector,
+                        &snapshots,
+                    )?,
+                    // `limit` or `per_note_cap` of zero asks for no results.
+                    None => Vec::new(),
+                },
                 SearchMode::Keyword => {
                     let raw = keyword_hits(&request, self.cache, &cache_snapshot, &snapshots)?;
                     apply_per_note_cap(raw, request.per_note_cap, request.limit)
@@ -245,22 +268,11 @@ impl<'a> VaultSearchCore<'a> {
     }
 }
 
-fn semantic_results(
-    request: &VaultSearchRequest,
-    cache: &SqliteCache,
-    conn: &rusqlite::Connection,
-    embedder: &dyn Embedder,
-    snapshots: &BTreeMap<VaultId, VaultSnapshotRead>,
-) -> Result<Vec<VaultSearchResult>, VaultReadError> {
-    if request.limit == 0 || request.per_note_cap == 0 {
-        return Ok(Vec::new());
-    }
-
-    if snapshots.is_empty() {
-        return Ok(Vec::new());
-    }
-    let query_vector = embedder
-        .embed(&[format!("{}{}", embedder.query_prefix(), request.query)])
+/// Embeds one search query. Callers run this before checking out a cache read
+/// lease, never while holding one.
+fn embed_query(embedder: &dyn Embedder, query: &str) -> Result<Vec<f32>, VaultReadError> {
+    embedder
+        .embed(&[format!("{}{}", embedder.query_prefix(), query)])
         .map_err(|message| error(None, "search_unavailable", &message, true))?
         .into_iter()
         .next()
@@ -271,10 +283,24 @@ fn semantic_results(
                 "embedder returned no vectors",
                 true,
             )
-        })?;
+        })
+}
+
+fn semantic_results(
+    request: &VaultSearchRequest,
+    cache: &SqliteCache,
+    conn: &rusqlite::Connection,
+    query_vector: &[f32],
+    snapshots: &BTreeMap<VaultId, VaultSnapshotRead>,
+) -> Result<Vec<VaultSearchResult>, VaultReadError> {
+    // `limit` and `per_note_cap` are the caller's to check: it gates the
+    // embedding on them, so a zero never reaches here.
+    if snapshots.is_empty() {
+        return Ok(Vec::new());
+    }
 
     progressively_cap_semantic_results(request.limit, request.per_note_cap, |raw_k| {
-        semantic_hits_with_vector(request, cache, conn, snapshots, &query_vector, raw_k)
+        semantic_hits_with_vector(request, cache, conn, snapshots, query_vector, raw_k)
     })
 }
 
@@ -582,7 +608,8 @@ mod tests {
     use std::path::Path;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Barrier};
+    use std::sync::{Arc, Barrier, Condvar, mpsc};
+    use std::time::Duration;
 
     use tempfile::TempDir;
 
@@ -648,9 +675,25 @@ mod tests {
     }
 
     fn workspace(vaults: &[(&str, &[(&str, &str)])]) -> Workspace {
+        workspace_on(vaults, |_| SqliteCache::in_memory(384).expect("cache"))
+    }
+
+    /// The file-backed twin of [`workspace`]. Production opens the cache from
+    /// a file, and only that source pools and accounts read connections, so an
+    /// in-memory workspace cannot observe the reader ceiling at all.
+    fn file_backed_workspace(vaults: &[(&str, &[(&str, &str)])]) -> Workspace {
+        workspace_on(vaults, |directory| {
+            SqliteCache::open(directory.join("cache.sqlite3"), 384).expect("file cache")
+        })
+    }
+
+    fn workspace_on(
+        vaults: &[(&str, &[(&str, &str)])],
+        open_cache: impl FnOnce(&Path) -> SqliteCache,
+    ) -> Workspace {
         let directory = tempfile::tempdir().expect("tempdir");
         let store = VaultRegistryStore::new(directory.path().join("state/vaults.json"));
-        let cache = SqliteCache::in_memory(384).expect("cache");
+        let cache = open_cache(directory.path());
         let runtime = VaultCollectionRuntime::new();
         let mut revision = 0;
         let mut registry = None;
@@ -709,6 +752,179 @@ mod tests {
             let path = root.join(path);
             std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
             std::fs::write(path, contents).expect("write note");
+        }
+    }
+
+    /// A browser answers one typed query with several overlapping requests,
+    /// and the sidebar adds its own. More of those than the cache has reader
+    /// slots must queue for a slot, not collect a 503.
+    #[test]
+    fn concurrent_searches_past_the_reader_ceiling_queue_rather_than_fail() {
+        let workspace = file_backed_workspace(&[
+            ("First", &[("Home.md", "# Home\n\nzeno needle")]),
+            ("Second", &[("Home.md", "# Home\n\nzeno needle")]),
+        ]);
+        let embedder = StubEmbedder::new(384);
+        let core = VaultSearchCore::new(&workspace.cache, &workspace.vaults, &embedder);
+
+        // One search at a time. A slot dropped on the floor would push this
+        // above zero and never come back down.
+        for round in 0..10 {
+            core.search(request(VaultScope::All, "zeno"))
+                .expect("sequential search");
+            assert_eq!(
+                workspace.cache.active_read_leases(),
+                0,
+                "a search must return its reader slot; {round} rounds in, it had not"
+            );
+        }
+
+        // Search-as-you-type plus the sidebar's tree and recent calls put
+        // well over four reads in flight at once. Each one must come back with
+        // its results, so a search that failed for some unrelated reason
+        // cannot pass this as though it had been served.
+        for concurrency in [2_usize, 4, 6, 8] {
+            std::thread::scope(|scope| {
+                let searches = (0..concurrency)
+                    .map(|_| scope.spawn(|| core.search(request(VaultScope::All, "zeno"))))
+                    .collect::<Vec<_>>();
+                for search in searches {
+                    let hits = search
+                        .join()
+                        .expect("search thread")
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "{concurrency} concurrent searches must all be served: {error:?}"
+                            )
+                        });
+                    assert_eq!(
+                        hits.data.results.len(),
+                        2,
+                        "a served search must still return both Vaults' matches"
+                    );
+                }
+            });
+        }
+    }
+
+    /// Every production embedder runs inference behind its own `Mutex`, so
+    /// concurrent semantic searches queue on it one at a time. A search that
+    /// took its reader slot first would pin that slot for the whole wait while
+    /// touching no database at all, and four typed-ahead searches were enough
+    /// to starve an unrelated `/tree` or `/recent` read.
+    #[test]
+    fn a_search_holds_no_reader_slot_while_the_embedder_serializes() {
+        let workspace =
+            file_backed_workspace(&[("First", &[("Home.md", "# Home\n\nzeno needle")])]);
+        let (arrived_tx, arrived_rx) = mpsc::channel();
+        let release = Arc::new((std::sync::Mutex::new(false), Condvar::new()));
+        let embedder = SerializedSlowEmbedder {
+            inner: StubEmbedder::new(384),
+            model: std::sync::Mutex::new(()),
+            arrived: arrived_tx,
+            release: release.clone(),
+        };
+        let core = VaultSearchCore::new(&workspace.cache, &workspace.vaults, &embedder);
+
+        std::thread::scope(|scope| {
+            let searches = (0..4)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let mut semantic = request(VaultScope::All, "zeno");
+                        semantic.mode = SearchMode::Semantic;
+                        core.search(semantic)
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            // Hold every search inside the embedder at once, the state four
+            // typed-ahead queries reach in production. A search that never
+            // arrives fails here rather than hanging the test.
+            for index in 0..4 {
+                arrived_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .unwrap_or_else(|_| panic!("search {index} never reached the embedder"));
+            }
+            // The lease count is the assertion that isolates this from the
+            // reader queue: with a slot held across inference the sidebar read
+            // would merely be delayed until one search finished, and a test
+            // that only checked `is_ok` would pass on the queue alone.
+            let held = workspace.cache.active_read_leases();
+            let sidebar = workspace
+                .cache
+                .snapshot_note_content(workspace.vault_ids[0], "home");
+
+            let (released, wake) = &*release;
+            *released
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+            wake.notify_all();
+
+            for search in searches {
+                search
+                    .join()
+                    .expect("search thread")
+                    .expect("a search held behind the embedder must still complete");
+            }
+            assert_eq!(
+                held, 0,
+                "four searches inside the embedder must hold no reader slot between them"
+            );
+            assert!(
+                sidebar.is_ok(),
+                "an unrelated read was starved by searches waiting on the embedder: {:?}",
+                sidebar.err()
+            );
+        });
+    }
+
+    /// Stands in for the production embedders, which all wrap inference in a
+    /// `Mutex` (see `fastembed_embedder.rs`). Announces each arrival and then
+    /// parks until the test releases it, so every caller can be held inside
+    /// inference at once.
+    struct SerializedSlowEmbedder {
+        inner: StubEmbedder,
+        model: std::sync::Mutex<()>,
+        arrived: mpsc::Sender<()>,
+        release: Arc<(std::sync::Mutex<bool>, Condvar)>,
+    }
+
+    impl Embedder for SerializedSlowEmbedder {
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+            self.arrived.send(()).expect("announce arrival");
+            let (released, wake) = &*self.release;
+            let mut parked = released
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            // Bounded so a failing assertion ends the test rather than
+            // leaving these threads parked for the scope to join forever.
+            while !*parked {
+                let (next, wait) = wake
+                    .wait_timeout(parked, Duration::from_secs(5))
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                parked = next;
+                if wait.timed_out() {
+                    break;
+                }
+            }
+            drop(parked);
+            let _inference = self
+                .model
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            self.inner.embed(texts)
+        }
+
+        fn embedding_dim(&self) -> usize {
+            self.inner.embedding_dim()
+        }
+
+        fn identity(&self) -> String {
+            self.inner.identity()
+        }
+
+        fn token_count(&self, text: &str, add_special_tokens: bool) -> Result<usize, String> {
+            self.inner.token_count(text, add_special_tokens)
         }
     }
 


### PR DESCRIPTION
## The report

A deployed instance answered `/search`, `/tree` and `/recent` with 503s at 0 ms latency, sustained for ~30 seconds, across both Vaults and the `all` scope. The search modal showed `SQLite read connection limit (4) reached; retry shortly`.

## Cause

Not a leak. `VaultSearchCore::search` checked out one of the cache's four file-backed reader slots and *then* called the embedder. Every production embedder wraps inference in a `Mutex` (`src/embed/fastembed_embedder.rs:21`), so concurrent semantic searches queued on that lock one at a time, each still holding a reader slot while touching no database at all.

Search-as-you-type (`zen` → `zeno` → `zenoc` in the logs) put four of those in flight, which pinned every slot. Anything else was rejected on arrival, which is the 0 ms latency. Both Vault IDs and `all` failed together because the lease counter is per-process: one cache serves the whole collection.

Reproduced against a file-backed cache: the instrumented probe printed `leases=4` alongside the reported error for an unrelated sidebar read.

## Changes

- **Embed before checking out the read snapshot.** Inference needs no database, so the slot is now held only for the SQLite work.
- **A caller at the ceiling waits for the next free slot** instead of taking an immediate error. `MAX_READ_CONNECTIONS` bounds how many SQLite handles exist at once; it was never a load-shedding policy, and rejecting a request that a free slot would serve microseconds later is what turned a burst into an outage. The wait runs on Tokio's blocking pool (ADR-19 routes all reads through `spawn_blocking`), so it cannot stall an async worker.

## Accepted trade-off

Hoisting the embed moves two things ahead of the snapshot read, both visible only when the embedder is unhealthy: a query whose Vaults do not participate is embedded anyway, and an unhealthy embedder is reported ahead of a bad layer name or an unavailable single Vault. Detecting either first needs the pinned generation, which would mean holding the slot across inference again. Recorded in the module map rather than worked around.

## ADR-15

This reorders code on the retrieval path, which ADR-15 covers. Reviewed and judged quality-neutral by inspection rather than by an eval run: the query is embedded from the same text with the same model into the same vector, and that vector is fed to the same KNN with the same candidate counts and filters. Only the order of two independent steps changed, so no metric the harness reports can move. Owner's call, recorded here.

## Tests

The reader ceiling is only accounted for file-backed caches, and every existing test built its cache with `SqliteCache::in_memory`, so nothing in the suite could observe this. Both regression tests use a new file-backed workspace.

`a_search_holds_no_reader_slot_while_the_embedder_serializes` asserts the lease count, not just a successful read: the reader queue alone would otherwise turn it green with the hoist reverted. Verified red at `left: 4, right: 0` with only the hoist reverted, and it fails rather than hangs if a search never reaches the embedder.

1104 tests pass, clippy clean, `just docs-freshness` acknowledged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DzvLcQ7xv5fERmJtvZUvT
