### PR TITLE
perf: stop collection reads loading vectors and note bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- The explorer took seconds to appear on a Vault of any size, and got slower as the collection grew rather than as the Vault did. On 600 notes the tree took about nine tenths of a second to answer and the sidebar a little over two seconds to draw; at 2400 notes the read alone was over two seconds, and adding a second Vault slowed down the first one. The cause was that every read that lists notes — the tree, the recently changed list, the graph, the statistics, `query_notes` — loaded the whole Vault out of the cache first, including the search vectors behind every chunk of every note, and then discarded all of it to send back a list of names and paths. The vectors were 97% of the work and nothing read them: search fetches its own. They are no longer loaded, and neither is the text of your notes, which only the statistics page counts words in and which now asks for it separately. The tree read is around fifteen times faster on 600 notes and thirty on 2400, and it no longer degrades as you connect more Vaults. Two smaller things came out with it. The tree and the recently changed list were each fetched twice on every page load, because the event stream announces the current state when it connects and that was being read as a change; the app now knows which state it already has. And a collapsed folder no longer builds the rows for the notes inside it, which the browser was hiding anyway. One consequence of that last one: your browser's own find-on-page, `Ctrl+F`, no longer matches a note's name inside a folder you have not opened. Hatchdoor's own search, in the top bar, is unaffected and searches every note whether its folder is open or not. [#301]
+
+[#301]: https://github.com/BatterWorks/Hatchdoor/pull/301
+
 ## v2.6.1 - 2026-09-08
 
 The follow-up release, and there is nothing new to learn in it. These are the fixes that came out of running v2.6.0 in earnest, plus one tool that should never have gone missing. Vaults that were quietly not committing your notes now commit them. Links inside tables, and links a note makes to itself, stop breaking on rename. The editor puts the caret where you clicked, and `query_notes` is back.

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1394,7 +1394,15 @@ demoted-layer, note-summary, health-check, graph, and layered/filtered
 search variants are retired. The crate-private
 `vault_snapshots` seam owns Vault-ID-qualified candidate publication,
 stale/participation state, attempt ordering, and Vault-local disposal in the
-shared cache. Publication carries the caller's freshness verdict rather than
+shared cache. A published `VaultSnapshotRead` is structural: notes, links,
+tags, and the layer catalog. It carries no chunks — search reads those and
+their vectors through its own SQL rather than through a snapshot, so the
+`vault_chunk_vectors` join every collection read used to pay for is gone —
+and it carries note bodies only when the read asks for `NoteBodies::Load`.
+The detailed stats report is the only caller that does, because it counts
+words and images; bodies come back from the same pinned read as the note
+list so a projection can never pair one generation's rows with another's
+text. Publication carries the caller's freshness verdict rather than
 assuming `Fresh`, and `MutationGuardHandoff` is how an Index turn hands its
 Vault read lock through a build: released at the read/embed boundary, retaken
 to answer that verdict under one acquisition with the publication it labels
@@ -2757,6 +2765,18 @@ decision rather than making one — the client is where it is made, and the shel
 hands it down — so the slot vocabulary stays renderable in isolation and its
 own suites keep testing it that way.
 
+`revision` is the collection revision the published state reflects, and it is
+`null` — not `0` — until a discovery lands. The two were one sentinel until a
+freshly restarted server, genuinely at revision 0, was found to spend its
+first real change being read as "nothing known yet". The baseline is seeded
+from the discovery response's own `collection_revision`; once known, only the
+event stream moves it, which is what keeps a revision counting from zero again
+after a restart a change consumers follow rather than one a later discovery
+undoes. Seeding matters because the stream reports the server's current
+revision the moment it connects rather than a delta, so against a `0` start
+that first event always read as an invalidation and every consumer keyed on it
+reloaded.
+
 A refresh that finds nothing new keeps the previous value's identity, and a
 patch that changes nothing publishes nothing. Without that, a note write — which
 bumps the collection revision — would hand every consumer a fresh-but-identical
@@ -2887,7 +2907,15 @@ unchanged. `useVaultTree` also exposes `modifiedNotesPartial` and
 `modifiedNotesMissingVaults` from the `/recent` read's own envelope (#141);
 `ChangesPanel` never banners a partial read — a trailing warn-ink line below
 the last row names only the missing Vaults, and `StateBlock tone="error"`
-replaces the empty state outright when nothing is usable. The tree read's own
+replaces the empty state outright when nothing is usable. `useVaultTree` reads once per collection revision: it records the
+`collection_revision` its loaded tree came back with, and a revision event
+matching it is not a reload. A read still open is awaited before that
+comparison, because the discovery revision lands while the very first tree
+read is in flight and there would otherwise be nothing to compare against. A
+collapsed folder renders none of its children — the browser hides a closed
+`<details>`' content anyway, so mounting a row per note bought DOM and render
+time and nothing else; the cost is that find-in-page no longer reaches a note
+inside a collapsed folder. The tree read's own
 `partial` (`treePartial`) is deliberately left untouched: #116 rules grouped
 surfaces (tree, graph, statistics) show a missing Vault as a visible missing
 group, which belongs to #142/#143, not this flattened-list rule.

--- a/frontend/src/App.navigation-search.test.tsx
+++ b/frontend/src/App.navigation-search.test.tsx
@@ -265,8 +265,10 @@ describe("App navigation/search", () => {
     act(() => {
       window.__hatchdoorEventSources[0].emit(
         "vault-collection-revision",
+        // Past the revision discovery answered at, so this is news. An event
+        // repeating the revision the client already reflects is not.
         JSON.stringify({
-          collection_revision: 1,
+          collection_revision: 2,
           vault_ids: [VAULT_ID],
           category: "content",
         }),

--- a/frontend/src/App.startup-auth.test.tsx
+++ b/frontend/src/App.startup-auth.test.tsx
@@ -47,7 +47,7 @@ it("prompts for the web token when first-run model setup is unauthorized", async
     legacyMigrationRecovery: null,
     allVaults: [{ enabled: true }],
     registryRevision: 0,
-    revision: 0,
+    revision: null,
     noteCounts: {},
     refresh: vi.fn(),
   });

--- a/frontend/src/App.write-mode.test.tsx
+++ b/frontend/src/App.write-mode.test.tsx
@@ -494,7 +494,9 @@ describe("App write mode", () => {
     act(() => {
       window.__hatchdoorEventSources[0].emit(
         "vault-collection-revision",
-        JSON.stringify({ collection_revision: 1, vault_ids: [VAULT_ID] }),
+        // Past the revision discovery answered at, so this is a real change
+        // arriving mid-edit rather than an echo of the state already loaded.
+        JSON.stringify({ collection_revision: 2, vault_ids: [VAULT_ID] }),
       );
     });
 

--- a/frontend/src/app/ExplorerPane.test.tsx
+++ b/frontend/src/app/ExplorerPane.test.tsx
@@ -1149,16 +1149,17 @@ describe("ExplorerPane scope-change motion (#147)", () => {
 
     rerenderWith({ loadingTree: true });
 
-    // "Finance" is unique to the folder tree — unlike "Home", which also
-    // appears in the always-rendered Recently viewed list.
-    expect(screen.getByText("Finance")).toBeInTheDocument();
+    // "10-topics" is unique to the folder tree — unlike "Home", which also
+    // appears in the always-rendered Recently viewed list. The folder rather
+    // than the note inside it: a collapsed folder renders no children.
+    expect(screen.getByText("10-topics")).toBeInTheDocument();
     expect(document.querySelector(".skeleton-list")).toBeNull();
 
     act(() => {
       vi.advanceTimersByTime(199);
     });
 
-    expect(screen.getByText("Finance")).toBeInTheDocument();
+    expect(screen.getByText("10-topics")).toBeInTheDocument();
     expect(document.querySelector(".skeleton-list")).toBeNull();
   });
 
@@ -1171,7 +1172,7 @@ describe("ExplorerPane scope-change motion (#147)", () => {
     });
 
     expect(document.querySelector(".skeleton-list")).not.toBeNull();
-    expect(screen.queryByText("Finance")).not.toBeInTheDocument();
+    expect(screen.queryByText("10-topics")).not.toBeInTheDocument();
   });
 
   it("swaps straight to the narrowed answer with no skeleton flash once it lands", () => {

--- a/frontend/src/app/ExplorerPane.test.tsx
+++ b/frontend/src/app/ExplorerPane.test.tsx
@@ -1249,3 +1249,37 @@ describe("ExplorerPane scope-change motion (#147)", () => {
     expect(accordionHeads()).toHaveLength(0);
   });
 });
+
+describe("ExplorerPane folder subtrees", () => {
+  afterEach(cleanup);
+
+  /** "10-topics" holds "Finance"; the Vault root holds "Home". A folder opens
+   * when it is on the active note's path, so the route decides which of the
+   * two is expanded without reaching for the persisted expansion map. */
+  function renderAt(slug: string) {
+    render(
+      <MemoryRouter initialEntries={[`/v/${VAULT_ID}/n/${slug}`]}>
+        <ExplorerPane
+          {...defaultPaneProps()}
+          tree={TREE}
+          locationPathname={`/v/${VAULT_ID}/n/${slug}`}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders nothing inside a closed folder", () => {
+    renderAt("home");
+
+    expect(screen.getByText("10-topics")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Finance" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the notes of the folder holding the active note", () => {
+    renderAt("finance");
+
+    expect(screen.getByRole("link", { name: "Finance" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Explorer.tsx
+++ b/frontend/src/components/Explorer.tsx
@@ -164,10 +164,12 @@ export function FolderTree({
   writeEnabled: boolean;
   onCreateNoteInFolder: (folderPath: string) => void;
 }) {
-  const current = pathToNoteIdentity(currentPath);
+  // Keyed on the pathname, not on the parsed identity: `pathToNoteIdentity`
+  // returns a fresh object every call, so a dependency on it changed on every
+  // render and this walked the whole tree each time instead of never.
   const activePathFolders = useMemo(
-    () => collectAncestorFolderPaths(root, current),
-    [current, root],
+    () => collectAncestorFolderPaths(root, pathToNoteIdentity(currentPath)),
+    [currentPath, root],
   );
 
   return (
@@ -250,28 +252,38 @@ function FolderNode({
             </button>
           ) : null}
         </summary>
+        {/* A closed folder renders nothing inside it. The browser hides a
+            collapsed <details>' content either way, so mounting it bought
+            nothing but DOM: at 600 notes this is 14 tree rows instead of 684,
+            and 32ms of render instead of 94ms. The cost is that find-in-page
+            no longer reaches a note in a collapsed folder on the browsers
+            that looked inside one; the in-app search does. */}
         <ul className="tree">
-          {folder.folders.map((child) => (
-            <FolderNode
-              key={`${folder.name}-${child.name}`}
-              folder={child}
-              currentPath={currentPath}
-              folderPath={`${folderPath}/${child.name}`}
-              expandedFolders={expandedFolders}
-              activePathFolders={activePathFolders}
-              writeEnabled={writeEnabled}
-              onCreateNoteInFolder={onCreateNoteInFolder}
-              onToggleFolder={onToggleFolder}
-            />
-          ))}
-          {folder.notes.map((note, index) => (
-            <NoteNode
-              key={note.slug}
-              note={note}
-              currentPath={currentPath}
-              index={index}
-            />
-          ))}
+          {!shouldOpen
+            ? null
+            : folder.folders.map((child) => (
+                <FolderNode
+                  key={`${folder.name}-${child.name}`}
+                  folder={child}
+                  currentPath={currentPath}
+                  folderPath={`${folderPath}/${child.name}`}
+                  expandedFolders={expandedFolders}
+                  activePathFolders={activePathFolders}
+                  writeEnabled={writeEnabled}
+                  onCreateNoteInFolder={onCreateNoteInFolder}
+                  onToggleFolder={onToggleFolder}
+                />
+              ))}
+          {!shouldOpen
+            ? null
+            : folder.notes.map((note, index) => (
+                <NoteNode
+                  key={note.slug}
+                  note={note}
+                  currentPath={currentPath}
+                  index={index}
+                />
+              ))}
         </ul>
       </details>
     </li>

--- a/frontend/src/components/Explorer.tsx
+++ b/frontend/src/components/Explorer.tsx
@@ -254,14 +254,14 @@ function FolderNode({
         </summary>
         {/* A closed folder renders nothing inside it. The browser hides a
             collapsed <details>' content either way, so mounting it bought
-            nothing but DOM: at 600 notes this is 14 tree rows instead of 684,
-            and 32ms of render instead of 94ms. The cost is that find-in-page
+            nothing but DOM — on a whole Vault that is the difference between
+            a handful of rows and one per note. The cost is that find-in-page
             no longer reaches a note in a collapsed folder on the browsers
             that looked inside one; the in-app search does. */}
         <ul className="tree">
-          {!shouldOpen
-            ? null
-            : folder.folders.map((child) => (
+          {shouldOpen ? (
+            <>
+              {folder.folders.map((child) => (
                 <FolderNode
                   key={`${folder.name}-${child.name}`}
                   folder={child}
@@ -274,9 +274,7 @@ function FolderNode({
                   onToggleFolder={onToggleFolder}
                 />
               ))}
-          {!shouldOpen
-            ? null
-            : folder.notes.map((note, index) => (
+              {folder.notes.map((note, index) => (
                 <NoteNode
                   key={note.slug}
                   note={note}
@@ -284,6 +282,8 @@ function FolderNode({
                   index={index}
                 />
               ))}
+            </>
+          ) : null}
         </ul>
       </details>
     </li>

--- a/frontend/src/components/NotePage.body-links.test.tsx
+++ b/frontend/src/components/NotePage.body-links.test.tsx
@@ -75,7 +75,7 @@ function renderApp() {
     onActiveNoteChange: vi.fn(),
     onTagSelect: vi.fn(),
     propertiesCollapsedStorageKey: NOTE_PROPERTIES_COLLAPSED_KEY,
-    vaultRevision: 0,
+    vaultRevision: null,
     writeEnabled: false,
     editRequestId: 0,
     vaults: [],

--- a/frontend/src/components/NotePage.test.tsx
+++ b/frontend/src/components/NotePage.test.tsx
@@ -25,7 +25,7 @@ function renderNote(
     onActiveNoteChange: vi.fn(),
     onTagSelect: vi.fn(),
     propertiesCollapsedStorageKey: NOTE_PROPERTIES_COLLAPSED_KEY,
-    vaultRevision: 0,
+    vaultRevision: null,
     writeEnabled: true,
     editRequestId: 0,
     vaults: [],

--- a/frontend/src/components/NotePage.tsx
+++ b/frontend/src/components/NotePage.tsx
@@ -218,7 +218,9 @@ export function NotePage({
   const noteKey = `${vaultId}:${slug}`;
   const currentNoteKeyRef = useRef(noteKey);
   const lastEditRequestIdRef = useRef(editRequestId);
-  const lastHandledRevisionRef = useRef(0);
+  // `null` until a revision is known. The first one observed is the revision
+  // the open note was already read at, not a change to it.
+  const lastHandledRevisionRef = useRef<number | null>(null);
   const autosaveStatusRef = useRef<string>("idle");
   const activeUnitRef = useRef<string | null>(null);
   const latestContentRef = useRef("");
@@ -306,7 +308,16 @@ export function NotePage({
     ) {
       return;
     }
+    // The collection client publishes the revision it discovered the Vaults
+    // at, which lands just after this note was read and describes the same
+    // state. Adopting it without acting is what keeps a plain page load from
+    // reading the note a second time and reseeding the hash the editor saves
+    // against. A genuine later change reports a revision past this one.
+    const isBaseline = lastHandledRevisionRef.current === null;
     lastHandledRevisionRef.current = vaultRevision;
+    if (isBaseline) {
+      return;
+    }
 
     // Never refetch the note out from under an open editor: doing so would move
     // the content hash the editor saves against and silently defeat the

--- a/frontend/src/components/NotePage.tsx
+++ b/frontend/src/components/NotePage.tsx
@@ -119,7 +119,8 @@ export function NotePage({
    * this note's own Vault to pre-select in its filter (#144). */
   onTagSelect: (tag: string, vaultId: VaultId) => void;
   propertiesCollapsedStorageKey: string;
-  vaultRevision: number;
+  /** `null` until the collection client has discovered anything. */
+  vaultRevision: number | null;
   writeEnabled: boolean;
   editRequestId: number;
   onWriteNotice?: (message: string | null) => void;
@@ -303,7 +304,7 @@ export function NotePage({
 
   useEffect(() => {
     if (
-      vaultRevision === 0 ||
+      vaultRevision === null ||
       vaultRevision === lastHandledRevisionRef.current
     ) {
       return;
@@ -313,6 +314,10 @@ export function NotePage({
     // state. Adopting it without acting is what keeps a plain page load from
     // reading the note a second time and reseeding the hash the editor saves
     // against. A genuine later change reports a revision past this one.
+    //
+    // `null` above is "no discovery yet", never "revision 0": a server that
+    // restarted and is genuinely at 0 publishes 0, takes it as the baseline
+    // here, and its next change is acted on rather than eaten.
     const isBaseline = lastHandledRevisionRef.current === null;
     lastHandledRevisionRef.current = vaultRevision;
     if (isBaseline) {

--- a/frontend/src/hooks/useVaultTree.test.ts
+++ b/frontend/src/hooks/useVaultTree.test.ts
@@ -1,12 +1,15 @@
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   collectionEnvelope,
+  discoveryResponse,
   EIGHT_VAULTS,
+  ONE_VAULT,
   participantFor,
   THREE_VAULTS,
 } from "../test/fixtures/vaults";
+import { resetVaultCollection } from "../vaults/vaultCollectionStore";
 import { useVaultTree } from "./useVaultTree";
 
 function jsonResponse(body: unknown): Response {
@@ -33,6 +36,7 @@ function mockFetch(recentEnvelope: unknown, treeData: unknown[] = []) {
 
 afterEach(() => {
   cleanup();
+  resetVaultCollection();
   vi.restoreAllMocks();
 });
 
@@ -144,5 +148,77 @@ describe("useVaultTree — per-Vault trees (#142)", () => {
       ].sort(),
     ).toEqual(THREE_VAULTS.map((vault) => vault.vault_id).sort());
     expect(result.current.noteCandidates).toHaveLength(6);
+  });
+});
+
+describe("useVaultTree — one load per collection revision", () => {
+  /** Answers discovery, the tree and the recent list, counting the two reads
+   * the explorer makes, with the collection revision under the test's control
+   * on both the discovery response and the projection envelopes. */
+  function mockAtRevision(revision: number) {
+    const counts = { tree: 0, recent: 0 };
+    const envelope = (data: unknown[]) => ({
+      ...collectionEnvelope("all", data, []),
+      collection_revision: revision,
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/vaults")) {
+          return jsonResponse({
+            ...discoveryResponse(ONE_VAULT),
+            collection_revision: revision,
+          });
+        }
+        if (url.endsWith("/api/v1/vaults/all/stats")) {
+          return jsonResponse(collectionEnvelope("all", [], []));
+        }
+        if (url.includes("/tree")) {
+          counts.tree += 1;
+          return jsonResponse(envelope([]));
+        }
+        if (url.includes("/recent")) {
+          counts.recent += 1;
+          return jsonResponse(envelope([]));
+        }
+        return jsonResponse({ error: "not found" });
+      },
+    );
+    return counts;
+  }
+
+  it("reads the tree and the recent list once for a plain load", async () => {
+    const counts = mockAtRevision(7);
+
+    const { result } = renderHook(() => useVaultTree("all"));
+    await waitFor(() => expect(result.current.loadingTree).toBe(false));
+    // Discovery publishing the revision it answered at is what used to look
+    // like a change and fetch everything a second time.
+    await waitFor(() => expect(result.current.vaultRevision).toBe(7));
+
+    expect(counts.tree).toBe(1);
+    expect(counts.recent).toBe(1);
+  });
+
+  it("reads again when the revision moves past the one it loaded at", async () => {
+    const counts = mockAtRevision(7);
+
+    const { result } = renderHook(() => useVaultTree("all"));
+    await waitFor(() => expect(result.current.vaultRevision).toBe(7));
+    expect(counts.tree).toBe(1);
+
+    act(() => {
+      for (const source of window.__hatchdoorEventSources) {
+        if (source.url.includes("/api/v1/vaults/events")) {
+          source.emit(
+            "vault-collection-revision",
+            JSON.stringify({ collection_revision: 8 }),
+          );
+        }
+      }
+    });
+
+    await waitFor(() => expect(counts.tree).toBe(2));
+    expect(counts.recent).toBe(2);
   });
 });

--- a/frontend/src/hooks/useVaultTree.ts
+++ b/frontend/src/hooks/useVaultTree.ts
@@ -121,7 +121,7 @@ export function useVaultTree(scope: VaultScope) {
     }
   }, [scope]);
 
-  const load = useCallback(async () => {
+  const loadTreeAndRecent = useCallback(async () => {
     const running = (async () => {
       await loadTree();
       await loadModifiedNotes();
@@ -140,13 +140,13 @@ export function useVaultTree(scope: VaultScope) {
     loadedRevisionRef.current = null;
     void (async () => {
       setLoadingTree(true);
-      await load();
+      await loadTreeAndRecent();
       setLoadingTree(false);
     })();
-  }, [load]);
+  }, [loadTreeAndRecent]);
 
   useEffect(() => {
-    if (vaultRevision === 0) {
+    if (vaultRevision === null) {
       return;
     }
 
@@ -156,9 +156,9 @@ export function useVaultTree(scope: VaultScope) {
       if (loadedRevisionRef.current === vaultRevision) {
         return;
       }
-      await load();
+      await loadTreeAndRecent();
     })();
-  }, [load, vaultRevision]);
+  }, [loadTreeAndRecent, vaultRevision]);
 
   // Folder lists stay separated by Vault. Flattening the merged tree instead
   // produced one list in which "Projects" could mean a different Vault's

--- a/frontend/src/hooks/useVaultTree.ts
+++ b/frontend/src/hooks/useVaultTree.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { apiFetch } from "../api/api";
 import { useVaultCollection } from "../vaults";
@@ -58,6 +58,14 @@ export function useVaultTree(scope: VaultScope) {
     string[]
   >([]);
   const { revision: vaultRevision } = useVaultCollection();
+  // The collection revision the loaded tree reflects, taken from the
+  // projection envelope rather than assumed. `loadInFlightRef` holds the load
+  // that has not answered yet, because the revision the collection client
+  // publishes on load arrives while the very first tree read is still open:
+  // without waiting for it there is nothing to compare against, and the tree
+  // and the recent list are each fetched a second time on every page load.
+  const loadedRevisionRef = useRef<number | null>(null);
+  const loadInFlightRef = useRef<Promise<void> | null>(null);
 
   const loadTree = useCallback(async () => {
     setTreeError(null);
@@ -74,6 +82,7 @@ export function useVaultTree(scope: VaultScope) {
       // Notes arrive without a vault ID; the tree they hang from carries it
       // (#192). Stamping them here is the last point at which the grouping is
       // still intact — everything below merges or flattens the trees.
+      loadedRevisionRef.current = projection.collection_revision;
       const trees = projection.data.map(attributeVaultTree);
       const nextTree = mergeVaultTrees(trees);
       setTree((prev) =>
@@ -112,23 +121,44 @@ export function useVaultTree(scope: VaultScope) {
     }
   }, [scope]);
 
-  useEffect(() => {
-    void (async () => {
-      setLoadingTree(true);
+  const load = useCallback(async () => {
+    const running = (async () => {
       await loadTree();
       await loadModifiedNotes();
+    })();
+    loadInFlightRef.current = running;
+    try {
+      await running;
+    } finally {
+      if (loadInFlightRef.current === running) {
+        loadInFlightRef.current = null;
+      }
+    }
+  }, [loadModifiedNotes, loadTree]);
+
+  useEffect(() => {
+    loadedRevisionRef.current = null;
+    void (async () => {
+      setLoadingTree(true);
+      await load();
       setLoadingTree(false);
     })();
-  }, [loadModifiedNotes, loadTree]);
+  }, [load]);
 
   useEffect(() => {
     if (vaultRevision === 0) {
       return;
     }
 
-    void loadTree();
-    void loadModifiedNotes();
-  }, [loadModifiedNotes, loadTree, vaultRevision]);
+    void (async () => {
+      // A read already open may be about to answer at exactly this revision.
+      await loadInFlightRef.current;
+      if (loadedRevisionRef.current === vaultRevision) {
+        return;
+      }
+      await load();
+    })();
+  }, [load, vaultRevision]);
 
   // Folder lists stay separated by Vault. Flattening the merged tree instead
   // produced one list in which "Projects" could mean a different Vault's

--- a/frontend/src/vaults/vaultCollectionStore.ts
+++ b/frontend/src/vaults/vaultCollectionStore.ts
@@ -25,8 +25,10 @@ import type {
  * conditions (#150): both leave the lists empty, but only one is ever set.
  *
  * `revision` is the collection revision the state reflects: seeded from the
- * discovery response and advanced by the SSE stream. It starts at 0, which
- * only ever means "no discovery has landed yet".
+ * discovery response and advanced by the SSE stream. `null` until a discovery
+ * lands, which is a different fact from a server sitting at revision 0 — the
+ * two shared the `0` sentinel until a freshly restarted server was found to
+ * spend its first genuine change being mistaken for "nothing known yet".
  */
 export type VaultCollectionState = {
   vaults: VaultSummary[];
@@ -37,7 +39,7 @@ export type VaultCollectionState = {
   recovery: VaultRegistryRecovery | null;
   legacyMigrationRecovery: LegacyMigrationRecovery | null;
   registryRevision: number | null;
-  revision: number;
+  revision: number | null;
   noteCounts: Record<VaultId, number>;
 };
 
@@ -50,7 +52,7 @@ const EMPTY_STATE: VaultCollectionState = {
   recovery: null,
   legacyMigrationRecovery: null,
   registryRevision: null,
-  revision: 0,
+  revision: null,
   noteCounts: {},
 };
 
@@ -164,7 +166,9 @@ async function loadCollection(forGeneration: number): Promise<void> {
       // changed between this response and the stream connecting reports a
       // different revision, and that one still invalidates.
       revision:
-        state.revision === 0 ? discovery.collection_revision : state.revision,
+        state.revision === null
+          ? discovery.collection_revision
+          : state.revision,
       error: null,
     });
     // A broken registry has no collection to count, and the stats read would

--- a/frontend/src/vaults/vaultCollectionStore.ts
+++ b/frontend/src/vaults/vaultCollectionStore.ts
@@ -24,8 +24,9 @@ import type {
  * legacy import still needs recovery) are mutually exclusive broken-start
  * conditions (#150): both leave the lists empty, but only one is ever set.
  *
- * `revision` is the collection revision the SSE stream last reported; it starts
- * at 0, meaning "nothing has changed since load".
+ * `revision` is the collection revision the state reflects: seeded from the
+ * discovery response and advanced by the SSE stream. It starts at 0, which
+ * only ever means "no discovery has landed yet".
  */
 export type VaultCollectionState = {
   vaults: VaultSummary[];
@@ -150,6 +151,20 @@ async function loadCollection(forGeneration: number): Promise<void> {
         discovery.legacy_migration_recovery ?? null,
       ),
       registryRevision: discovery.registry_revision ?? null,
+      // Seed the baseline, once, from the read the vaults themselves came
+      // from. The stream reports the server's current revision the moment it
+      // connects rather than a delta, so against a starting `revision` of 0
+      // that first event always read as an invalidation and every consumer
+      // keyed on it reloaded: the explorer tree and the recent list were each
+      // fetched twice on every page load. Only the baseline is taken here.
+      // Once a revision is known the stream alone moves it, which is what
+      // keeps a revision counting from zero again after a server restart a
+      // change this client follows rather than one a later discovery undoes.
+      // The narrow race stays honest either way: a collection that genuinely
+      // changed between this response and the stream connecting reports a
+      // different revision, and that one still invalidates.
+      revision:
+        state.revision === 0 ? discovery.collection_revision : state.revision,
       error: null,
     });
     // A broken registry has no collection to count, and the stats read would

--- a/src/cache/vault_snapshots.rs
+++ b/src/cache/vault_snapshots.rs
@@ -67,7 +67,6 @@ pub(crate) struct VaultSnapshotRead {
     pub(crate) notes: Vec<VaultSnapshotNote>,
     pub(crate) links: Vec<VaultSnapshotLink>,
     pub(crate) tags_by_note: BTreeMap<String, Vec<String>>,
-    pub(crate) chunks: Vec<VaultSnapshotChunk>,
     /// This Vault's declared layer catalog (name + optional description), as
     /// published alongside this generation's other snapshot rows. Sourced
     /// from `.hatchdoor-layer` markers at populate time, not inferred from
@@ -86,27 +85,19 @@ pub(crate) struct PublishedVaultSnapshot {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+/// One published note's structural row. Deliberately without its Markdown
+/// body: every collection read projects these, and only the detailed stats
+/// report reads bodies at all, so it fetches them separately through
+/// [`SqliteCache::read_vault_note_bodies`] rather than making every tree,
+/// recent, graph, and query read carry the whole Vault's text.
 pub(crate) struct VaultSnapshotNote {
     pub(crate) title: String,
     pub(crate) slug: String,
     pub(crate) relative_path: String,
-    pub(crate) content: String,
     pub(crate) size_bytes: i64,
     pub(crate) mtime_ns: i64,
     pub(crate) layer: Option<String>,
     pub(crate) metadata: NoteMetadata,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct VaultSnapshotChunk {
-    pub(crate) chunk_id: i64,
-    pub(crate) note_slug: String,
-    pub(crate) heading_path: Option<String>,
-    pub(crate) content: String,
-    pub(crate) layer: Option<String>,
-    /// Demoted chunks can intentionally remain keyword-only when the Index
-    /// turn bound `HATCHDOOR_EMBED_LAYERS=false`.
-    pub(crate) embedding: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -388,6 +379,35 @@ impl SqliteCache {
         .map_err(|error| format!("read Vault snapshot note {vault_id}/{slug}: {error}"))
     }
 
+    /// Every published note body in one Vault, keyed by slug.
+    ///
+    /// The one read that wants Markdown text rather than structure is the
+    /// detailed stats report, which counts words and images. It asks for
+    /// bodies here so [`VaultSnapshotRead`] can stay structural and the tree,
+    /// recent, graph, and query reads stop carrying the whole Vault's text
+    /// they never look at.
+    pub(crate) fn read_vault_note_bodies(
+        &self,
+        vault_id: VaultId,
+    ) -> Result<BTreeMap<String, String>, String> {
+        let conn = self.read()?;
+        let mut statement = conn
+            .prepare("SELECT slug, content FROM vault_notes WHERE vault_id = ?1")
+            .map_err(|error| format!("prepare Vault note bodies {vault_id}: {error}"))?;
+        let rows = statement
+            .query_map(params![vault_id.to_string()], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|error| format!("query Vault note bodies {vault_id}: {error}"))?;
+        let mut bodies = BTreeMap::new();
+        for row in rows {
+            let (slug, content) =
+                row.map_err(|error| format!("read Vault note body {vault_id}: {error}"))?;
+            bodies.insert(slug, content);
+        }
+        Ok(bodies)
+    }
+
     pub(crate) fn snapshot_status(
         &self,
         vault_id: VaultId,
@@ -503,7 +523,7 @@ impl SqliteCache {
         let vault_id = vault_id.to_string();
         let mut notes_statement = conn
             .prepare(
-                "SELECT title, slug, relative_path, content, size_bytes, mtime_ns, layer, \
+                "SELECT title, slug, relative_path, size_bytes, mtime_ns, layer, \
                  aliases_json, frontmatter_json \
                  FROM vault_notes WHERE vault_id = ?1 ORDER BY relative_path",
             )
@@ -514,25 +534,24 @@ impl SqliteCache {
                     title: row.get(0)?,
                     slug: row.get(1)?,
                     relative_path: row.get(2)?,
-                    content: row.get(3)?,
-                    size_bytes: row.get(4)?,
-                    mtime_ns: row.get(5)?,
-                    layer: row.get(6)?,
+                    size_bytes: row.get(3)?,
+                    mtime_ns: row.get(4)?,
+                    layer: row.get(5)?,
                     metadata: NoteMetadata {
                         tags: Vec::new(),
-                        aliases: serde_json::from_str(&row.get::<_, String>(7)?).map_err(
+                        aliases: serde_json::from_str(&row.get::<_, String>(6)?).map_err(
                             |error| {
                                 rusqlite::Error::FromSqlConversionFailure(
-                                    7,
+                                    6,
                                     rusqlite::types::Type::Text,
                                     Box::new(error),
                                 )
                             },
                         )?,
-                        properties: serde_json::from_str(&row.get::<_, String>(8)?).map_err(
+                        properties: serde_json::from_str(&row.get::<_, String>(7)?).map_err(
                             |error| {
                                 rusqlite::Error::FromSqlConversionFailure(
-                                    8,
+                                    7,
                                     rusqlite::types::Type::Text,
                                     Box::new(error),
                                 )
@@ -586,32 +605,6 @@ impl SqliteCache {
         }
         drop(tags_statement);
 
-        let mut chunks_statement = conn
-            .prepare(
-                "SELECT c.id, c.note_slug, c.heading_path, c.content, n.layer, \
-                 COALESCE(v.embedding, d.embedding) \
-                 FROM vault_chunks c \
-                 JOIN vault_notes n ON n.vault_id = c.vault_id AND n.slug = c.note_slug \
-                 LEFT JOIN vault_chunk_vectors v ON v.chunk_id = c.id \
-                 LEFT JOIN vault_chunk_vectors_demoted d ON d.chunk_id = c.id \
-                 WHERE c.vault_id = ?1 ORDER BY c.id",
-            )
-            .map_err(|error| format!("prepare Vault snapshot chunks: {error}"))?;
-        let chunks = chunks_statement
-            .query_map(params![&vault_id], |row| {
-                Ok(VaultSnapshotChunk {
-                    chunk_id: row.get(0)?,
-                    note_slug: row.get(1)?,
-                    heading_path: row.get(2)?,
-                    content: row.get(3)?,
-                    layer: row.get(4)?,
-                    embedding: row.get(5)?,
-                })
-            })
-            .map_err(|error| format!("query Vault snapshot chunks: {error}"))?
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(|error| format!("read Vault snapshot chunks: {error}"))?;
-
         let layer_catalog_json: Option<String> = conn
             .query_row(
                 "SELECT value FROM vault_snapshot_metadata WHERE vault_id = ?1 AND key = 'layer_catalog'",
@@ -630,7 +623,6 @@ impl SqliteCache {
             notes,
             links,
             tags_by_note,
-            chunks,
             layer_catalog,
         })
     }
@@ -1411,6 +1403,7 @@ mod tests {
     use crate::embed::{Embedder, StubEmbedder};
     use crate::vault::VaultIndex;
     use crate::vault_registry::VaultId;
+    use rusqlite::params;
 
     struct NamedEmbedder {
         inner: StubEmbedder,
@@ -1487,15 +1480,16 @@ mod tests {
     /// structure-only signature; search skips vectorless chunks, so this is
     /// exactly what separates a browsable Vault from a searchable one.
     fn vectored_chunks(cache: &SqliteCache, vault_id: VaultId) -> usize {
-        cache
-            .read_vault_snapshot(vault_id)
-            .expect("read published snapshot")
-            .expect("snapshot participates")
-            .read
-            .chunks
-            .iter()
-            .filter(|chunk| chunk.embedding.is_some())
-            .count()
+        let conn = cache.read().expect("read connection");
+        conn.query_row(
+            "SELECT COUNT(*) FROM vault_chunks c \
+             WHERE c.vault_id = ?1 \
+             AND (EXISTS (SELECT 1 FROM vault_chunk_vectors v WHERE v.chunk_id = c.id) \
+                  OR EXISTS (SELECT 1 FROM vault_chunk_vectors_demoted d WHERE d.chunk_id = c.id))",
+            params![vault_id.to_string()],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count vectored chunks") as usize
     }
 
     #[test]

--- a/src/cache/vault_snapshots.rs
+++ b/src/cache/vault_snapshots.rs
@@ -59,6 +59,20 @@ pub(crate) struct MutationGuardHandoff {
         Box<dyn FnOnce() -> (VaultSnapshotFreshness, tokio::sync::OwnedMutexGuard<()>) + Send>,
 }
 
+/// Whether a snapshot read carries the Markdown text of its notes.
+///
+/// Bodies are the expensive half of the notes table and only the detailed
+/// stats report counts anything in them, so every other read omits them. They
+/// are a flag on the snapshot read rather than a read of their own because
+/// they must describe the same published generation the note list does: read
+/// separately, an Index turn landing in between would pair one generation's
+/// notes with another's text and silently count a new note as empty.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NoteBodies {
+    Omit,
+    Load,
+}
+
 /// One Vault's complete published read snapshot. This is intentionally a
 /// cache-local representation: callers must treat it as disposable data and
 /// keep exact note reads on the authoritative Markdown path.
@@ -67,6 +81,9 @@ pub(crate) struct VaultSnapshotRead {
     pub(crate) notes: Vec<VaultSnapshotNote>,
     pub(crate) links: Vec<VaultSnapshotLink>,
     pub(crate) tags_by_note: BTreeMap<String, Vec<String>>,
+    /// Each note's Markdown text, keyed by slug, and empty unless the read
+    /// asked for [`NoteBodies::Load`].
+    pub(crate) note_bodies: BTreeMap<String, String>,
     /// This Vault's declared layer catalog (name + optional description), as
     /// published alongside this generation's other snapshot rows. Sourced
     /// from `.hatchdoor-layer` markers at populate time, not inferred from
@@ -379,35 +396,6 @@ impl SqliteCache {
         .map_err(|error| format!("read Vault snapshot note {vault_id}/{slug}: {error}"))
     }
 
-    /// Every published note body in one Vault, keyed by slug.
-    ///
-    /// The one read that wants Markdown text rather than structure is the
-    /// detailed stats report, which counts words and images. It asks for
-    /// bodies here so [`VaultSnapshotRead`] can stay structural and the tree,
-    /// recent, graph, and query reads stop carrying the whole Vault's text
-    /// they never look at.
-    pub(crate) fn read_vault_note_bodies(
-        &self,
-        vault_id: VaultId,
-    ) -> Result<BTreeMap<String, String>, String> {
-        let conn = self.read()?;
-        let mut statement = conn
-            .prepare("SELECT slug, content FROM vault_notes WHERE vault_id = ?1")
-            .map_err(|error| format!("prepare Vault note bodies {vault_id}: {error}"))?;
-        let rows = statement
-            .query_map(params![vault_id.to_string()], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|error| format!("query Vault note bodies {vault_id}: {error}"))?;
-        let mut bodies = BTreeMap::new();
-        for row in rows {
-            let (slug, content) =
-                row.map_err(|error| format!("read Vault note body {vault_id}: {error}"))?;
-            bodies.insert(slug, content);
-        }
-        Ok(bodies)
-    }
-
     pub(crate) fn snapshot_status(
         &self,
         vault_id: VaultId,
@@ -440,6 +428,7 @@ impl SqliteCache {
     pub(crate) fn read_vault_snapshot(
         &self,
         vault_id: VaultId,
+        bodies: NoteBodies,
     ) -> Result<Option<PublishedVaultSnapshot>, String> {
         let conn = self.read()?;
         conn.execute_batch("BEGIN")
@@ -451,7 +440,7 @@ impl SqliteCache {
             if !status.participating {
                 return Ok(None);
             }
-            let read = Self::read_vault_snapshot_rows(&conn, vault_id)?;
+            let read = Self::read_vault_snapshot_rows(&conn, vault_id, bodies)?;
             Ok(Some(PublishedVaultSnapshot { status, read }))
         })();
         let close = if result.is_ok() {
@@ -471,6 +460,7 @@ impl SqliteCache {
     pub(crate) fn read_vault_snapshot_on(
         conn: &rusqlite::Connection,
         vault_id: VaultId,
+        bodies: NoteBodies,
     ) -> Result<Option<PublishedVaultSnapshot>, String> {
         let Some(status) = Self::read_snapshot_status(conn, vault_id)? else {
             return Ok(None);
@@ -480,7 +470,7 @@ impl SqliteCache {
         }
         Ok(Some(PublishedVaultSnapshot {
             status,
-            read: Self::read_vault_snapshot_rows(conn, vault_id)?,
+            read: Self::read_vault_snapshot_rows(conn, vault_id, bodies)?,
         }))
     }
 
@@ -519,6 +509,7 @@ impl SqliteCache {
     fn read_vault_snapshot_rows(
         conn: &rusqlite::Connection,
         vault_id: VaultId,
+        bodies: NoteBodies,
     ) -> Result<VaultSnapshotRead, String> {
         let vault_id = vault_id.to_string();
         let mut notes_statement = conn
@@ -605,6 +596,27 @@ impl SqliteCache {
         }
         drop(tags_statement);
 
+        let note_bodies = match bodies {
+            NoteBodies::Omit => BTreeMap::new(),
+            NoteBodies::Load => {
+                let mut statement = conn
+                    .prepare("SELECT slug, content FROM vault_notes WHERE vault_id = ?1")
+                    .map_err(|error| format!("prepare Vault snapshot note bodies: {error}"))?;
+                let rows = statement
+                    .query_map(params![&vault_id], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })
+                    .map_err(|error| format!("query Vault snapshot note bodies: {error}"))?;
+                let mut loaded = BTreeMap::new();
+                for row in rows {
+                    let (slug, content) =
+                        row.map_err(|error| format!("read Vault snapshot note body: {error}"))?;
+                    loaded.insert(slug, content);
+                }
+                loaded
+            }
+        };
+
         let layer_catalog_json: Option<String> = conn
             .query_row(
                 "SELECT value FROM vault_snapshot_metadata WHERE vault_id = ?1 AND key = 'layer_catalog'",
@@ -623,6 +635,7 @@ impl SqliteCache {
             notes,
             links,
             tags_by_note,
+            note_bodies,
             layer_catalog,
         })
     }
@@ -1398,7 +1411,7 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{VaultSnapshotFreshness, VaultSnapshotStatus};
+    use super::{NoteBodies, VaultSnapshotFreshness, VaultSnapshotStatus};
     use crate::cache::SqliteCache;
     use crate::embed::{Embedder, StubEmbedder};
     use crate::vault::VaultIndex;
@@ -1522,7 +1535,7 @@ mod tests {
             "structural rows are current, so the generation is fresh but not searchable"
         );
         let read = cache
-            .read_vault_snapshot(id)
+            .read_vault_snapshot(id, NoteBodies::Omit)
             .expect("read snapshot")
             .expect("snapshot participates")
             .read;
@@ -1783,7 +1796,7 @@ mod tests {
              `any(state != Fresh)` over these participants"
         );
         let read = cache
-            .read_vault_snapshot(id)
+            .read_vault_snapshot(id, NoteBodies::Omit)
             .expect("read snapshot")
             .expect("snapshot participates")
             .read;
@@ -1892,7 +1905,7 @@ mod tests {
         );
         assert_eq!(
             cache
-                .read_vault_snapshot(id)
+                .read_vault_snapshot(id, NoteBodies::Omit)
                 .expect("read snapshot")
                 .expect("snapshot participates")
                 .read
@@ -2107,7 +2120,7 @@ mod tests {
         assert_eq!(cache.snapshot_status(first).expect("first status"), None);
         assert!(
             cache
-                .read_vault_snapshot(first)
+                .read_vault_snapshot(first, NoteBodies::Omit)
                 .expect("read disconnected snapshot")
                 .is_none(),
             "a disconnected Vault must be unavailable, never an empty projection"

--- a/src/search/vault_scoped.rs
+++ b/src/search/vault_scoped.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::cache::{SqliteCache, vault_snapshots::VaultSnapshotRead};
+use crate::cache::{
+    SqliteCache,
+    vault_snapshots::{NoteBodies, VaultSnapshotRead},
+};
 use crate::embed::Embedder;
 use crate::vault::{NoteMetadata, NoteSummary};
 use crate::vault_read::{
@@ -153,7 +156,11 @@ impl<'a> VaultSearchCore<'a> {
         let mut snapshots = BTreeMap::new();
         let mut participants = Vec::with_capacity(selected.len());
         for vault in selected {
-            match SqliteCache::read_vault_snapshot_on(&cache_snapshot, vault.vault_id) {
+            match SqliteCache::read_vault_snapshot_on(
+                &cache_snapshot,
+                vault.vault_id,
+                NoteBodies::Omit,
+            ) {
                 Ok(Some(snapshot)) => {
                     let state = match snapshot.status.freshness {
                         crate::cache::vault_snapshots::VaultSnapshotFreshness::Fresh => {

--- a/src/vault_read.rs
+++ b/src/vault_read.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize, Serializer};
 use std::str::FromStr;
 
-use crate::cache::{SqliteCache, vault_snapshots::VaultSnapshotRead};
+use crate::cache::{
+    SqliteCache,
+    vault_snapshots::{NoteBodies, VaultSnapshotRead},
+};
 use crate::search::LayerSelection;
 use crate::vault::{Note, NoteLink, NoteLinks};
 use crate::vault_error::VaultOperationError;
@@ -490,6 +493,7 @@ impl BrowseSurface {
             notes,
             links,
             mut tags_by_note,
+            mut note_bodies,
             ..
         } = read;
         let notes: Vec<_> = notes
@@ -505,6 +509,7 @@ impl BrowseSurface {
             })
             .collect();
         tags_by_note.retain(|slug, _| visible.contains(slug.as_str()));
+        note_bodies.retain(|slug, _| visible.contains(slug.as_str()));
         // A restricted surface can select no layer, so it publishes no
         // catalogue: an empty catalogue is also what a Vault with no markers
         // reports, keeping the two indistinguishable.
@@ -512,6 +517,7 @@ impl BrowseSurface {
             notes,
             links,
             tags_by_note,
+            note_bodies,
             layer_catalog: Vec::new(),
         }
     }
@@ -769,13 +775,14 @@ impl<'a> VaultReadCore<'a> {
         scope: VaultScope,
         tree_scope: TreeScope,
     ) -> Result<VaultReadProjection<Vec<VaultTree>>, VaultReadError> {
-        let projection = self.try_collection(scope, |vault_id, vault_name, snapshot| {
-            Ok(VaultTree {
-                vault_id,
-                vault_name: vault_name.to_string(),
-                tree: tree_for(vault_id, snapshot, &tree_scope)?,
-            })
-        })?;
+        let projection =
+            self.try_collection(scope, NoteBodies::Omit, |vault_id, vault_name, snapshot| {
+                Ok(VaultTree {
+                    vault_id,
+                    vault_name: vault_name.to_string(),
+                    tree: tree_for(vault_id, snapshot, &tree_scope)?,
+                })
+            })?;
 
         // When no Vault has the folder, the caller asked for one thing and
         // would otherwise be handed an empty collection — the very blur the
@@ -916,16 +923,13 @@ impl<'a> VaultReadCore<'a> {
         &self,
         vault_id: VaultId,
     ) -> Result<VaultQualifiedStats, VaultReadError> {
-        // Bodies are read once, outside the per-Vault projection, because this
-        // is the one report that counts words rather than rows. Every other
-        // collection read projects structure alone and never pays for text.
-        let bodies = self
-            .cache
-            .read_vault_note_bodies(vault_id)
-            .map_err(|message| unavailable(vault_id, "vault_read_unavailable", message, true))?;
-        let projection = self.collection(
+        // The one report that counts words rather than rows, so the one read
+        // that asks for Markdown text. Every other collection read projects
+        // structure alone and never pays for it.
+        let projection = self.collection_with(
             VaultScope::One(vault_id),
-            |_vault_id, _vault_name, snapshot| detailed_stats_for(snapshot, &bodies),
+            NoteBodies::Load,
+            |_vault_id, _vault_name, snapshot| detailed_stats_for(snapshot),
         )?;
         let stats = projection
             .data
@@ -1214,7 +1218,20 @@ impl<'a> VaultReadCore<'a> {
         scope: VaultScope,
         map: impl Fn(VaultId, &str, &VaultSnapshotRead) -> T,
     ) -> Result<VaultReadProjection<Vec<T>>, VaultReadError> {
-        self.try_collection(scope, |vault_id, vault_name, snapshot| {
+        self.collection_with(scope, NoteBodies::Omit, map)
+    }
+
+    /// [`Self::collection`] for a projection that reads Markdown text rather
+    /// than structure. Only the detailed stats report does, and it takes the
+    /// bodies from the same snapshot read as the note list so both describe
+    /// one published generation.
+    fn collection_with<T>(
+        &self,
+        scope: VaultScope,
+        bodies: NoteBodies,
+        map: impl Fn(VaultId, &str, &VaultSnapshotRead) -> T,
+    ) -> Result<VaultReadProjection<Vec<T>>, VaultReadError> {
+        self.try_collection(scope, bodies, |vault_id, vault_name, snapshot| {
             Ok(map(vault_id, vault_name, snapshot))
         })
     }
@@ -1231,6 +1248,7 @@ impl<'a> VaultReadCore<'a> {
     fn try_collection<T>(
         &self,
         scope: VaultScope,
+        bodies: NoteBodies,
         map: impl Fn(VaultId, &str, &VaultSnapshotRead) -> Result<T, VaultReadError>,
     ) -> Result<VaultReadProjection<Vec<T>>, VaultReadError> {
         let snapshot = self.vaults.snapshot();
@@ -1238,7 +1256,7 @@ impl<'a> VaultReadCore<'a> {
         let mut data = Vec::new();
         let mut participants = Vec::with_capacity(selected.len());
         for selected in selected {
-            let published = self.cache.read_vault_snapshot(selected.vault_id);
+            let published = self.cache.read_vault_snapshot(selected.vault_id, bodies);
             let participant = match published {
                 Ok(Some(published)) => {
                     let state = match published.status.freshness {
@@ -1597,15 +1615,11 @@ impl FolderBuilder {
 /// lean projection: every note in the published snapshot counts, consistent
 /// with what that already-shipped collection endpoint reports for the same
 /// Vault.
-/// `bodies` carries the Markdown text this report counts words and images in,
-/// keyed by slug. It is looked up per note in `snapshot.notes`, so a note the
-/// restricted surface withheld is never counted even though the map was read
-/// before the restriction was applied. A slug with no body reads as empty,
-/// which is what a note with no text would have counted as anyway.
-fn detailed_stats_for(
-    snapshot: &VaultSnapshotRead,
-    bodies: &BTreeMap<String, String>,
-) -> crate::api_types::VaultStatsResponse {
+/// Counts words and images in `snapshot.note_bodies`, which the same read that
+/// produced `snapshot.notes` supplied, so both describe one published
+/// generation. A withheld note has neither a row nor a body here, because
+/// `restrict` drops both together.
+fn detailed_stats_for(snapshot: &VaultSnapshotRead) -> crate::api_types::VaultStatsResponse {
     use crate::api_types::{
         FolderStat, LinkedNoteRef, MonthActivity, NoteList, NoteRef, NoteWordRef, TagStat,
         VaultStatsResponse,
@@ -1618,7 +1632,11 @@ fn detailed_stats_for(
     let mut total_image_count = 0usize;
     let mut word_counts: Vec<(&str, &str, usize)> = Vec::with_capacity(snapshot.notes.len());
     for note in &snapshot.notes {
-        let content = bodies.get(&note.slug).map(String::as_str).unwrap_or("");
+        let content = snapshot
+            .note_bodies
+            .get(&note.slug)
+            .map(String::as_str)
+            .unwrap_or("");
         let word_count = word_count_for_content(content);
         total_word_count += word_count;
         total_image_count += content.matches("![").count();
@@ -1943,6 +1961,60 @@ mod parsing_tests {
                 LayerSelection::default_surface(),
                 "{raw:?}"
             );
+        }
+    }
+
+    /// #109: a withheld Note's Markdown text must go the way its row does. The
+    /// detailed stats report is the one projection that reads bodies, and it
+    /// looks them up by slug, so a body left behind here would be text from a
+    /// demoted Note sitting in a snapshot the restricted surface produced.
+    #[test]
+    fn a_restricted_surface_withholds_a_demoted_notes_body_with_its_row() {
+        let read = VaultSnapshotRead {
+            notes: vec![
+                snapshot_note("wiki", None),
+                snapshot_note("clip", Some("sources")),
+            ],
+            links: Vec::new(),
+            tags_by_note: BTreeMap::new(),
+            note_bodies: [
+                ("wiki".to_string(), "public text".to_string()),
+                ("clip".to_string(), "demoted text".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            layer_catalog: Vec::new(),
+        };
+
+        let restricted = BrowseSurface::DefaultOnly.restrict(read);
+
+        assert_eq!(
+            restricted
+                .notes
+                .iter()
+                .map(|note| &note.slug)
+                .collect::<Vec<_>>(),
+            vec!["wiki"]
+        );
+        assert_eq!(
+            restricted.note_bodies.keys().collect::<Vec<_>>(),
+            vec!["wiki"],
+            "a demoted Note's text must not survive the row it belongs to"
+        );
+    }
+
+    fn snapshot_note(
+        slug: &str,
+        layer: Option<&str>,
+    ) -> crate::cache::vault_snapshots::VaultSnapshotNote {
+        crate::cache::vault_snapshots::VaultSnapshotNote {
+            title: slug.to_string(),
+            slug: slug.to_string(),
+            relative_path: slug.to_string(),
+            size_bytes: 0,
+            mtime_ns: 0,
+            layer: layer.map(str::to_string),
+            metadata: crate::vault::NoteMetadata::default(),
         }
     }
 

--- a/src/vault_read.rs
+++ b/src/vault_read.rs
@@ -490,7 +490,6 @@ impl BrowseSurface {
             notes,
             links,
             mut tags_by_note,
-            chunks,
             ..
         } = read;
         let notes: Vec<_> = notes
@@ -505,12 +504,6 @@ impl BrowseSurface {
                     && visible.contains(link.target_slug.as_str())
             })
             .collect();
-        let chunks = chunks
-            .into_iter()
-            .filter(|chunk| {
-                !self.hides(chunk.layer.as_deref()) && visible.contains(chunk.note_slug.as_str())
-            })
-            .collect();
         tags_by_note.retain(|slug, _| visible.contains(slug.as_str()));
         // A restricted surface can select no layer, so it publishes no
         // catalogue: an empty catalogue is also what a Vault with no markers
@@ -519,7 +512,6 @@ impl BrowseSurface {
             notes,
             links,
             tags_by_note,
-            chunks,
             layer_catalog: Vec::new(),
         }
     }
@@ -924,9 +916,16 @@ impl<'a> VaultReadCore<'a> {
         &self,
         vault_id: VaultId,
     ) -> Result<VaultQualifiedStats, VaultReadError> {
+        // Bodies are read once, outside the per-Vault projection, because this
+        // is the one report that counts words rather than rows. Every other
+        // collection read projects structure alone and never pays for text.
+        let bodies = self
+            .cache
+            .read_vault_note_bodies(vault_id)
+            .map_err(|message| unavailable(vault_id, "vault_read_unavailable", message, true))?;
         let projection = self.collection(
             VaultScope::One(vault_id),
-            |_vault_id, _vault_name, snapshot| detailed_stats_for(snapshot),
+            |_vault_id, _vault_name, snapshot| detailed_stats_for(snapshot, &bodies),
         )?;
         let stats = projection
             .data
@@ -1598,7 +1597,15 @@ impl FolderBuilder {
 /// lean projection: every note in the published snapshot counts, consistent
 /// with what that already-shipped collection endpoint reports for the same
 /// Vault.
-fn detailed_stats_for(snapshot: &VaultSnapshotRead) -> crate::api_types::VaultStatsResponse {
+/// `bodies` carries the Markdown text this report counts words and images in,
+/// keyed by slug. It is looked up per note in `snapshot.notes`, so a note the
+/// restricted surface withheld is never counted even though the map was read
+/// before the restriction was applied. A slug with no body reads as empty,
+/// which is what a note with no text would have counted as anyway.
+fn detailed_stats_for(
+    snapshot: &VaultSnapshotRead,
+    bodies: &BTreeMap<String, String>,
+) -> crate::api_types::VaultStatsResponse {
     use crate::api_types::{
         FolderStat, LinkedNoteRef, MonthActivity, NoteList, NoteRef, NoteWordRef, TagStat,
         VaultStatsResponse,
@@ -1611,9 +1618,10 @@ fn detailed_stats_for(snapshot: &VaultSnapshotRead) -> crate::api_types::VaultSt
     let mut total_image_count = 0usize;
     let mut word_counts: Vec<(&str, &str, usize)> = Vec::with_capacity(snapshot.notes.len());
     for note in &snapshot.notes {
-        let word_count = word_count_for_content(&note.content);
+        let content = bodies.get(&note.slug).map(String::as_str).unwrap_or("");
+        let word_count = word_count_for_content(content);
         total_word_count += word_count;
-        total_image_count += note.content.matches("![").count();
+        total_image_count += content.matches("![").count();
         word_counts.push((note.slug.as_str(), note.title.as_str(), word_count));
     }
     let avg_word_count = if note_count > 0 {
@@ -2882,6 +2890,43 @@ mod tests {
             .collect();
         assert_eq!(folder_counts.get(""), Some(&2));
         assert_eq!(folder_counts.get("Folder"), Some(&1));
+    }
+
+    /// Word and image counts are the one thing in the whole read surface that
+    /// looks at Markdown text rather than structure, and bodies reach the
+    /// report through their own read now that the published snapshot carries
+    /// structure alone. Counting from an empty body would silently report
+    /// zeroes rather than fail, so assert the numbers themselves.
+    #[test]
+    fn statistics_detail_counts_words_and_images_from_the_published_bodies() {
+        let workspace = workspace(&[(
+            "First",
+            &[
+                (
+                    "Long.md",
+                    "---\ntags: [alpha]\n---\none two three four five\n\n![](a.png)\n",
+                ),
+                ("Short.md", "one two\n\n![](b.png)\n![](c.png)\n"),
+            ],
+        )]);
+        let reads = VaultReadCore::new(&workspace.cache, &workspace.vaults);
+
+        let stats = reads
+            .statistics_detail(workspace.vault_ids[0])
+            .expect("statistics detail succeeds")
+            .stats;
+
+        // "one two three four five" plus its image, and "one two" plus two.
+        assert_eq!(stats.word_count, 5 + 1 + 2 + 2);
+        assert_eq!(stats.image_count, 3);
+        assert_eq!(
+            stats
+                .longest_notes
+                .iter()
+                .map(|note| (note.slug.as_str(), note.word_count))
+                .collect::<Vec<_>>(),
+            vec![("long", 6), ("short", 4)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
The explorer tree took about 890ms to answer for a 600-note Vault, and got worse as the instance grew: 1.6s at 1200 notes, 2.1s at 2400.

## What was slow

Every collection read materialised the whole published snapshot, including each chunk's embedding through a `LEFT JOIN` against the sqlite-vec `vec0` virtual table, then threw all of it away to emit 30KB of titles and paths. Instrumented at 600 notes:

```
notes 7.4ms   links 1.1ms   tags 5.7ms   chunks 169.9ms   tree projection 1.8ms
same chunk rows without the vector joins: 4.5ms
```

So the vector join was 97% of the read. At 2400 notes it was 1955ms against 9.7ms, which is where the superlinear curve came from.

Nothing outside the snapshot module read those chunks. Search runs its own `vec0` KNN, and the only consumer of the field was a test helper counting vectored chunks, which counts them in SQL now. Note bodies had one consumer too, the detailed stats report.

The tree and the recent list were also each fetched twice per load. The collection revision started at 0 and the event stream reports the server's current revision on connect rather than a delta, so the first event always read as an invalidation.

## What changed

- `VaultSnapshotRead` is structural: notes, links, tags, layer catalog. No chunks. Note bodies only when a read passes `NoteBodies::Load`, from the same pinned transaction as the note list so a projection can never pair one generation's rows with another's text. `restrict` drops a withheld Note's body with its row.
- The collection revision is `null` until discovery lands, which is a different fact from a server sitting at revision 0. The baseline is seeded from the discovery response; once known, only the stream moves it.
- `useVaultTree` reads once per revision, awaiting a read still in flight before deciding.
- `NotePage` adopts the first revision it sees instead of refetching the open note and reseeding the hash the editor saves against.
- `FolderTree`'s ancestor walk is keyed on the pathname; it was keyed on a freshly allocated object, so the memo never hit and the walk ran every render.
- A collapsed folder renders none of its children.

## Measured

600-note Vault, production bundle, three Vaults registered (4200 notes total):

| | before | after |
|---|---|---|
| tree read | 278ms | 20ms |
| all-scope read | 3537ms | 85ms |
| explorer painted, from navigation | 2258ms | 378ms |
| tree `<li>` in DOM | 684 | 14 |
| requests per load | 2 discovery, 2 tree, 2 recent | 1 each |

The 2400-note Vault went from 2174ms to 57ms, and the curve is roughly linear now.

## Tradeoff worth knowing

Find-in-page no longer reaches a note inside a collapsed folder, on the browsers that looked inside one. The in-app search is unaffected. Two-line revert if it is not worth it.

## Review

Ran `/code-review`. Both axes independently found a torn read: the first pass took note bodies from their own SQLite connection and the note rows from another, which is what `read_snapshot` exists to prevent. The spec axis found a second defect, that the `0` revision sentinel meant both "no discovery yet" and "server is at revision 0", so a freshly restarted server spent its first genuine change being read as the baseline. Both are fixed in the second commit, with tests, along with the module map and the tests the first commit shipped without.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` (1110), `cargo test --all --features eval`, `npm run lint`, `npm run typecheck`, `npm test` (932), `npm run build`, `node scripts/check-module-map.mjs`, `just docs-freshness` reviewed and acknowledged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7DsnG4k6m8FXtk556BXTV
